### PR TITLE
Polish docs for network, vApp and Org resources

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -165,7 +165,7 @@ The following arguments are used to configure the VMware vCloud Director Provide
 * `logging_file` - (Optional; *v2.0+*) The name of the log file (when `logging` is enabled). By default is 
   `go-vcloud-director` and it can also be changed using the `VCD_API_LOGGING_FILE` environment variable.
 
-## Connection cache (*2.0+*)
+## Connection Cache (*2.0+*)
 
 vCloud Director connection calls can be expensive, and if a definition file contains several resources, it may trigger 
 multiple connections. There is a cache engine, disabled by default, which can be activated by the `VCD_CACHE` 

--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -10,7 +10,8 @@ description: |-
 
 Provides a vCloud Director Org VDC Network. This can be used to create,
 modify, and delete internal networks for vApps to connect.
-**v2.0+** : this resource is deprecated, and replaced by [vcd-network-routed](vcd-network-routed).
+
+**Deprecated in v2.0+** : this resource is deprecated and replaced by [vcd-network-routed](vcd-network-routed).
 It is also complemented by [vcd-network-isolated](vcd-network-isolated) and [vcd-network-direct](d-network-direct).
 
 ## Example Usage

--- a/website/docs/r/network_direct.html.markdown
+++ b/website/docs/r/network_direct.html.markdown
@@ -6,10 +6,12 @@ description: |-
   Provides a vCloud Director Org VDC Network attached to an external one. This can be used to create, modify, and delete internal networks for vApps to connect.
 ---
 
-# vcd\_network\_direct (*v2.0+*)
+# vcd\_network\_direct
 
 Provides a vCloud Director Org VDC Network directly connected to an external network. This can be used to create,
 modify, and delete internal networks for vApps to connect.
+
+Supported in provider *v2.0+*
 
 ## Example Usage
 

--- a/website/docs/r/network_isolated.html.markdown
+++ b/website/docs/r/network_isolated.html.markdown
@@ -6,10 +6,12 @@ description: |-
   Provides a vCloud Director Org VDC isolated Network. This can be used to create, modify, and delete internal networks for vApps to connect.
 ---
 
-# vcd\_network\_isolated (*v2.0+*)
+# vcd\_network\_isolated
 
 Provides a vCloud Director Org VDC isolated Network. This can be used to create,
 modify, and delete internal networks for vApps to connect. This network is not attached to external networks or routers.
+
+Supported in provider *v2.0+*
 
 ## Example Usage
 

--- a/website/docs/r/network_routed.html.markdown
+++ b/website/docs/r/network_routed.html.markdown
@@ -6,10 +6,12 @@ description: |-
   Provides a vCloud Director Org VDC routed Network. This can be used to create, modify, and delete internal networks for vApps to connect.
 ---
 
-# vcd\_network\_routed (*v2.0+*)
+# vcd\_network\_routed
 
 Provides a vCloud Director Org VDC routed Network. This can be used to create,
 modify, and delete internal networks for vApps to connect.
+
+Supported in provider *v2.0+*
 
 ## Example Usage
 

--- a/website/docs/r/vapp.html.markdown
+++ b/website/docs/r/vapp.html.markdown
@@ -13,6 +13,59 @@ modify, and delete vApps.
 
 ## Example Usage
 
+Example with more than one VM under a vApp.
+
+```hcl
+resource "vcd_network_direct" "net" {
+  name             = "net"
+  external_network = "corp-network"
+}
+
+resource "vcd_vapp" "web" {
+  name          = "web"
+  
+  metadata {
+    role    = "web"
+    env     = "staging"
+    version = "v1"
+  }
+  
+  depends_on = ["vcd_network_direct.net"]
+}
+
+resource "vcd_vapp_vm" "web1" {
+  vapp_name     = "${vcd_vapp.web.name}"
+  name          = "web1"
+  catalog_name  = "Boxes"
+  template_name = "lampstack-1.10.1-ubuntu-10.04"
+  memory        = 2048
+  cpus          = 1
+
+  network_name = "net"
+  ip           = "10.10.104.161"
+  
+  depends_on = ["vcd_vapp.web"]
+}
+
+resource "vcd_vapp_vm" "web2" {
+  vapp_name     = "${vcd_vapp.web.name}"
+  name          = "web2"
+  catalog_name  = "Boxes"
+  template_name = "lampstack-1.10.1-ubuntu-10.04"
+  memory        = 2048
+  cpus          = 1
+
+  network_name = "net"
+  ip           = "10.10.104.162"
+  
+  depends_on = ["vcd_vapp.web"]
+}
+```
+
+## Example of vApp with single VM
+
+**Not recommended in v2.0+** : in the earlier version of the provider it was possible to define a vApp with a single VM in one resource, but it is not recommended as of *v2.0+* provider. Please define vApp and VM in separate resources instead. 
+
 ```hcl
 resource "vcd_network_routed" "net" {
   # ...

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -13,6 +13,9 @@
         <li<%= sidebar_current("docs-vcd-resource") %>>
           <a href="#">Resources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-vcd-resource-org") %>>
+              <a href="/docs/providers/vcd/r/org.html">vcd_org</a>
+            </li>
             <li<%= sidebar_current("docs-vcd-resource-catalog") %>>
               <a href="/docs/providers/vcd/r/catalog.html">vcd_catalog</a>
             </li>


### PR DESCRIPTION
- Add first example in vApp with vApp and VM resources being separate
- Add a warning that it's not recommended anymore to create vApp and VM in a single resource
- Make notes about v2.0+ consistent
- Add Org page to vcd.erb

Signed-off-by: Linas Virbalas <lvirbalas@vmware.com>