### PR TITLE
FindEdgeGateway should return correct EdgeGateway

### DIFF
--- a/vendor/github.com/ukcloud/govcloudair/types/v56/types.go
+++ b/vendor/github.com/ukcloud/govcloudair/types/v56/types.go
@@ -1623,8 +1623,8 @@ type QueryResultEdgeGatewayRecordsType struct {
 	PageSize int     `xml:"pageSize,attr,omitempty"` // Page size, as a number of records or references.
 	Total    float64 `xml:"total,attr,omitempty"`    // Total number of records or references in the container.
 	// Elements
-	Link              LinkList                          `xml:"Link,omitempty"`    // A reference to an entity or operation associated with this object.
-	EdgeGatewayRecord *QueryResultEdgeGatewayRecordType `xml:"EdgeGatewayRecord"` // A record representing a query result.
+	Link              []*Link                             `xml:"Link,omitempty"`    // A reference to an entity or operation associated with this object.
+	EdgeGatewayRecord []*QueryResultEdgeGatewayRecordType `xml:"EdgeGatewayRecord"` // A record representing a EdgeGateway result.
 }
 
 type QueryResultRecordsType struct {
@@ -1637,7 +1637,7 @@ type QueryResultRecordsType struct {
 	Total    float64 `xml:"total,attr,omitempty"`    // Total number of records or references in the container.
 	// Elements
 	Link                       []*Link                                      `xml:"Link,omitempty"`             // A reference to an entity or operation associated with this object.
-	EdgeGatewayRecord          *QueryResultEdgeGatewayRecordType            `xml:"EdgeGatewayRecord"`          // A record representing a query result.
+	EdgeGatewayRecord          []*QueryResultEdgeGatewayRecordType          `xml:"EdgeGatewayRecord"`          // A record representing a EdgeGateway result.
 	VMRecord                   []*QueryResultVMRecordType                   `xml:"VMRecord"`                   // A record representing a VM result.
 	VAppRecord                 []*QueryResultVAppRecordType                 `xml:"VAppRecord"`                 // A record representing a VApp result.
 	OrgVdcStorageProfileRecord []*QueryResultOrgVdcStorageProfileRecordType `xml:"OrgVdcStorageProfileRecord"` // A record representing storage profiles

--- a/vendor/github.com/ukcloud/govcloudair/vdc.go
+++ b/vendor/github.com/ukcloud/govcloudair/vdc.go
@@ -188,7 +188,19 @@ func (v *Vdc) FindEdgeGateway(edgegateway string) (EdgeGateway, error) {
 				return EdgeGateway{}, fmt.Errorf("error decoding edge gateway query response: %s", err)
 			}
 
-			u, err = url.ParseRequestURI(query.EdgeGatewayRecord.HREF)
+			var href string
+
+			for _, edge := range query.EdgeGatewayRecord {
+				if edge.Name == edgegateway {
+					href = edge.HREF
+				}
+			}
+
+			if href == "" {
+				return EdgeGateway{}, fmt.Errorf("can't find edge gateway with name: %s", edgegateway)
+			}
+
+			u, err = url.ParseRequestURI(href)
 			if err != nil {
 				return EdgeGateway{}, fmt.Errorf("error decoding edge gateway query response: %s", err)
 			}


### PR DESCRIPTION
EdgeGatewayRecord can be one element or multiple elements. Ensure to select the correct one. This probably fixes #11.

I'll submit this to https://github.com/UKCloud/govcloudair, but I didn't have time today.