### PR TITLE
Fix vApp/VM provisioning guest customization initscript

### DIFF
--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -211,20 +211,6 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 				}
 			}
 
-			if d.Get("power_on").(bool) == true {
-				err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-					task, err := vapp.PowerOn()
-					if err != nil {
-						return resource.RetryableError(fmt.Errorf("error powerOn machine: %#v", err))
-					}
-					return resource.RetryableError(task.WaitTaskCompletion())
-				})
-
-				if err != nil {
-					return fmt.Errorf("error completing powerOn tasks: %#v", err)
-				}
-			}
-
 			initscript, ok := d.GetOk("initscript")
 			if ok {
 				err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
@@ -237,6 +223,20 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 				})
 				if err != nil {
 					return fmt.Errorf(errorCompletingTask, err)
+				}
+			}
+
+			if d.Get("power_on").(bool) == true {
+				err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
+					task, err := vapp.PowerOn()
+					if err != nil {
+						return resource.RetryableError(fmt.Errorf("error powerOn machine: %#v", err))
+					}
+					return resource.RetryableError(task.WaitTaskCompletion())
+				})
+
+				if err != nil {
+					return fmt.Errorf("error completing powerOn tasks: %#v", err)
 				}
 			}
 


### PR DESCRIPTION
Guest Customization is a feature used by vCloud Director during vApp provisioning to configure various settings inside the VM guest operating system (via vmware-tools):
- Set hostname.
- Set/change local root/admin password.
- Set network settings (static IP, dhcp, etc).
- Run "initscript" inside the VM on next/first power-on, enabling automated ssh authorized keys configuration etc to get unattended remote management and devops tools working.
 
Currently terraform-provider-vcd enables guest customization for the vApp when configuring "initscript" for the vApp in Terraform settings. Unfortunately guest customization / initscript is enabled by terraform-provider-vcd in the wrong place/order. Currently it's enabled *after* vApp power-on is executed, which is wrong and results in the scenario where guest customization and initscript do not work automatically during vApp provisioning.. instead they get executed during the *next* vApp power-off/power-on cycle after provisioning, which clearly isn't ideal or intended, and results in Terraform provisioned vApps having wrong hostname, wrong root/admin passwords, wrong networking settings, and most importantly (because the initscript isn't executed) things like ssh authorized keys are not getting set inside the VMs, preventing unattended remote management by Terraform remote provisioners, ansible and other devops tools.

This PR changes the order of actions and calls vapp.RunCustomizationScript() before running vapp.PowerOn(), which makes Guest Customization and initscripts working properly during the vApp provisioning process.

I've tested the patch now against vCloud Director 9.1, and similar patch earlier against vCloud Director 8.20 and 9.0.

Fixes at least the following terraform-provider-vcd issues:
https://github.com/terraform-providers/terraform-provider-vcd/issues/62
https://github.com/terraform-providers/terraform-provider-vcd/issues/88

This supersedes the earlier PR (https://github.com/terraform-providers/terraform-provider-vcd/pull/92), which was against the old codebase in the master branch. 
