### PR TITLE
Add more network tests

### DIFF
--- a/vcd/resource_vcd_network_test.go
+++ b/vcd/resource_vcd_network_test.go
@@ -15,42 +15,124 @@ type networkDef struct {
 	gateway         string
 	startIpAddress  string
 	endIpAddress    string
+	startIpAddress2 string
+	endIpAddress2   string
 	externalNetwork string
 	configText      string
 	resourceName    string
 }
 
-func TestAccVcdNetworkIsolated(t *testing.T) {
+const (
+	isolatedStaticNetwork string = "TestAccVcdNetworkIsoStatic"
+	isolatedDhcpNetwork   string = "TestAccVcdNetworkIsoDhcp"
+	isolatedMixedNetwork  string = "TestAccVcdNetworkIsoMixed"
+	routedNetworkStatic   string = "TestAccVcdNetworkRoutedStatic"
+	routedNetworkDhcp     string = "TestAccVcdNetworkRoutedDhcp"
+	routedNetworkMixed    string = "TestAccVcdNetworkRoutedMixed"
+	directNetwork         string = "TestAccVcdNetworkDirect"
+)
+
+func TestAccVcdNetworkIsolatedStatic(t *testing.T) {
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
 	}
 
 	var def = networkDef{
-		name:           "TestAccVcdNetworkIso",
+		name:           isolatedStaticNetwork,
 		gateway:        "192.168.2.1",
 		startIpAddress: "192.168.2.2",
-		endIpAddress:   "192.168.2.100",
-		configText:     testAccCheckVcdNetworkIsolated,
+		endIpAddress:   "192.168.2.50",
+		configText:     testAccCheckVcdNetworkIsolatedStatic,
 		resourceName:   "vcd_network_isolated",
 	}
 
 	runTest(def, t)
 }
 
-func TestAccVcdNetworkRouted(t *testing.T) {
+func TestAccVcdNetworkIsolatedDhcp(t *testing.T) {
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	var def = networkDef{
+		name:           isolatedDhcpNetwork,
+		gateway:        "192.168.2.1",
+		startIpAddress: "192.168.2.51",
+		endIpAddress:   "192.168.2.100",
+		configText:     testAccCheckVcdNetworkIsolatedDhcp,
+		resourceName:   "vcd_network_isolated",
+	}
+	runTest(def, t)
+}
+
+func TestAccVcdNetworkIsolatedMixed(t *testing.T) {
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	var def = networkDef{
+		name:            isolatedMixedNetwork,
+		gateway:         "192.168.2.1",
+		startIpAddress:  "192.168.2.2",
+		endIpAddress:    "192.168.2.50",
+		startIpAddress2: "192.168.2.51",
+		endIpAddress2:   "192.168.2.100",
+		configText:      testAccCheckVcdNetworkIsolatedMixed,
+		resourceName:    "vcd_network_isolated",
+	}
+	runTest(def, t)
+}
+
+func TestAccVcdNetworkRoutedStatic(t *testing.T) {
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
 	}
 
 	var def = networkDef{
-		name:           "TestAccVcdNetworkEGW",
+		name:           routedNetworkStatic,
 		gateway:        "10.10.102.1",
 		startIpAddress: "10.10.102.2",
-		endIpAddress:   "10.10.102.100",
-		configText:     testAccCheckVcdNetworkRouted,
+		endIpAddress:   "10.10.102.50",
+		configText:     testAccCheckVcdNetworkRoutedStatic,
 		resourceName:   "vcd_network_routed",
+	}
+	runTest(def, t)
+}
+
+func TestAccVcdNetworkRoutedDhcp(t *testing.T) {
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	var def = networkDef{
+		name:           routedNetworkDhcp,
+		gateway:        "10.10.102.1",
+		startIpAddress: "10.10.102.51",
+		endIpAddress:   "10.10.102.100",
+		configText:     testAccCheckVcdNetworkRoutedDhcp,
+		resourceName:   "vcd_network_routed",
+	}
+	runTest(def, t)
+}
+
+func TestAccVcdNetworkRoutedMixed(t *testing.T) {
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	var def = networkDef{
+		name:            routedNetworkMixed,
+		gateway:         "10.10.102.1",
+		startIpAddress:  "10.10.102.2",
+		endIpAddress:    "10.10.102.50",
+		startIpAddress2: "10.10.102.51",
+		endIpAddress2:   "10.10.102.100",
+		configText:      testAccCheckVcdNetworkRoutedMixed,
+		resourceName:    "vcd_network_routed",
 	}
 	runTest(def, t)
 }
