### PR TITLE
Fix guest customization by enabling it before first vapp power-on

### DIFF
--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -179,20 +179,6 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 				}
 			}
 
-			if d.Get("power_on").(bool) == true {
-				err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-					task, err := vapp.PowerOn()
-					if err != nil {
-						return resource.RetryableError(fmt.Errorf("Error powerOn machine: %#v", err))
-					}
-					return resource.RetryableError(task.WaitTaskCompletion())
-				})
-
-				if err != nil {
-					return fmt.Errorf("Error completing powerOn tasks: %#v", err)
-				}
-			}
-
 			initscript := d.Get("initscript").(string)
 
 			err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
@@ -205,6 +191,20 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 			})
 			if err != nil {
 				return fmt.Errorf("Error completing tasks: %#v", err)
+			}
+
+			if d.Get("power_on").(bool) == true {
+				err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
+					task, err := vapp.PowerOn()
+					if err != nil {
+						return resource.RetryableError(fmt.Errorf("Error powerOn machine: %#v", err))
+					}
+					return resource.RetryableError(task.WaitTaskCompletion())
+				})
+
+				if err != nil {
+					return fmt.Errorf("Error completing powerOn tasks: %#v", err)
+				}
 			}
 
 		}


### PR DESCRIPTION
Guest customization does not seem to work properly currently, because it's enabled *after* the first vapp power-on. Guest customization needs to be enabled before the first vapp power-on to work properly.

This PR fixes the problem. Tested with vCloud Director 9.x.

Fixes the following issues:
https://github.com/terraform-providers/terraform-provider-vcd/issues/88
https://github.com/terraform-providers/terraform-provider-vcd/issues/62
