### PR TITLE
dnat: allow different src/translated port

### DIFF
--- a/vcd/resource_vcd_dnat_test.go
+++ b/vcd/resource_vcd_dnat_test.go
@@ -24,15 +24,46 @@ func TestAccVcdDNAT_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckVcdDNATDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: fmt.Sprintf(testAccCheckVcdDnat_basic, os.Getenv("VCD_EDGE_GATWEWAY"), os.Getenv("VCD_EXTERNAL_IP")),
+				Config: fmt.Sprintf(testAccCheckVcdDnat_basic, os.Getenv("VCD_EDGE_GATEWAY"), os.Getenv("VCD_EXTERNAL_IP")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdDNATExists("vcd_dnat.bar", &e),
 					resource.TestCheckResourceAttr(
 						"vcd_dnat.bar", "external_ip", os.Getenv("VCD_EXTERNAL_IP")),
 					resource.TestCheckResourceAttr(
-						"vcd_dnat.bar", "port", "77"),
+						"vcd_dnat.bar", "port", "7777"),
 					resource.TestCheckResourceAttr(
 						"vcd_dnat.bar", "internal_ip", "10.10.102.60"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVcdDNAT_tlate(t *testing.T) {
+	if v := os.Getenv("VCD_EXTERNAL_IP"); v == "" {
+		t.Skip("Environment variable VCD_EXTERNAL_IP must be set to run DNAT tests")
+		return
+	}
+
+	var e govcd.EdgeGateway
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVcdDNATDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckVcdDnat_tlate, os.Getenv("VCD_EDGE_GATEWAY"), os.Getenv("VCD_EXTERNAL_IP")),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVcdDNATtlateExists("vcd_dnat.bar", &e),
+					resource.TestCheckResourceAttr(
+						"vcd_dnat.bar", "external_ip", os.Getenv("VCD_EXTERNAL_IP")),
+					resource.TestCheckResourceAttr(
+						"vcd_dnat.bar", "port", "7777"),
+					resource.TestCheckResourceAttr(
+						"vcd_dnat.bar", "internal_ip", "10.10.102.60"),
+					resource.TestCheckResourceAttr(
+						"vcd_dnat.bar", "translated_port", "77"),
 				),
 			},
 		},
@@ -63,8 +94,48 @@ func testAccCheckVcdDNATExists(n string, gateway *govcd.EdgeGateway) resource.Te
 		for _, v := range edgeGateway.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule {
 			if v.RuleType == "DNAT" &&
 				v.GatewayNatRule.OriginalIP == os.Getenv("VCD_EXTERNAL_IP") &&
-				v.GatewayNatRule.OriginalPort == "77" &&
+				v.GatewayNatRule.OriginalPort == "7777" &&
 				v.GatewayNatRule.TranslatedIP == "10.10.102.60" {
+				found = true
+			}
+		}
+		if !found {
+			return fmt.Errorf("DNAT rule was not found")
+		}
+
+		*gateway = edgeGateway
+
+		return nil
+	}
+}
+
+func testAccCheckVcdDNATtlateExists(n string, gateway *govcd.EdgeGateway) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DNAT ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		gatewayName := rs.Primary.Attributes["edge_gateway"]
+		edgeGateway, err := conn.OrgVdc.FindEdgeGateway(gatewayName)
+
+		if err != nil {
+			return fmt.Errorf("Could not find edge gateway")
+		}
+
+		var found bool
+		for _, v := range edgeGateway.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule {
+			if v.RuleType == "DNAT" &&
+				v.GatewayNatRule.OriginalIP == os.Getenv("VCD_EXTERNAL_IP") &&
+				v.GatewayNatRule.OriginalPort == "7777" &&
+				v.GatewayNatRule.TranslatedIP == "10.10.102.60" &&
+				v.GatewayNatRule.TranslatedPort == "77" {
 				found = true
 			}
 		}
@@ -96,8 +167,9 @@ func testAccCheckVcdDNATDestroy(s *terraform.State) error {
 		for _, v := range edgeGateway.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule {
 			if v.RuleType == "DNAT" &&
 				v.GatewayNatRule.OriginalIP == os.Getenv("VCD_EXTERNAL_IP") &&
-				v.GatewayNatRule.OriginalPort == "77" &&
-				v.GatewayNatRule.TranslatedIP == "10.10.102.60" {
+				v.GatewayNatRule.OriginalPort == "7777" &&
+				v.GatewayNatRule.TranslatedIP == "10.10.102.60" &&
+				v.GatewayNatRule.TranslatedPort == "77" {
 				found = true
 			}
 		}
@@ -114,7 +186,16 @@ const testAccCheckVcdDnat_basic = `
 resource "vcd_dnat" "bar" {
 	edge_gateway = "%s"
 	external_ip = "%s"
-	port = 77
+	port = 7777
 	internal_ip = "10.10.102.60"
+}
+`
+const testAccCheckVcdDnat_tlate = `
+resource "vcd_dnat" "bar" {
+	edge_gateway = "%s"
+	external_ip = "%s"
+	port = 7777
+	internal_ip = "10.10.102.60"
+	translated_port = 77
 }
 `

--- a/website/docs/r/dnat.html.markdown
+++ b/website/docs/r/dnat.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # vcd\_dnat
 
 Provides a vCloud Director DNAT resource. This can be used to create, modify,
-and delete destination NATs to map an external IP/port to a VM.
+and delete destination NATs to map an external IP/port to an internal IP/port.
 
 ## Example Usage
 
@@ -19,6 +19,7 @@ resource "vcd_dnat" "web" {
   external_ip  = "78.101.10.20"
   port         = 80
   internal_ip  = "10.10.0.5"
+  translated_port = 8080
 }
 ```
 


### PR DESCRIPTION
Initial  issue 
"vcd_dnat missing separate original and translated port in vCloud Director provider"
https://github.com/hashicorp/terraform/issues/12384

Added a new (optional) param translated_port, keeping the existing port as the src port.
If translated_port is not specified use port - allows backward compatibility.
The name translated_port was selected because it is closer to the api and is less confusing than internal/external for example.

Based on PR for terraform https://github.com/hashicorp/terraform/pull/14437/, now in a separate provider repo.

The corresponding issue in govair is vmware/govcloudair#37 and UKCloud/govcloudair#3