### PR TITLE
provider/vcd: Adding MultiVM Support to vApps

### DIFF
--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -66,6 +66,7 @@ func Provider() terraform.ResourceProvider {
 			"vcd_dnat":            resourceVcdDNAT(),
 			"vcd_snat":            resourceVcdSNAT(),
 			"vcd_edgegateway_vpn": resourceVcdEdgeGatewayVpn(),
+			"vcd_vapp_vm":         resourceVcdVAppVm(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/vcd/resource_vcd_network_test.go
+++ b/vcd/resource_vcd_network_test.go
@@ -21,7 +21,7 @@ func TestAccVcdNetwork_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckVcdNetworkDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: fmt.Sprintf(testAccCheckVcdNetwork_basic, os.Getenv("VCD_EDGE_GATWEWAY")),
+				Config: fmt.Sprintf(testAccCheckVcdNetwork_basic, os.Getenv("VCD_EDGE_GATEWAY")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdNetworkExists("vcd_network.foonet", &network),
 					testAccCheckVcdNetworkAttributes(&network),

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -327,9 +327,15 @@ func getVAppIPAddress(d *schema.ResourceData, meta interface{}) (string, error) 
 		if err != nil {
 			return resource.RetryableError(fmt.Errorf("Unable to find vapp."))
 		}
-		ip = vapp.VApp.Children.VM[0].NetworkConnectionSection.NetworkConnection.IPAddress
+
+		// getting the IP of the specific Vm, rather than index zero.
+		// Required as once we add more VM's, index zero doesn't guarantee the
+		// 'first' one, and tests will fail sometimes (annoying huh?)
+		vm, err := vcdClient.OrgVdc.FindVMByName(vapp, d.Get("name").(string))
+
+		ip = vm.VM.NetworkConnectionSection.NetworkConnection.IPAddress
 		if ip == "" {
-			return resource.RetryableError(fmt.Errorf("Timeout: VM did not aquire IP address"))
+			return resource.RetryableError(fmt.Errorf("Timeout: VM did not acquire IP address"))
 		}
 		return nil
 	})

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -19,7 +19,7 @@ func TestAccVcdVApp_PowerOff(t *testing.T) {
 		CheckDestroy: testAccCheckVcdVAppDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: fmt.Sprintf(testAccCheckVcdVApp_basic, os.Getenv("VCD_EDGE_GATWEWAY")),
+				Config: fmt.Sprintf(testAccCheckVcdVApp_basic, os.Getenv("VCD_EDGE_GATEWAY")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppExists("vcd_vapp.foobar", &vapp),
 					testAccCheckVcdVAppAttributes(&vapp),
@@ -32,7 +32,7 @@ func TestAccVcdVApp_PowerOff(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: fmt.Sprintf(testAccCheckVcdVApp_powerOff, os.Getenv("VCD_EDGE_GATWEWAY")),
+				Config: fmt.Sprintf(testAccCheckVcdVApp_powerOff, os.Getenv("VCD_EDGE_GATEWAY")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppExists("vcd_vapp.foobar", &vapp),
 					testAccCheckVcdVAppAttributes_off(&vapp),
@@ -147,8 +147,8 @@ resource "vcd_network" "foonet" {
 
 resource "vcd_vapp" "foobar" {
   name = "foobar"
-  template_name = "base-centos-7.0-x86_64_v-0.1_b-74"
-  catalog_name = "NubesLab"
+  template_name = "Skyscape_CentOS_6_4_x64_50GB_Small_v1.0.1"
+  catalog_name = "Skyscape Catalogue"
   network_name = "${vcd_network.foonet.name}"
   memory = 1024
 	cpus = 1
@@ -168,13 +168,13 @@ resource "vcd_network" "foonet" {
 }
 
 resource "vcd_vapp" "foobar" {
-  name = "foobar"
-  template_name = "base-centos-7.0-x86_64_v-0.1_b-74"
-  catalog_name = "NubesLab"
-  network_name = "${vcd_network.foonet.name}"
-  memory = 1024
-	cpus = 1
-	ip = "10.10.102.160"
-	power_on = false
+  name          = "foobar"
+  template_name = "Skyscape_CentOS_6_4_x64_50GB_Small_v1.0.1"
+  catalog_name  = "Skyscape Catalogue"
+  network_name  = "${vcd_network.foonet.name}"
+  memory        = 1024
+  cpus          = 1
+  ip            = "10.10.102.160"
+  power_on      = false
 }
 `

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -1,0 +1,332 @@
+package vcd
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+)
+
+func resourceVcdVAppVm() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVcdVAppVmCreate,
+		Update: resourceVcdVAppVmUpdate,
+		Read:   resourceVcdVAppVmRead,
+		Delete: resourceVcdVAppVmDelete,
+
+		Schema: map[string]*schema.Schema{
+			"vapp_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"template_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"catalog_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"memory": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"cpus": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"ip": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"initscript": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"href": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"power_on": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+		},
+	}
+}
+
+func resourceVcdVAppVmCreate(d *schema.ResourceData, meta interface{}) error {
+	vcdClient := meta.(*VCDClient)
+
+	catalog, err := vcdClient.Org.FindCatalog(d.Get("catalog_name").(string))
+	if err != nil {
+		return fmt.Errorf("Error finding catalog: %#v", err)
+	}
+
+	catalogitem, err := catalog.FindCatalogItem(d.Get("template_name").(string))
+	if err != nil {
+		return fmt.Errorf("Error finding catelog item: %#v", err)
+	}
+
+	vapptemplate, err := catalogitem.GetVAppTemplate()
+	if err != nil {
+		return fmt.Errorf("Error finding VAppTemplate: %#v", err)
+	}
+
+	vapp, err := vcdClient.OrgVdc.FindVAppByName(d.Get("vapp_name").(string))
+
+	// get the network of the first child
+
+	if len(vapp.VApp.Children.VM) == 0 {
+		d.SetId("")
+		return fmt.Errorf("Current multi-VM support requires network to be determinted by initial VM. No VM's found so aborting.")
+	}
+
+	netname := vapp.VApp.Children.VM[0].NetworkConnectionSection.NetworkConnection.Network
+
+	log.Printf("[TRACE] Network name found: %s", netname)
+
+	net, err := vcdClient.OrgVdc.FindVDCNetwork(netname)
+	if err != nil {
+		return fmt.Errorf("Error finding OrgVCD Network: %#v", err)
+	}
+
+	err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
+		log.Printf("[TRACE] Creating VM: %s", d.Get("name").(string))
+		e := vapp.AddVM(net, vapptemplate, d.Get("name").(string))
+
+		if e != nil {
+			return resource.RetryableError(fmt.Errorf("Error: %#v", e))
+		}
+
+		e = vcdClient.OrgVdc.Refresh()
+		if e != nil {
+			return resource.RetryableError(fmt.Errorf("Error: %#v", e))
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	vm, err := vcdClient.OrgVdc.FindVMByName(vapp, d.Get("name").(string))
+
+	if err != nil {
+		d.SetId("")
+		return fmt.Errorf("Error getting VM1 : %#v", err)
+	}
+
+	err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
+		task, err := vm.ChangeNetworkConfig(netname, d.Get("ip").(string))
+		if err != nil {
+			return resource.RetryableError(fmt.Errorf("Error with Networking change: %#v", err))
+		}
+		return resource.RetryableError(task.WaitTaskCompletion())
+	})
+	if err != nil {
+		return fmt.Errorf("Error changing network: %#v", err)
+	}
+
+	if initscript, ok := d.GetOk("initscript"); ok {
+		err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
+			task, err := vm.RunCustomizationScript(d.Get("name").(string), initscript.(string))
+			if err != nil {
+				return resource.RetryableError(fmt.Errorf("Error with setting init script: %#v", err))
+			}
+			return resource.RetryableError(task.WaitTaskCompletion())
+		})
+		if err != nil {
+			return fmt.Errorf("Error completing tasks: %#v", err)
+		}
+	}
+
+	d.SetId(d.Get("name").(string))
+
+	return resourceVcdVAppVmUpdate(d, meta)
+}
+
+func resourceVcdVAppVmUpdate(d *schema.ResourceData, meta interface{}) error {
+
+	vcdClient := meta.(*VCDClient)
+
+	vapp, err := vcdClient.OrgVdc.FindVAppByName(d.Get("vapp_name").(string))
+
+	if err != nil {
+		return fmt.Errorf("error finding vapp: %s", err)
+	}
+
+	vm, err := vcdClient.OrgVdc.FindVMByName(vapp, d.Get("name").(string))
+
+	if err != nil {
+		d.SetId("")
+		return fmt.Errorf("Error getting VM2: %#v", err)
+	}
+
+	status, err := vm.GetStatus()
+	if err != nil {
+		return fmt.Errorf("Error getting VM status: %#v", err)
+	}
+
+	if d.HasChange("memory") || d.HasChange("cpus") || d.HasChange("power_on") {
+		if status != "POWERED_OFF" {
+			task, err := vm.PowerOff()
+			if err != nil {
+				return fmt.Errorf("Error Powering Off: %#v", err)
+			}
+			err = task.WaitTaskCompletion()
+			if err != nil {
+				return fmt.Errorf("Error completing tasks: %#v", err)
+			}
+		}
+
+		if d.HasChange("memory") {
+			err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
+				task, err := vm.ChangeMemorySize(d.Get("memory").(int))
+				if err != nil {
+					return resource.RetryableError(fmt.Errorf("Error changing memory size: %#v", err))
+				}
+
+				return resource.RetryableError(task.WaitTaskCompletion())
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		if d.HasChange("cpus") {
+			err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
+				task, err := vm.ChangeCPUcount(d.Get("cpus").(int))
+				if err != nil {
+					return resource.RetryableError(fmt.Errorf("Error changing cpu count: %#v", err))
+				}
+
+				return resource.RetryableError(task.WaitTaskCompletion())
+			})
+			if err != nil {
+				return fmt.Errorf("Error completing task: %#v", err)
+			}
+		}
+
+		if d.Get("power_on").(bool) {
+			task, err := vm.PowerOn()
+			if err != nil {
+				return fmt.Errorf("Error Powering Up: %#v", err)
+			}
+			err = task.WaitTaskCompletion()
+			if err != nil {
+				return fmt.Errorf("Error completing tasks: %#v", err)
+			}
+		}
+
+	}
+
+	return resourceVcdVAppVmRead(d, meta)
+}
+
+func resourceVcdVAppVmRead(d *schema.ResourceData, meta interface{}) error {
+	vcdClient := meta.(*VCDClient)
+
+	vapp, err := vcdClient.OrgVdc.FindVAppByName(d.Get("vapp_name").(string))
+
+	if err != nil {
+		return fmt.Errorf("error finding vapp: %s", err)
+	}
+
+	vm, err := vcdClient.OrgVdc.FindVMByName(vapp, d.Get("name").(string))
+
+	if err != nil {
+		d.SetId("")
+		return fmt.Errorf("Error getting VM3 : %#v", err)
+	}
+
+	d.Set("name", vm.VM.Name)
+	d.Set("ip", vm.VM.NetworkConnectionSection.NetworkConnection.IPAddress)
+	d.Set("href", vm.VM.HREF)
+
+	return nil
+}
+
+func resourceVcdVAppVmDelete(d *schema.ResourceData, meta interface{}) error {
+	vcdClient := meta.(*VCDClient)
+
+	vapp, err := vcdClient.OrgVdc.FindVAppByName(d.Get("vapp_name").(string))
+
+	if err != nil {
+		return fmt.Errorf("error finding vapp: %s", err)
+	}
+
+	vm, err := vcdClient.OrgVdc.FindVMByName(vapp, d.Get("name").(string))
+
+	if err != nil {
+		return fmt.Errorf("Error getting VM4 : %#v", err)
+	}
+
+	status, err := vapp.GetStatus()
+	if err != nil {
+		return fmt.Errorf("Error getting vApp status: %#v", err)
+	}
+
+	log.Printf("[TRACE] Vapp Status:: %s", status)
+	if status != "POWERED_OFF" {
+		log.Printf("[TRACE] Undeploying vApp: %s", vapp.VApp.Name)
+		task, err := vapp.Undeploy()
+		if err != nil {
+			return fmt.Errorf("Error Undeploying vApp: %#v", err)
+		}
+		err = task.WaitTaskCompletion()
+		if err != nil {
+			return fmt.Errorf("Error completing tasks: %#v", err)
+		}
+	}
+
+	err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
+		log.Printf("[TRACE] Removing VM: %s", vm.VM.Name)
+		err := vapp.RemoveVM(vm)
+		if err != nil {
+			return resource.RetryableError(fmt.Errorf("Error deleting: %#v", err))
+		}
+
+		return nil
+	})
+
+	if status != "POWERED_OFF" {
+		log.Printf("[TRACE] Redeploying vApp: %s", vapp.VApp.Name)
+		task, err := vapp.Deploy()
+		if err != nil {
+			return fmt.Errorf("Error Deploying vApp: %#v", err)
+		}
+		err = task.WaitTaskCompletion()
+		if err != nil {
+			return fmt.Errorf("Error completing tasks: %#v", err)
+		}
+
+		log.Printf("[TRACE] Powering on vApp: %s", vapp.VApp.Name)
+		task, err = vapp.PowerOn()
+		if err != nil {
+			return fmt.Errorf("Error Powering on vApp: %#v", err)
+		}
+		err = task.WaitTaskCompletion()
+		if err != nil {
+			return fmt.Errorf("Error completing tasks: %#v", err)
+		}
+	}
+
+	return err
+}

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -1,0 +1,115 @@
+package vcd
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	govcd "github.com/ukcloud/govcloudair"
+)
+
+func TestAccVcdVAppVm_Basic(t *testing.T) {
+	var vapp govcd.VApp
+	var vm govcd.VM
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVcdVAppVmDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckVcdVAppVm_basic, os.Getenv("VCD_EDGE_GATEWAY")),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVcdVAppVmExists("vcd_vapp_vm.moo", &vapp, &vm),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_vm.moo", "name", "moo"),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_vm.moo", "ip", "10.10.102.161"),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_vm.moo", "power_on", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVcdVAppVmExists(n string, vapp *govcd.VApp, vm *govcd.VM) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No VAPP ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		vapp, err := conn.OrgVdc.FindVAppByName("foobar")
+
+		resp, err := conn.OrgVdc.FindVMByName(vapp, "moo")
+
+		if err != nil {
+			return err
+		}
+
+		*vm = resp
+
+		return nil
+	}
+}
+
+func testAccCheckVcdVAppVmDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*VCDClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vcd_vapp" {
+			continue
+		}
+
+		_, err := conn.OrgVdc.FindVAppByName("foobar")
+
+		if err == nil {
+			return fmt.Errorf("VPCs still exist")
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+const testAccCheckVcdVAppVm_basic = `
+resource "vcd_network" "foonet" {
+	name = "foonet"
+	edge_gateway = "%s"
+	gateway = "10.10.102.1"
+	static_ip_pool {
+		start_address = "10.10.102.2"
+		end_address = "10.10.102.254"
+	}
+}
+
+resource "vcd_vapp" "foobar" {
+  name          = "foobar"
+  template_name = "Skyscape_CentOS_6_4_x64_50GB_Small_v1.0.1"
+  catalog_name  = "Skyscape Catalogue"
+  network_name  = "${vcd_network.foonet.name}"
+  memory        = 1024
+  cpus          = 1
+  ip            = "10.10.102.160"
+}
+
+resource "vcd_vapp_vm" "moo" {
+  vapp_name     = "${vcd_vapp.foobar.name}"
+  name          = "moo"
+  catalog_name  = "Skyscape Catalogue"
+  template_name = "Skyscape_CentOS_6_4_x64_50GB_Small_v1.0.1"
+  memory        = 1024
+  cpus          = 1
+  ip            = "10.10.102.161"
+}
+`

--- a/vendor/github.com/ukcloud/govcloudair/vapp.go
+++ b/vendor/github.com/ukcloud/govcloudair/vapp.go
@@ -153,8 +153,7 @@ func (v *VApp) AddVM(orgvdcnetwork OrgVDCNetwork, vapptemplate VAppTemplate, nam
 	s, _ := url.ParseRequestURI(v.VApp.HREF)
 	s.Path += "/action/recomposeVApp"
 
-	fmt.Println(s)
-	fmt.Println(string(output))
+	log.Printf("[TRACE] Recompose XML: %s", string(output))
 
 	b := bytes.NewBufferString(xml.Header + string(output))
 
@@ -165,16 +164,23 @@ func (v *VApp) AddVM(orgvdcnetwork OrgVDCNetwork, vapptemplate VAppTemplate, nam
 	task := NewTask(v.c)
 	v.Refresh()
 	if v.VApp.Tasks != nil {
-		fmt.Println("AYE")
+		log.Printf("[TRACE] Beginning Task of Adding VM: %s", name)
 		for _, t := range v.VApp.Tasks.Task {
 			task.Task = t
+			log.Printf("[TRACE] Awaiting Task to Finish: %s", task.Task.Name)
+			log.Printf("[TRACE] Awaiting Task to Finish: %s", task.Task.Description)
+			log.Printf("[TRACE] Awaiting Task to Finish: %s", task.Task.StartTime)
+			log.Printf("[TRACE] Awaiting Task to Finish: %s", task.Task.Status)
+			if task.Task.Status == "error" {
+				log.Printf("[WARN] Errored Idle Task: %s", task.Task.Error.Message)
+				log.Printf("[INFO] Moving onto next Task")
+				continue
+			}
 			err := task.WaitTaskCompletion()
 			if err != nil {
 				return fmt.Errorf("Error performing task: %#v", err)
 			}
 		}
-	} else {
-		fmt.Println("NO")
 	}
 
 	resp, err := checkResp(v.c.Http.Do(req))
@@ -198,12 +204,15 @@ func (v *VApp) AddVM(orgvdcnetwork OrgVDCNetwork, vapptemplate VAppTemplate, nam
 
 func (v *VApp) RemoveVM(vm VM) error {
 
+	v.Refresh()
 	task := NewTask(v.c)
-	for _, t := range v.VApp.Tasks.Task {
-		task.Task = t
-		err := task.WaitTaskCompletion()
-		if err != nil {
-			return fmt.Errorf("Error performing task: %#v", err)
+	if v.VApp.Tasks != nil {
+		for _, t := range v.VApp.Tasks.Task {
+			task.Task = t
+			err := task.WaitTaskCompletion()
+			if err != nil {
+				return fmt.Errorf("Error performing task: %#v", err)
+			}
 		}
 	}
 
@@ -249,7 +258,7 @@ func (v *VApp) RemoveVM(vm VM) error {
 	return nil
 }
 
-func (v *VApp) ComposeVApp(orgvdcnetwork OrgVDCNetwork, vapptemplate VAppTemplate, storage_profile_reference *types.Reference, name string, description string) (Task, error) {
+func (v *VApp) ComposeVApp(orgvdcnetwork OrgVDCNetwork, vapptemplate VAppTemplate, storageprofileref types.Reference, name string, description string) (Task, error) {
 
 	if vapptemplate.VAppTemplate.Children == nil || orgvdcnetwork.OrgVDCNetwork == nil {
 		return Task{}, fmt.Errorf("can't compose a new vApp, objects passed are not valid")
@@ -303,7 +312,7 @@ func (v *VApp) ComposeVApp(orgvdcnetwork OrgVDCNetwork, vapptemplate VAppTemplat
 				InnerNetwork:     orgvdcnetwork.OrgVDCNetwork.Name,
 				ContainerNetwork: orgvdcnetwork.OrgVDCNetwork.Name,
 			},
-			StorageProfile: storage_profile_reference,
+			StorageProfile: &storageprofileref,
 		},
 	}
 
@@ -654,7 +663,6 @@ func (v *VApp) Customize(computername, script string, changeSid bool) (Task, err
 
 	// The request was successful
 	return *task, nil
-
 }
 
 func (v *VApp) GetStatus() (string, error) {
@@ -717,6 +725,56 @@ func (v *VApp) ChangeCPUcount(size int) (Task, error) {
 	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.rasdItem+xml")
+
+	resp, err := checkResp(v.c.Http.Do(req))
+	if err != nil {
+		return Task{}, fmt.Errorf("error customizing VM: %s", err)
+	}
+
+	task := NewTask(v.c)
+
+	if err = decodeBody(resp, task.Task); err != nil {
+		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
+	}
+
+	// The request was successful
+	return *task, nil
+
+}
+
+func (v *VApp) ChangeStorageProfile(name string) (Task, error) {
+	err := v.Refresh()
+	if err != nil {
+		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
+	}
+
+	if v.VApp.Children == nil {
+		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
+	}
+
+	vdc, err := v.c.retrieveVDC()
+	storageprofileref, err := vdc.FindStorageProfileReference(name)
+
+	newprofile := &types.VM{
+		Name:           v.VApp.Children.VM[0].Name,
+		StorageProfile: &storageprofileref,
+		Xmlns:          "http://www.vmware.com/vcloud/v1.5",
+	}
+
+	output, err := xml.MarshalIndent(newprofile, "  ", "    ")
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+	}
+
+	log.Printf("[DEBUG] VCD Client configuration: %s", output)
+
+	b := bytes.NewBufferString(xml.Header + string(output))
+
+	s, _ := url.ParseRequestURI(v.VApp.Children.VM[0].HREF)
+
+	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+
+	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.vm+xml")
 
 	resp, err := checkResp(v.c.Http.Do(req))
 	if err != nil {

--- a/vendor/github.com/ukcloud/govcloudair/vm.go
+++ b/vendor/github.com/ukcloud/govcloudair/vm.go
@@ -5,13 +5,13 @@
 package govcloudair
 
 import (
-	// "bytes"
-	// "encoding/xml"
+	"bytes"
+	"encoding/xml"
 	"fmt"
-	// "log"
+	"log"
 	"net/url"
-	// "os"
-	// "strconv"
+	"os"
+	"strconv"
 
 	types "github.com/ukcloud/govcloudair/types/v56"
 )
@@ -26,6 +26,41 @@ func NewVM(c *Client) *VM {
 		VM: new(types.VM),
 		c:  c,
 	}
+}
+
+func (v *VM) GetStatus() (string, error) {
+	err := v.Refresh()
+	if err != nil {
+		return "", fmt.Errorf("error refreshing VM: %v", err)
+	}
+	return types.VAppStatuses[v.VM.Status], nil
+}
+
+func (v *VM) Refresh() error {
+
+	if v.VM.HREF == "" {
+		return fmt.Errorf("cannot refresh VM, Object is empty")
+	}
+
+	u, _ := url.ParseRequestURI(v.VM.HREF)
+
+	req := v.c.NewRequest(map[string]string{}, "GET", *u, nil)
+
+	resp, err := checkResp(v.c.Http.Do(req))
+	if err != nil {
+		return fmt.Errorf("error retrieving task: %s", err)
+	}
+
+	// Empty struct before a new unmarshal, otherwise we end up with duplicate
+	// elements in slices.
+	v.VM = &types.VM{}
+
+	if err = decodeBody(resp, v.VM); err != nil {
+		return fmt.Errorf("error decoding task response VM: %s", err)
+	}
+
+	// The request was successful
+	return nil
 }
 
 func (c *VCDClient) FindVMByHREF(vmhref string) (VM, error) {
@@ -51,5 +86,354 @@ func (c *VCDClient) FindVMByHREF(vmhref string) (VM, error) {
 	}
 
 	return *newvm, nil
+
+}
+
+func (v *VM) PowerOn() (Task, error) {
+
+	s, _ := url.ParseRequestURI(v.VM.HREF)
+	s.Path += "/power/action/powerOn"
+
+	req := v.c.NewRequest(map[string]string{}, "POST", *s, nil)
+
+	resp, err := checkResp(v.c.Http.Do(req))
+	if err != nil {
+		return Task{}, fmt.Errorf("error powering on VM: %s", err)
+	}
+
+	task := NewTask(v.c)
+
+	if err = decodeBody(resp, task.Task); err != nil {
+		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
+	}
+
+	// The request was successful
+	return *task, nil
+
+}
+
+func (v *VM) PowerOff() (Task, error) {
+
+	s, _ := url.ParseRequestURI(v.VM.HREF)
+	s.Path += "/power/action/powerOff"
+
+	req := v.c.NewRequest(map[string]string{}, "POST", *s, nil)
+
+	resp, err := checkResp(v.c.Http.Do(req))
+	if err != nil {
+		return Task{}, fmt.Errorf("error powering off VM: %s", err)
+	}
+
+	task := NewTask(v.c)
+
+	if err = decodeBody(resp, task.Task); err != nil {
+		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
+	}
+
+	// The request was successful
+	return *task, nil
+
+}
+
+func (v *VM) ChangeCPUcount(size int) (Task, error) {
+
+	err := v.Refresh()
+	if err != nil {
+		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
+	}
+
+	newcpu := &types.OVFItem{
+		XmlnsRasd:       "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData",
+		XmlnsVCloud:     "http://www.vmware.com/vcloud/v1.5",
+		XmlnsXsi:        "http://www.w3.org/2001/XMLSchema-instance",
+		VCloudHREF:      v.VM.HREF + "/virtualHardwareSection/cpu",
+		VCloudType:      "application/vnd.vmware.vcloud.rasdItem+xml",
+		AllocationUnits: "hertz * 10^6",
+		Description:     "Number of Virtual CPUs",
+		ElementName:     strconv.Itoa(size) + " virtual CPU(s)",
+		InstanceID:      4,
+		Reservation:     0,
+		ResourceType:    3,
+		VirtualQuantity: size,
+		Weight:          0,
+		Link: &types.Link{
+			HREF: v.VM.HREF + "/virtualHardwareSection/cpu",
+			Rel:  "edit",
+			Type: "application/vnd.vmware.vcloud.rasdItem+xml",
+		},
+	}
+
+	output, err := xml.MarshalIndent(newcpu, "  ", "    ")
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+	}
+
+	debug := os.Getenv("GOVCLOUDAIR_DEBUG")
+
+	if debug == "true" {
+		fmt.Printf("\n\nXML DEBUG: %s\n\n", string(output))
+	}
+
+	b := bytes.NewBufferString(xml.Header + string(output))
+
+	s, _ := url.ParseRequestURI(v.VM.HREF)
+	s.Path += "/virtualHardwareSection/cpu"
+
+	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+
+	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.rasdItem+xml")
+
+	resp, err := checkResp(v.c.Http.Do(req))
+	if err != nil {
+		return Task{}, fmt.Errorf("error customizing VM: %s", err)
+	}
+
+	task := NewTask(v.c)
+
+	if err = decodeBody(resp, task.Task); err != nil {
+		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
+	}
+
+	// The request was successful
+	return *task, nil
+
+}
+
+func (v *VM) ChangeMemorySize(size int) (Task, error) {
+
+	err := v.Refresh()
+	if err != nil {
+		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
+	}
+
+	newmem := &types.OVFItem{
+		XmlnsRasd:       "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData",
+		XmlnsVCloud:     "http://www.vmware.com/vcloud/v1.5",
+		XmlnsXsi:        "http://www.w3.org/2001/XMLSchema-instance",
+		VCloudHREF:      v.VM.HREF + "/virtualHardwareSection/memory",
+		VCloudType:      "application/vnd.vmware.vcloud.rasdItem+xml",
+		AllocationUnits: "byte * 2^20",
+		Description:     "Memory Size",
+		ElementName:     strconv.Itoa(size) + " MB of memory",
+		InstanceID:      5,
+		Reservation:     0,
+		ResourceType:    4,
+		VirtualQuantity: size,
+		Weight:          0,
+		Link: &types.Link{
+			HREF: v.VM.HREF + "/virtualHardwareSection/memory",
+			Rel:  "edit",
+			Type: "application/vnd.vmware.vcloud.rasdItem+xml",
+		},
+	}
+
+	output, err := xml.MarshalIndent(newmem, "  ", "    ")
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+	}
+
+	debug := os.Getenv("GOVCLOUDAIR_DEBUG")
+
+	if debug == "true" {
+		fmt.Printf("\n\nXML DEBUG: %s\n\n", string(output))
+	}
+
+	b := bytes.NewBufferString(xml.Header + string(output))
+
+	s, _ := url.ParseRequestURI(v.VM.HREF)
+	s.Path += "/virtualHardwareSection/memory"
+
+	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+
+	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.rasdItem+xml")
+
+	resp, err := checkResp(v.c.Http.Do(req))
+	if err != nil {
+		return Task{}, fmt.Errorf("error customizing VM: %s", err)
+	}
+
+	task := NewTask(v.c)
+
+	if err = decodeBody(resp, task.Task); err != nil {
+		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
+	}
+
+	// The request was successful
+	return *task, nil
+
+}
+
+func (v *VM) ChangeNetworkConfig(network, ip string) (Task, error) {
+	err := v.Refresh()
+	if err != nil {
+		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
+	}
+
+	// Determine what type of address is requested for the vApp
+	ipAllocationMode := "NONE"
+	ipAddress := "Any"
+
+	// TODO: Review current behaviour of using DHCP when left blank
+	if ip == "" || ip == "dhcp" {
+		ipAllocationMode = "DHCP"
+	} else if ip == "allocated" {
+		ipAllocationMode = "POOL"
+	} else if ip == "none" {
+		ipAllocationMode = "NONE"
+	} else if ip != "" {
+		ipAllocationMode = "MANUAL"
+		// TODO: Check a valid IP has been given
+		ipAddress = ip
+	}
+
+	networkConnection := &types.NetworkConnection{
+		Network:                 network,
+		NeedsCustomization:      true,
+		NetworkConnectionIndex:  0,
+		IPAddress:               ipAddress,
+		IsConnected:             true,
+		IPAddressAllocationMode: ipAllocationMode,
+	}
+
+	newnetwork := &types.NetworkConnectionSection{
+		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Ovf:   "http://schemas.dmtf.org/ovf/envelope/1",
+		Info:  "Specifies the available VM network connections",
+		PrimaryNetworkConnectionIndex: 0,
+		NetworkConnection:             networkConnection,
+	}
+
+	output, err := xml.MarshalIndent(newnetwork, "  ", "    ")
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+	}
+
+	log.Printf("[DEBUG] NetworkXML: %s", output)
+
+	b := bytes.NewBufferString(xml.Header + string(output))
+
+	s, _ := url.ParseRequestURI(v.VM.HREF)
+	s.Path += "/networkConnectionSection/"
+
+	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+
+	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.networkConnectionSection+xml")
+
+	resp, err := checkResp(v.c.Http.Do(req))
+	if err != nil {
+		return Task{}, fmt.Errorf("error customizing VM Network: %s", err)
+	}
+
+	task := NewTask(v.c)
+
+	if err = decodeBody(resp, task.Task); err != nil {
+		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
+	}
+
+	// The request was successful
+	return *task, nil
+}
+
+func (v *VM) RunCustomizationScript(computername, script string) (Task, error) {
+	return v.Customize(computername, script, false)
+}
+
+func (v *VM) Customize(computername, script string, changeSid bool) (Task, error) {
+	err := v.Refresh()
+	if err != nil {
+		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
+	}
+
+	vu := &types.GuestCustomizationSection{
+		Ovf:   "http://schemas.dmtf.org/ovf/envelope/1",
+		Xsi:   "http://www.w3.org/2001/XMLSchema-instance",
+		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+
+		HREF:                v.VM.HREF,
+		Type:                "application/vnd.vmware.vcloud.guestCustomizationSection+xml",
+		Info:                "Specifies Guest OS Customization Settings",
+		Enabled:             true,
+		ComputerName:        computername,
+		CustomizationScript: script,
+		ChangeSid:           false,
+	}
+
+	output, err := xml.MarshalIndent(vu, "  ", "    ")
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+	}
+
+	log.Printf("[DEBUG] VCD Client configuration: %s", output)
+
+	debug := os.Getenv("GOVCLOUDAIR_DEBUG")
+
+	if debug == "true" {
+		fmt.Printf("\n\nXML DEBUG: %s\n\n", string(output))
+	}
+
+	b := bytes.NewBufferString(xml.Header + string(output))
+
+	s, _ := url.ParseRequestURI(v.VM.HREF)
+	s.Path += "/guestCustomizationSection/"
+
+	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+
+	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.guestCustomizationSection+xml")
+
+	resp, err := checkResp(v.c.Http.Do(req))
+	if err != nil {
+		return Task{}, fmt.Errorf("error customizing VM: %s", err)
+	}
+
+	task := NewTask(v.c)
+
+	if err = decodeBody(resp, task.Task); err != nil {
+		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
+	}
+
+	// The request was successful
+	return *task, nil
+}
+
+func (v *VM) Undeploy() (Task, error) {
+
+	vu := &types.UndeployVAppParams{
+		Xmlns:               "http://www.vmware.com/vcloud/v1.5",
+		UndeployPowerAction: "powerOff",
+	}
+
+	output, err := xml.MarshalIndent(vu, "  ", "    ")
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+	}
+
+	debug := os.Getenv("GOVCLOUDAIR_DEBUG")
+
+	if debug == "true" {
+		fmt.Printf("\n\nXML DEBUG: %s\n\n", string(output))
+	}
+
+	b := bytes.NewBufferString(xml.Header + string(output))
+
+	s, _ := url.ParseRequestURI(v.VM.HREF)
+	s.Path += "/action/undeploy"
+
+	req := v.c.NewRequest(map[string]string{}, "POST", *s, b)
+
+	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.undeployVAppParams+xml")
+
+	resp, err := checkResp(v.c.Http.Do(req))
+	if err != nil {
+		return Task{}, fmt.Errorf("error undeploy vApp: %s", err)
+	}
+
+	task := NewTask(v.c)
+
+	if err = decodeBody(resp, task.Task); err != nil {
+		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
+	}
+
+	// The request was successful
+	return *task, nil
 
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -530,16 +530,16 @@
 			"revisionTime": "2016-09-27T10:08:44Z"
 		},
 		{
-			"checksumSHA1": "YOsTnuSgZn1CUUBNZJDjdPt072E=",
+			"checksumSHA1": "dA4Aw1HN/az0CkoZCRjja2DNRQ4=",
 			"path": "github.com/ukcloud/govcloudair",
-			"revision": "81750aa743ea8c1ab671ae615b2277d1835c7eb2",
-			"revisionTime": "2017-04-26T18:57:05Z"
+			"revision": "21a03d42696f78a0e601327ee53ae969e95f5877",
+			"revisionTime": "2017-06-09T14:42:01Z"
 		},
 		{
 			"checksumSHA1": "8FHandxT6XIwsawRe0eNupivqho=",
 			"path": "github.com/ukcloud/govcloudair/types/v56",
-			"revision": "3c7799ae4b9cd5896a77990514578681c837c7bb",
-			"revisionTime": "2017-04-12T09:42:31Z"
+			"revision": "21a03d42696f78a0e601327ee53ae969e95f5877",
+			"revisionTime": "2017-06-09T14:42:01Z"
 		},
 		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",
@@ -562,5 +562,5 @@
 			"versionExact": "v1.6.1"
 		}
 	],
-	"rootPath": "github.com/terraform-providers/terraform-provider-vcd"
+	"rootPath": "github.com/hashicorp/terraform-provider-vcd"
 }

--- a/website/source/docs/providers/vcd/r/vapp_vm.html.markdown
+++ b/website/source/docs/providers/vcd/r/vapp_vm.html.markdown
@@ -1,0 +1,77 @@
+---
+layout: "vcd"
+page_title: "vCloudDirector: vcd_vapp_vm"
+sidebar_current: "docs-vcd-resource-vapp-vm"
+description: |-
+  Provides a vCloud Director VM resource. This can be used to create, modify, and delete VMs within a vApp.
+---
+
+# vcd\_vapp\_vm
+
+Provides a vCloud Director VM resource. This can be used to create,
+modify, and delete VMs within a vApp.
+
+~> **Note:** The new VM resource has been added as an addition to the way vApps have always worked with this provider i.e. creating a vApp will create 1 VM of the same name. This can only be deleted by removing the vApp. The new functionality only allows additional VMs to be added/removed. Future revisions will included the ability to configure a different network in addition to storage requirements.
+
+## Example Usage
+
+```hcl
+resource "vcd_network" "net" {
+  # ...
+}
+
+resource "vcd_vapp" "web" {
+  name          = "web"
+  catalog_name  = "Boxes"
+  template_name = "lampstack-1.10.1-ubuntu-10.04"
+  memory        = 2048
+  cpus          = 1
+
+  network_name = "${vcd_network.net.name}"
+  network_href = "${vcd_network.net.href}"
+  ip           = "10.10.104.160"
+
+  metadata {
+    role    = "web"
+    env     = "staging"
+    version = "v1"
+  }
+}
+
+resource "vcd_vapp_vm" "web2" {
+  name          = "web2"
+  catalog_name  = "Boxes"
+  template_name = "lampstack-1.10.1-ubuntu-10.04"
+  memory        = 2048
+  cpus          = 1
+
+  ip           = "10.10.104.161"
+}
+
+resource "vcd_vapp_vm" "web3" {
+  name          = "web3"
+  catalog_name  = "Boxes"
+  template_name = "lampstack-1.10.1-ubuntu-10.04"
+  memory        = 2048
+  cpus          = 1
+
+  ip           = "10.10.104.162"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name for the vApp
+* `catalog_name` - (Required) The catalog name in which to find the given vApp Template
+* `template_name` - (Required) The name of the vApp Template to use
+* `memory` - (Optional) The amount of RAM (in MB) to allocate to the vApp
+* `cpus` - (Optional) The number of virtual CPUs to allocate to the vApp
+* `initscript` (Optional) A script to be run only on initial boot
+* `ip` - (Optional) The IP to assign to this vApp. Must be an IP address or
+  one of dhcp, allocated or none. If given the address must be within the
+  `static_ip_pool` set for the network. If left blank, and the network has
+  `dhcp_pool` set with at least one available IP then this will be set with
+  DHCP.
+* `power_on` - (Optional) A boolean value stating if this vApp should be powered on. Default to `true`


### PR DESCRIPTION
Adding Multi-VM for vApps to vCloud provider + tests + documentation

$make testacc TEST=./builtin/providers/vcd
=== RUN TestAccVcdVAppVm_Basic
--- PASS: TestAccVcdVAppVm_Basic (501.34s)
PASS
ok github.com/hashicorp/terraform/builtin/providers/vcd 501.417s

Patched from
https://github.com/hashicorp/terraform/pull/15221