@@ -62,7 +144,7 @@ func TestAccVcdNetworkDirect(t *testing.T) {
 	}
 
 	var def = networkDef{
-		name:            "TestAccVcdNetworkDirect",
+		name:            directNetwork,
 		externalNetwork: testConfig.Networking.ExternalNetwork,
 		configText:      testAccCheckVcdNetworkDirect,
 		resourceName:    "vcd_network_direct",
@@ -83,32 +165,36 @@ func runTest(def networkDef, t *testing.T) {
 		"Gateway":         def.gateway,
 		"StartIpAddress":  def.startIpAddress,
 		"EndIpAddress":    def.endIpAddress,
+		"StartIpAddress2": def.startIpAddress2,
+		"EndIpAddress2":   def.endIpAddress2,
 		"ExternalNetwork": def.externalNetwork,
 		"FuncName":        networkName,
 	}
 	var network govcd.OrgVDCNetwork
 	configText := templateFill(def.configText, params)
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	// steps for external network
-	var steps = []resource.TestStep{
-		resource.TestStep{
-			Config:      configText,
-			ExpectError: regexp.MustCompile(`After applying this step, the plan was not empty`),
-			Check: resource.ComposeTestCheckFunc(
-				testAccCheckVcdNetworkExists(def.resourceName+"."+networkName, &network),
-				testAccCheckVcdNetworkAttributes(networkName, &network),
-				resource.TestCheckResourceAttr(
-					def.resourceName+"."+networkName, "name", networkName),
-				resource.TestMatchResourceAttr(
-					def.resourceName+"."+networkName, "href", generatedHrefRegexp),
-			),
-		},
-	}
+	var steps []resource.TestStep
 
-	// Basic tests for isolated and routed
-	if def.externalNetwork == "" {
+	switch def.name {
+	case directNetwork:
 		steps = []resource.TestStep{
-
+			resource.TestStep{
+				Config:      configText,
+				ExpectError: regexp.MustCompile(`After applying this step, the plan was not empty`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVcdNetworkExists(def.resourceName+"."+networkName, &network),
+					testAccCheckVcdNetworkAttributes(networkName, &network),
+					resource.TestCheckResourceAttr(
+						def.resourceName+"."+networkName, "name", networkName),
+					resource.TestMatchResourceAttr(
+						def.resourceName+"."+networkName, "href", generatedHrefRegexp),
+				),
+			},
+		}
+	case routedNetworkStatic, routedNetworkMixed, isolatedStaticNetwork, isolatedMixedNetwork:
+		steps = []resource.TestStep{
 			resource.TestStep{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
@@ -125,6 +211,25 @@ func runTest(def networkDef, t *testing.T) {
 				),
 			},
 		}
+	case isolatedDhcpNetwork, routedNetworkDhcp:
+		steps = []resource.TestStep{
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVcdNetworkExists(def.resourceName+"."+networkName, &network),
+					testAccCheckVcdNetworkAttributes(networkName, &network),
+					resource.TestCheckResourceAttr(
+						def.resourceName+"."+networkName, "name", networkName),
+					resource.TestCheckResourceAttr(
+						def.resourceName+"."+networkName, "dhcp_pool.#", "1"),
+					resource.TestCheckResourceAttr(
+						def.resourceName+"."+networkName, "gateway", def.gateway),
+					resource.TestMatchResourceAttr(
+						def.resourceName+"."+networkName, "href", generatedHrefRegexp),
+				),
+			},
+		}
+
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -212,7 +317,7 @@ func testAccCheckVcdNetworkAttributes(name string, network *govcd.OrgVDCNetwork)
 	}
 }
 
