### PR TITLE
provider: Deprecate maxRetryTimeout in favour of max_retry_timeout

### DIFF
--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -45,6 +45,12 @@ func Provider() terraform.ResourceProvider {
 			},
 
 			"maxRetryTimeout": &schema.Schema{
+				Type:       schema.TypeInt,
+				Optional:   true,
+				Deprecated: "Deprecated. Use max_retry_timeout instead.",
+			},
+
+			"max_retry_timeout": &schema.Schema{
 				Type:        schema.TypeInt,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_MAX_RETRY_TIMEOUT", 60),
@@ -74,13 +80,20 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	maxRetryTimeout := d.Get("max_retry_timeout").(int)
+
+	// TODO: Deprecated, remove in next major release
+	if v, ok := d.GetOk("maxRetryTimeout"); ok {
+		maxRetryTimeout = v.(int)
+	}
+
 	config := Config{
 		User:            d.Get("user").(string),
 		Password:        d.Get("password").(string),
 		Org:             d.Get("org").(string),
 		Href:            d.Get("url").(string),
 		VDC:             d.Get("vdc").(string),
-		MaxRetryTimeout: d.Get("maxRetryTimeout").(int),
+		MaxRetryTimeout: maxRetryTimeout,
 		InsecureFlag:    d.Get("allow_unverified_ssl").(bool),
 	}
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -24,7 +24,7 @@ provider "vcd" {
   org                  = "${var.vcd_org}"
   url                  = "${var.vcd_url}"
   vdc                  = "${var.vcd_vdc}"
-  maxRetryTimeout      = "${var.vcd_maxRetryTimeout}"
+  max_retry_timeout    = "${var.vcd_max_retry_timeout}"
   allow_unverified_ssl = "${var.vcd_allow_unverified_ssl}"
 }
 
@@ -51,12 +51,13 @@ The following arguments are used to configure the VMware vCloud Director Provide
   API operations against. If not set the plugin will select the first virtual
   datacenter available to your Org. Can also be specified with the `VCD_VDC` environment
   variable.
-* `maxRetryTimeout` - (Optional) This provides you with the ability to specify the maximum
+* `max_retry_timeout` - (Optional) This provides you with the ability to specify the maximum
   amount of time (in seconds) you are prepared to wait for interactions on resources managed
   by vCloud Director to be successful. If a resource action fails, the action will be retried
-  (as long as it is still within the `maxRetryTimeout` value) to try and ensure success.
+  (as long as it is still within the `max_retry_timeout` value) to try and ensure success.
   Defaults to 60 seconds if not set.
   Can also be specified with the `VCD_MAX_RETRY_TIMEOUT` environment variable.
+* `maxRetryTimeout` - (Deprecated) Use `max_retry_timeout` instead.
 * `allow_unverified_ssl` - (Optional) Boolean that can be set to true to
   disable SSL certificate verification. This should be used with care as it
   could allow an attacker to intercept your auth token. If omitted, default


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform/pull/15562

This needs to happen before bumping vendored `hashicorp/terraform` to `v0.10.0`.
