### PR TITLE
Removed default for description in VcdVApp

### DIFF
--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -22,18 +22,15 @@ func resourceVcdVApp() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-
 			"template_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-
 			"catalog_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
 			"network_name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -59,7 +56,6 @@ func resourceVcdVApp() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "terrafrom vapp",
 			},
 			"initscript": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
As the description for a `vcd_vapp` is optional, can we remove the default value? Otherwise I have to override this in every terraform definition. 