### PR TITLE
Update doc resource pages with features in vmware-takes-ownership branch

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -128,6 +128,8 @@ The following arguments are used to configure the VMware vCloud Director Provide
   *v2.0+* `org` may be set to "System" when connection as Sys Admin is desired
   (set `user` to "administrator" in this case).
   
+  Note: `org` value is case sensitive.
+  
 * `sysorg` - (Optional; *v2.0+*) - Organization for user authentication. Can also be
    specified with the `VCD_SYS_ORG` environment variable. Set `sysorg` to "System" and
    `user` to "administrator" to free up `org` argument for setting a default organization

--- a/website/docs/r/catalog_item.html.markdown
+++ b/website/docs/r/catalog_item.html.markdown
@@ -3,7 +3,7 @@ layout: "vcd"
 page_title: "vCloudDirector: vcd_catalog_item"
 sidebar_current: "docs-vcd-resource-catalog-item"
 description: |-
-Provides a vCloud Director catalog item resource. This can be used to upload and delete OVA file in catalog.
+Provides a vCloud Director catalog item resource. This can be used to upload and delete OVA file inside a catalog.
 ---
 
 # vcd\_catalog\_item
@@ -31,7 +31,7 @@ resource "vcd_catalog_item" "myNewCatalogItem" {
 
 The following arguments are supported:
 
-* `org` - (Optional) The name of organization to use. Not needed if defined at provider level
+* `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations
 * `catalog` - (Required) The name of the catalog where to upload OVA file
 * `name` - (Required) Item name in catalog
 * `description` - (Optional) - Description of item

--- a/website/docs/r/catalog_media.html.markdown
+++ b/website/docs/r/catalog_media.html.markdown
@@ -3,12 +3,12 @@ layout: "vcd"
 page_title: "vCloudDirector: vcd_catalog_media"
 sidebar_current: "docs-vcd-resource-catalog-media"
 description: |-
-  Provides a vCloud Director Media resource. This can be used to upload and delete media file in catalog.
+  Provides a vCloud Director media resource. This can be used to upload and delete media (ISO) file inside a catalog.
 ---
 
 # vcd\_catalog\_media
 
-Provides a vCloud Director Media resource. This can be used to upload media to catalog and delete it.
+Provides a vCloud Director media resource. This can be used to upload media to catalog and delete it.
 
 Supported in provider *v2.0+*
 
@@ -31,7 +31,7 @@ resource "vcd_catalog_media" "myNewMedia" {
 
 The following arguments are supported:
 
-* `org` - (Optional) The name of organization to use, isn't needed if defined/match at provider level
+* `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations
 * `catalog` - (Required) The name of the catalog where to upload media file
 * `name` - (Required) Media file name in catalog
 * `description` - (Optional) - Description of media file

--- a/website/docs/r/dnat.html.markdown
+++ b/website/docs/r/dnat.html.markdown
@@ -31,3 +31,5 @@ The following arguments are supported:
 * `external_ip` - (Required) One of the external IPs available on your Edge Gateway
 * `port` - (Required) The port number to map
 * `internal_ip` - (Required) The IP of the VM to map to
+* `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations
+* `vdc` - (Optional; *v2.0+*) The name of VDC to use, optional if defined at provider level

--- a/website/docs/r/edgegateway_vpn.html.markdown
+++ b/website/docs/r/edgegateway_vpn.html.markdown
@@ -68,6 +68,8 @@ The following arguments are supported:
 * `shared_secret` - (Required) - Shared Secret
 * `local_subnets` - (Required) - List of Local Subnets see [Local Subnets](#localsubnets) below for details.
 * `peer_subnets` - (Required) - List of Peer Subnets see [Peer Subnets](#peersubnets) below for details.
+* `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations
+* `vdc` - (Optional; *v2.0+*) The name of VDC to use, optional if defined at provider level
 
 <a id="localsubnets"></a>
 ## Local Subnets

--- a/website/docs/r/firewall_rules.html.markdown
+++ b/website/docs/r/firewall_rules.html.markdown
@@ -66,6 +66,8 @@ The following arguments are supported:
 * `edge_gateway` - (Required) The name of the edge gateway on which to apply the Firewall Rules
 * `default_action` - (Required) Either "allow" or "deny". Specifies what to do should none of the rules match
 * `rule` - (Optional) Configures a firewall rule; see [Rules](#rules) below for details.
+* `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations
+* `vdc` - (Optional; *v2.0+*) The name of VDC to use, optional if defined at provider level
 
 <a id="rules"></a>
 ## Rules

--- a/website/docs/r/snat.html.markdown
+++ b/website/docs/r/snat.html.markdown
@@ -28,3 +28,5 @@ The following arguments are supported:
 * `edge_gateway` - (Required) The name of the edge gateway on which to apply the SNAT
 * `external_ip` - (Required) One of the external IPs available on your Edge Gateway
 * `internal_ip` - (Required) The IP or IP Range of the VM(s) to map from
+* `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations
+* `vdc` - (Optional; *v2.0+*) The name of VDC to use, optional if defined at provider level

--- a/website/docs/r/vapp.html.markdown
+++ b/website/docs/r/vapp.html.markdown
@@ -75,3 +75,5 @@ The following arguments are supported:
 * `metadata` - (Optional) Key value map of metadata to assign to this vApp
 * `ovf` - (Optional) Key value map of ovf parameters to assign to VM product section
 * `power_on` - (Optional) A boolean value stating if this vApp should be powered on. Default to `true`
+* `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations
+* `vdc` - (Optional; *v2.0+*) The name of VDC to use, optional if defined at provider level

--- a/website/docs/r/vapp.html.markdown
+++ b/website/docs/r/vapp.html.markdown
@@ -14,7 +14,7 @@ modify, and delete vApps.
 ## Example Usage
 
 ```hcl
-resource "vcd_network" "net" {
+resource "vcd_network_routed" "net" {
   # ...
 }
 
@@ -26,7 +26,6 @@ resource "vcd_vapp" "web" {
   cpus          = 1
 
   network_name = "${vcd_network.net.name}"
-  network_href = "${vcd_network.net.href}"
   ip           = "10.10.104.160"
 
   metadata {
@@ -38,18 +37,22 @@ resource "vcd_vapp" "web" {
   ovf {
     hostname = "web"
   }
+  
+  depends_on = ["vcd_network_routed.net"]
 }
 ```
 
-## Example RAW vApp with No VMS
+## Example of Empty vApp with no VMs
 
 ```hcl
-resource "vcd_network" "net" {
+resource "vcd_network_routed" "net" {
   # ...
 }
 
 resource "vcd_vapp" "web" {
   name          = "web"
+  
+  depends_on = ["vcd_network_routed.net"]
 }
 ```
 

--- a/website/docs/r/vapp_vm.html.markdown
+++ b/website/docs/r/vapp_vm.html.markdown
@@ -11,7 +11,7 @@ description: |-
 Provides a vCloud Director VM resource. This can be used to create,
 modify, and delete VMs within a vApp.
 
-~> **Note:** To make sure resources are created in the right order and both plan apply and destroy suceeds, use the `depends_on` clause (see example below)
+~> **Note:** To make sure resources are created in the right order and both plan apply and destroy succeeds, use the `depends_on` clause (see example below)
 
 
 ## Example Usage

--- a/website/docs/r/vapp_vm.html.markdown
+++ b/website/docs/r/vapp_vm.html.markdown
@@ -65,3 +65,6 @@ The following arguments are supported:
   `dhcp_pool` set with at least one available IP then this will be set with
   DHCP.
 * `power_on` - (Optional) A boolean value stating if this vApp should be powered on. Default to `true`
+* `accept_all_eulas` - (Optional; *v2.0+*) Automatically accept EULA if OVA has it
+* `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations
+* `vdc` - (Optional; *v2.0+*) The name of VDC to use, optional if defined at provider level

--- a/website/docs/r/vapp_vm.html.markdown
+++ b/website/docs/r/vapp_vm.html.markdown
@@ -11,18 +11,35 @@ description: |-
 Provides a vCloud Director VM resource. This can be used to create,
 modify, and delete VMs within a vApp.
 
-~> **Note:** There is known bug with this implementation, that to use the vcd_vapp_vm resource, you must set the paralellism parameter to 1. [We are working on this.](https://github.com/terraform-providers/terraform-provider-vcd/issues/27)
+~> **Note:** To make sure resources are created in the right order and both plan apply and destroy suceeds, use the `depends_on` clause (see example below)
 
 
 ## Example Usage
 
 ```hcl
-resource "vcd_network" "net" {
-  # ...
+resource "vcd_network_direct" "net" {
+  name             = "net"
+  external_network = "corp-network"
 }
 
 resource "vcd_vapp" "web" {
   name          = "web"
+  
+  depends_on = ["vcd_network_direct.net"]
+}
+
+resource "vcd_vapp_vm" "web1" {
+  vapp_name     = "${vcd_vapp.web.name}"
+  name          = "web1"
+  catalog_name  = "Boxes"
+  template_name = "lampstack-1.10.1-ubuntu-10.04"
+  memory        = 2048
+  cpus          = 1
+
+  network_name = "net"
+  ip           = "10.10.104.161"
+  
+  depends_on = ["vcd_vapp.web"]
 }
 
 resource "vcd_vapp_vm" "web2" {
@@ -33,18 +50,10 @@ resource "vcd_vapp_vm" "web2" {
   memory        = 2048
   cpus          = 1
 
-  ip           = "10.10.104.161"
-}
-
-resource "vcd_vapp_vm" "web3" {
-  vapp_name     = "${vcd_vapp.web.name}"
-  name          = "web3"
-  catalog_name  = "Boxes"
-  template_name = "lampstack-1.10.1-ubuntu-10.04"
-  memory        = 2048
-  cpus          = 1
-
+  network_name = "net"
   ip           = "10.10.104.162"
+  
+  depends_on = ["vcd_vapp.web"]
 }
 ```
 
@@ -59,6 +68,7 @@ The following arguments are supported:
 * `memory` - (Optional) The amount of RAM (in MB) to allocate to the vApp
 * `cpus` - (Optional) The number of virtual CPUs to allocate to the vApp
 * `initscript` (Optional) A script to be run only on initial boot
+* `network_name` - (Optional) Name of the network this VM should connect to
 * `ip` - (Optional) The IP to assign to this vApp. Must be an IP address or
   one of dhcp, allocated or none. If given the address must be within the
   `static_ip_pool` set for the network. If left blank, and the network has


### PR DESCRIPTION
Contents of this documentation PR:
- Update doc entry page that `org` value is case sensitive
- Add `accept_all_eulas` parameter description for `vcd_vapp_vm` resource
- Add `org` and `vdc` optional parameter description for all resources

Part of issue #112