-const testAccCheckVcdNetworkIsolated = `
+const testAccCheckVcdNetworkIsolatedStatic = `
 resource "vcd_network_isolated" "{{.NetworkName}}" {
   name       = "{{.NetworkName}}"
   org        = "{{.Org}}"
@@ -226,6 +331,38 @@ resource "vcd_network_isolated" "{{.NetworkName}}" {
 }
 `
 
+const testAccCheckVcdNetworkIsolatedDhcp = `
+resource "vcd_network_isolated" "{{.NetworkName}}" {
+  name       = "{{.NetworkName}}"
+  org        = "{{.Org}}"
+  vdc        = "{{.Vdc}}"
+  gateway    = "{{.Gateway}}"
+  dns1       = "192.168.2.1"
+  dhcp_pool {
+    start_address = "{{.StartIpAddress}}"
+    end_address   = "{{.EndIpAddress}}"
+  }
+}
+`
+
+const testAccCheckVcdNetworkIsolatedMixed = `
+resource "vcd_network_isolated" "{{.NetworkName}}" {
+  name       = "{{.NetworkName}}"
+  org        = "{{.Org}}"
+  vdc        = "{{.Vdc}}"
+  gateway    = "{{.Gateway}}"
+  dns1       = "192.168.2.1"
+  static_ip_pool {
+    start_address = "{{.StartIpAddress}}"
+    end_address   = "{{.EndIpAddress}}"
+  }
+  dhcp_pool {
+    start_address = "{{.StartIpAddress2}}"
+    end_address   = "{{.EndIpAddress2}}"
+  }
+}
+`
+
 const testAccCheckVcdNetworkDirect = `
 resource "vcd_network_direct" "{{.NetworkName}}" {
   name             = "{{.NetworkName}}"
@@ -235,7 +372,7 @@ resource "vcd_network_direct" "{{.NetworkName}}" {
 }
 `
 
-const testAccCheckVcdNetworkRouted = `
+const testAccCheckVcdNetworkRoutedStatic = `
 resource "vcd_network_routed" "{{.NetworkName}}" {
   name         = "{{.NetworkName}}"
   org          = "{{.Org}}"
@@ -245,6 +382,38 @@ resource "vcd_network_routed" "{{.NetworkName}}" {
   static_ip_pool {
     start_address = "{{.StartIpAddress}}"
     end_address   = "{{.EndIpAddress}}"
+  }
+}
+`
+
+const testAccCheckVcdNetworkRoutedDhcp = `
+resource "vcd_network_routed" "{{.NetworkName}}" {
+  name         = "{{.NetworkName}}"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  gateway      = "{{.Gateway}}"
+  dhcp_pool {
+    start_address = "{{.StartIpAddress}}"
+    end_address   = "{{.EndIpAddress}}"
+  }
+}
+`
+
+const testAccCheckVcdNetworkRoutedMixed = `
+resource "vcd_network_routed" "{{.NetworkName}}" {
+  name         = "{{.NetworkName}}"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  gateway      = "{{.Gateway}}"
+  static_ip_pool {
+    start_address = "{{.StartIpAddress}}"
+    end_address   = "{{.EndIpAddress}}"
+  }
+  dhcp_pool {
+    start_address = "{{.StartIpAddress2}}"
+    end_address   = "{{.EndIpAddress2}}"
   }
 }
 `

--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -3,12 +3,12 @@ layout: "vcd"
 page_title: "vCloudDirector: vcd_network"
 sidebar_current: "docs-vcd-resource-network"
 description: |-
-  Provides a vCloud Director VDC Network. This can be used to create, modify, and delete internal networks for vApps to connect.
+  Provides a vCloud Director Org VDC Network. This can be used to create, modify, and delete internal networks for vApps to connect.
 ---
 
 # vcd\_network (Deprecated)
 
-Provides a vCloud Director VDC Network. This can be used to create,
+Provides a vCloud Director Org VDC Network. This can be used to create,
 modify, and delete internal networks for vApps to connect.
 **v2.0+** : this resource is deprecated, and replaced by [vcd-network-routed](vcd-network-routed).
 It is also complemented by [vcd-network-isolated](vcd-network-isolated) and [vcd-network-direct](d-network-direct).

--- a/website/docs/r/network_direct.html.markdown
+++ b/website/docs/r/network_direct.html.markdown
@@ -15,8 +15,8 @@ modify, and delete internal networks for vApps to connect.
 
 ```hcl
 resource "vcd_network_direct" "net" {
-  org              = "my-org"  #Optional
-  vdc              = "my-vdc"  #Optional
+  org              = "my-org" #Optional
+  vdc              = "my-vdc" #Optional
 
   name             = "my-net"
   external_network = "my-ext-net"

--- a/website/docs/r/network_direct.html.markdown
+++ b/website/docs/r/network_direct.html.markdown
@@ -3,20 +3,21 @@ layout: "vcd"
 page_title: "vCloudDirector: vcd_network_direct"
 sidebar_current: "docs-vcd-resource-network-direct"
 description: |-
-  Provides a vCloud Director VDC Network attached to an external one. This can be used to create, modify, and delete internal networks for vApps to connect.
+  Provides a vCloud Director Org VDC Network attached to an external one. This can be used to create, modify, and delete internal networks for vApps to connect.
 ---
 
 # vcd\_network\_direct (*v2.0+*)
 
-Provides a vCloud Director VDC Network directly connected to an external network. This can be used to create,
+Provides a vCloud Director Org VDC Network directly connected to an external network. This can be used to create,
 modify, and delete internal networks for vApps to connect.
 
 ## Example Usage
 
 ```hcl
 resource "vcd_network_direct" "net" {
-  org              = "my-org"
-  vdc              = "my-vdc"
+  org              = "my-org"  #Optional
+  vdc              = "my-vdc"  #Optional
+
   name             = "my-net"
   external_network = "my-ext-net"
 }
@@ -26,6 +27,9 @@ resource "vcd_network_direct" "net" {
 
 The following arguments are supported:
 
+* `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when 
+  connected as sysadmin working across different organisations
+* `vdc` - (Optional; *v2.0+*) The name of VDC to use, optional if defined at provider level
 * `name` - (Required) A unique name for the network
 * `external_network` - (Required) The name of the external network.
 * `shared` - (Optional) Defines if this network is shared between multiple vDCs

--- a/website/docs/r/network_direct.html.markdown
+++ b/website/docs/r/network_direct.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "vcd"
+page_title: "vCloudDirector: vcd_network_direct"
+sidebar_current: "docs-vcd-resource-network-direct"
+description: |-
+  Provides a vCloud Director VDC Network attached to an external one. This can be used to create, modify, and delete internal networks for vApps to connect.
+---
+
+# vcd\_network\_direct (*v2.0+*)
+
+Provides a vCloud Director VDC Network directly connected to an external network. This can be used to create,
+modify, and delete internal networks for vApps to connect.
+
+## Example Usage
+
+```hcl
+resource "vcd_network_direct" "net" {
+  org              = "my-org"
+  vdc              = "my-vdc"
+  name             = "my-net"
+  external_network = "my-ext-net"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name for the network
+* `external_network` - (Required) The name of the external network.
+* `shared` - (Optional) Defines if this network is shared between multiple vDCs
+  in the vOrg.  Defaults to `false`.
+

--- a/website/docs/r/network_isolated.html.markdown
+++ b/website/docs/r/network_isolated.html.markdown
@@ -1,34 +1,34 @@
 ---
 layout: "vcd"
-page_title: "vCloudDirector: vcd_network"
-sidebar_current: "docs-vcd-resource-network"
+page_title: "vCloudDirector: vcd_network_isolated"
+sidebar_current: "docs-vcd-resource-network-isolated"
 description: |-
-  Provides a vCloud Director VDC Network. This can be used to create, modify, and delete internal networks for vApps to connect.
+  Provides a vCloud Director VDC isolated Network. This can be used to create, modify, and delete internal networks for vApps to connect.
 ---
 
-# vcd\_network (Deprecated)
+# vcd\_network\_isolated (*v2.0+*)
 
-Provides a vCloud Director VDC Network. This can be used to create,
-modify, and delete internal networks for vApps to connect.
-**v2.0+** : this resource is deprecated, and replaced by [vcd-network-routed](vcd-network-routed).
-It is also complemented by [vcd-network-isolated](vcd-network-isolated) and [vcd-network-direct](d-network-direct).
+Provides a vCloud Director VDC isolated Network. This can be used to create,
+modify, and delete internal networks for vApps to connect. This network is not attached to external networks or routers.
 
 ## Example Usage
 
 ```hcl
-resource "vcd_network" "net" {
+resource "vcd_network_isolated" "net" {
+  org          = "my-org"
+  vdc          = "my-vdc"
   name         = "my-net"
-  edge_gateway = "Edge Gateway Name"
-  gateway      = "10.10.0.1"
+  gateway      = "192.168.2.1"
+  dns1         = "192.168.2.1"
 
   dhcp_pool {
-    start_address = "10.10.0.2"
-    end_address   = "10.10.0.100"
+    start_address = "192.168.2.2"
+    end_address   = "192.168.2.50"
   }
 
   static_ip_pool {
-    start_address = "10.10.0.152"
-    end_address   = "10.10.0.254"
+    start_address = "192.168.2.51"
+    end_address   = "192.168.2.100"
   }
 }
 ```
@@ -38,7 +38,6 @@ resource "vcd_network" "net" {
 The following arguments are supported:
 
 * `name` - (Required) A unique name for the network
-* `edge_gateway` - (Required) The name of the edge gateway
 * `netmask` - (Optional) The netmask for the new network. Defaults to `255.255.255.0`
 * `gateway` (Required) The gateway for this network
 * `dns1` - (Optional) First DNS server to use. Defaults to `8.8.8.8`

--- a/website/docs/r/network_isolated.html.markdown
+++ b/website/docs/r/network_isolated.html.markdown
@@ -15,8 +15,8 @@ modify, and delete internal networks for vApps to connect. This network is not a
 
 ```hcl
 resource "vcd_network_isolated" "net" {
-  org          = "my-org"  #Optional
-  vdc          = "my-vdc"  #Optional
+  org          = "my-org" #Optional
+  vdc          = "my-vdc" #Optional
 
   name         = "my-net"
   gateway      = "192.168.2.1"

--- a/website/docs/r/network_isolated.html.markdown
+++ b/website/docs/r/network_isolated.html.markdown
@@ -3,20 +3,21 @@ layout: "vcd"
 page_title: "vCloudDirector: vcd_network_isolated"
 sidebar_current: "docs-vcd-resource-network-isolated"
 description: |-
-  Provides a vCloud Director VDC isolated Network. This can be used to create, modify, and delete internal networks for vApps to connect.
+  Provides a vCloud Director Org VDC isolated Network. This can be used to create, modify, and delete internal networks for vApps to connect.
 ---
 
 # vcd\_network\_isolated (*v2.0+*)
 
-Provides a vCloud Director VDC isolated Network. This can be used to create,
+Provides a vCloud Director Org VDC isolated Network. This can be used to create,
 modify, and delete internal networks for vApps to connect. This network is not attached to external networks or routers.
 
 ## Example Usage
 
 ```hcl
 resource "vcd_network_isolated" "net" {
-  org          = "my-org"
-  vdc          = "my-vdc"
+  org          = "my-org"  #Optional
+  vdc          = "my-vdc"  #Optional
+
   name         = "my-net"
   gateway      = "192.168.2.1"
   dns1         = "192.168.2.1"
@@ -37,6 +38,9 @@ resource "vcd_network_isolated" "net" {
 
 The following arguments are supported:
 
+* `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when 
+  connected as sysadmin working across different organisations
+* `vdc` - (Optional; *v2.0+*) The name of VDC to use, optional if defined at provider level
 * `name` - (Required) A unique name for the network
 * `netmask` - (Optional) The netmask for the new network. Defaults to `255.255.255.0`
 * `gateway` (Required) The gateway for this network

--- a/website/docs/r/network_routed.html.markdown
+++ b/website/docs/r/network_routed.html.markdown
@@ -3,20 +3,21 @@ layout: "vcd"
 page_title: "vCloudDirector: vcd_network_routed"
 sidebar_current: "docs-vcd-resource-network-routed"
 description: |-
-  Provides a vCloud Director VDC routed Network. This can be used to create, modify, and delete internal networks for vApps to connect.
+  Provides a vCloud Director Org VDC routed Network. This can be used to create, modify, and delete internal networks for vApps to connect.
 ---
 
 # vcd\_network\_routed (*v2.0+*)
 
-Provides a vCloud Director VDC routed Network. This can be used to create,
+Provides a vCloud Director Org VDC routed Network. This can be used to create,
 modify, and delete internal networks for vApps to connect.
 
 ## Example Usage
 
 ```hcl
 resource "vcd_network_routed" "net" {
-  org          = "my-org"
-  vdc          = "my-vdc"
+  org          = "my-org"  # Optional
+  vdc          = "my-vdc"  # Optional
+
   name         = "my-net"
   edge_gateway = "Edge Gateway Name"
   gateway      = "10.10.0.1"
@@ -37,6 +38,9 @@ resource "vcd_network_routed" "net" {
 
 The following arguments are supported:
 
+* `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when 
+  connected as sysadmin working across different organisations
+* `vdc` - (Optional; *v2.0+*) The name of VDC to use, optional if defined at provider level
 * `name` - (Required) A unique name for the network
 * `edge_gateway` - (Required) The name of the edge gateway
 * `netmask` - (Optional) The netmask for the new network. Defaults to `255.255.255.0`

--- a/website/docs/r/network_routed.html.markdown
+++ b/website/docs/r/network_routed.html.markdown
@@ -15,8 +15,8 @@ modify, and delete internal networks for vApps to connect.
 
 ```hcl
 resource "vcd_network_routed" "net" {
-  org          = "my-org"  # Optional
-  vdc          = "my-vdc"  # Optional
+  org          = "my-org" # Optional
+  vdc          = "my-vdc" # Optional
 
   name         = "my-net"
   edge_gateway = "Edge Gateway Name"

--- a/website/docs/r/network_routed.html.markdown
+++ b/website/docs/r/network_routed.html.markdown
@@ -1,22 +1,22 @@
 ---
 layout: "vcd"
-page_title: "vCloudDirector: vcd_network"
-sidebar_current: "docs-vcd-resource-network"
+page_title: "vCloudDirector: vcd_network_routed"
+sidebar_current: "docs-vcd-resource-network-routed"
 description: |-
-  Provides a vCloud Director VDC Network. This can be used to create, modify, and delete internal networks for vApps to connect.
+  Provides a vCloud Director VDC routed Network. This can be used to create, modify, and delete internal networks for vApps to connect.
 ---
 
-# vcd\_network (Deprecated)
+# vcd\_network\_routed (*v2.0+*)
 
-Provides a vCloud Director VDC Network. This can be used to create,
+Provides a vCloud Director VDC routed Network. This can be used to create,
 modify, and delete internal networks for vApps to connect.
-**v2.0+** : this resource is deprecated, and replaced by [vcd-network-routed](vcd-network-routed).
-It is also complemented by [vcd-network-isolated](vcd-network-isolated) and [vcd-network-direct](d-network-direct).
 
 ## Example Usage
 
 ```hcl
-resource "vcd_network" "net" {
+resource "vcd_network_routed" "net" {
+  org          = "my-org"
+  vdc          = "my-vdc"
   name         = "my-net"
   edge_gateway = "Edge Gateway Name"
   gateway      = "10.10.0.1"

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -25,6 +25,15 @@
             <li<%= sidebar_current("docs-vcd-resource-network") %>>
               <a href="/docs/providers/vcd/r/network.html">vcd_network</a>
             </li>
+            <li<%= sidebar_current("docs-vcd-resource-network-routed") %>>
+              <a href="/docs/providers/vcd/r/network.html">vcd_network_routed</a>
+            </li>
+            <li<%= sidebar_current("docs-vcd-resource-network-direct") %>>
+              <a href="/docs/providers/vcd/r/network.html">vcd_network_direct</a>
+            </li>
+            <li<%= sidebar_current("docs-vcd-resource-network-isolated") %>>
+              <a href="/docs/providers/vcd/r/network.html">vcd_network_isolated</a>
+            </li>
             <li<%= sidebar_current("docs-vcd-resource-snat") %>>
               <a href="/docs/providers/vcd/r/snat.html">vcd_snat</a>
             </li>


### PR DESCRIPTION
Add tests that use combinations of static IP and DHCP parameters where appropriate.
Extends issues #96, #97.

This PR could conflict with others that are adding documentation (the file `vcd.erb` is used by many).

I am not sure about the hyperlinks within `network.html.markdown`.