### PR TITLE
Update vendor with vCD API upgrade

### DIFF
--- a/vendor/github.com/vmware/go-vcloud-director/govcd/api_vcd.go
+++ b/vendor/github.com/vmware/go-vcloud-director/govcd/api_vcd.go
@@ -70,7 +70,7 @@ func (vdcCli *VCDClient) vcdauthorize(user, pass, org string) error {
 	// Set Basic Authentication Header
 	req.SetBasicAuth(user+"@"+org, pass)
 	// Add the Accept header for vCA
-	req.Header.Add("Accept", "application/*+xml;version=5.5")
+	req.Header.Add("Accept", "application/*+xml;version="+vdcCli.Client.APIVersion)
 	resp, err := checkResp(vdcCli.Client.Http.Do(req))
 	if err != nil {
 		return err
@@ -89,7 +89,7 @@ func NewVCDClient(vcdEndpoint url.URL, insecure bool) *VCDClient {
 
 	return &VCDClient{
 		Client: Client{
-			APIVersion: "5.5",
+			APIVersion: "27.0", // supported by vCD 8.20, 9.0, 9.1, 9.5
 			VCDHREF:    vcdEndpoint,
 			Http: http.Client{
 				Transport: &http.Transport{
@@ -126,7 +126,7 @@ func (vdcCli *VCDClient) Disconnect() error {
 	}
 	req := vdcCli.Client.NewRequest(map[string]string{}, "DELETE", vdcCli.sessionHREF, nil)
 	// Add the Accept header for vCA
-	req.Header.Add("Accept", "application/xml;version=5.5")
+	req.Header.Add("Accept", "application/xml;version="+vdcCli.Client.APIVersion)
 	// Set Authorization Header
 	req.Header.Add(vdcCli.Client.VCDAuthHeader, vdcCli.Client.VCDToken)
 	if _, err := checkResp(vdcCli.Client.Http.Do(req)); err != nil {

--- a/vendor/github.com/vmware/go-vcloud-director/govcd/edgegateway.go
+++ b/vendor/github.com/vmware/go-vcloud-director/govcd/edgegateway.go
@@ -563,6 +563,9 @@ func (eGW *EdgeGateway) Create1to1Mapping(internal, external, description string
 		},
 	}
 
+	if newedgeconfig.NatService == nil {
+		newedgeconfig.NatService = &types.NatService{}
+	}
 	newedgeconfig.NatService.NatRule = append(newedgeconfig.NatService.NatRule, snat)
 
 	dnat := &types.NatRule{

--- a/vendor/github.com/vmware/go-vcloud-director/govcd/query.go
+++ b/vendor/github.com/vmware/go-vcloud-director/govcd/query.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Skyscape Cloud Services.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -25,11 +25,11 @@ func NewResults(cli *Client) *Results {
 func (vdcCli *VCDClient) Query(params map[string]string) (Results, error) {
 
 	req := vdcCli.Client.NewRequest(params, "GET", vdcCli.QueryHREF, nil)
-	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version=5.5")
+	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vdcCli.Client.APIVersion)
 
 	resp, err := checkResp(vdcCli.Client.Http.Do(req))
 	if err != nil {
-		return Results{}, fmt.Errorf("error retreiving query: %s", err)
+		return Results{}, fmt.Errorf("error retrieving query: %s", err)
 	}
 
 	results := NewResults(&vdcCli.Client)

--- a/vendor/github.com/vmware/go-vcloud-director/govcd/system.go
+++ b/vendor/github.com/vmware/go-vcloud-director/govcd/system.go
@@ -18,6 +18,12 @@ import (
 // settings parameter. The settings variable is defined in types.go.
 // Method will fail unless user has an admin token.
 // API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/POST-CreateOrganization.html
+// Organization creation in vCD has two bugs BZ 2177355, BZ 2228936 (fixes are in 9.1.0.3 and 9.5.0.2) which require
+// organization settings to be provided as workarounds.
+// At least one element among DelayAfterPowerOnSeconds, DeployedVMQuota, StoredVmQuota, UseServerBootSequence, getVdcQuota
+// should be set when providing generalOrgSettings.
+// If either VAppLeaseSettings or VAppTemplateLeaseSettings is provided then all elements need to have values, otherwise don't provide them at all.
+// Overall elements must be in the correct order.
 func CreateOrg(vcdClient *VCDClient, name string, fullName string, isEnabled bool, settings *types.OrgSettings) (Task, error) {
 	vcomp := &types.AdminOrg{
 		Xmlns:       "http://www.vmware.com/vcloud/v1.5",

--- a/vendor/github.com/vmware/go-vcloud-director/govcd/vapptemplate.go
+++ b/vendor/github.com/vmware/go-vcloud-director/govcd/vapptemplate.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -556,10 +556,10 @@
 			"revisionTime": "2016-09-27T10:08:44Z"
 		},
 		{
-			"checksumSHA1": "XOVcK8VdV42a4e0K8K0qbd99ouk=",
+			"checksumSHA1": "7HGSdZdK+4uadpqVZhEsloEh2p0=",
 			"path": "github.com/vmware/go-vcloud-director/govcd",
-			"revision": "14fe89645ad13dc3dbadc35f04dc15a979f675da",
-			"revisionTime": "2018-10-26T12:15:54Z"
+			"revision": "632f18297ddccb80c02fedd5d181c75e1195bb70",
+			"revisionTime": "2018-11-15T09:55:10Z"
 		},
 		{
 			"checksumSHA1": "PfPcGzRL/2qLcfZ9uY33iYs9IDg=",
@@ -570,8 +570,8 @@
 		{
 			"checksumSHA1": "mVNbgXU9MucqAsxc4EhI6kR6bZw=",
 			"path": "github.com/vmware/go-vcloud-director/util",
-			"revision": "14fe89645ad13dc3dbadc35f04dc15a979f675da",
-			"revisionTime": "2018-10-26T12:15:54Z"
+			"revision": "632f18297ddccb80c02fedd5d181c75e1195bb70",
+			"revisionTime": "2018-11-15T09:55:10Z"
 		},
 		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",


### PR DESCRIPTION
Add latest API upgrade from github.com/vmware/go-vcloud-director.

Signed-off-by: Giuseppe Maxia
