### PR TITLE
Add default timeout to test configuration

### DIFF
--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -242,14 +242,17 @@ func getConfigStruct() TestConfig {
 		// defined in vendor/github.com/hashicorp/terraform/helper/resource/testing.go
 		_ = os.Setenv("TF_ACC", "1")
 	}
+	// The following variables are used in ./provider.go
 	if configStruct.Provider.MaxRetryTimeout == 0 {
-		// Setting a default value that should be reasonable for these tests, as we run many heavy operations
-		_ = os.Setenv("VCD_MAX_RETRY_TIMEOUT", "300")
+		// If there is no retry timeout in the configuration, and there is no env variable for it, we set a new one
+		if os.Getenv("VCD_MAX_RETRY_TIMEOUT") == "" {
+			// Setting a default value that should be reasonable for these tests, as we run many heavy operations
+			_ = os.Setenv("VCD_MAX_RETRY_TIMEOUT", "300")
+		}
 	} else {
 		newRetryTimeout := fmt.Sprintf("%d", configStruct.Provider.MaxRetryTimeout)
 		_ = os.Setenv("VCD_MAX_RETRY_TIMEOUT", newRetryTimeout)
 	}
-	// The following variables are used in ./provider.go
 	if configStruct.Provider.SysOrg == "" {
 		configStruct.Provider.SysOrg = configStruct.VCD.Org
 	}

--- a/vcd/sample_vcd_test_config.json
+++ b/vcd/sample_vcd_test_config.json
@@ -11,13 +11,13 @@
     "allowInsecure": true,
     "//": "tfAcceptanceTests is needed to allow the whole test suite to run",
     "//": "Warning: it may cost time (from 14 to 40 min) and possibly money",
-    "tfAcceptanceTests": false,
+    "tfAcceptanceTests": true,
     "//": "If enabled, the test suite will cache the provider connection for up to 20 minutes",
     "//": "and then renew it automatically. This will save some heavy network traffic.",
-    "//": "The default is false",
-    "UseVcdConnectionCache": true,
-    "//": "The default for max retry timeout is 60, which often leads to premature test termination",
-    "//": "If no value is provided, the test suite will set the value to 300",
+    "//": "Disabled by default if UseVcdConnectionCache is not set",
+    "useVcdConnectionCache": true,
+    "//": "The Terraform provider default for max retry timeout is 60, which often leads to premature test termination",
+    "//": "This value changes the default for the test suite. If no value is provided, it will set to 300",
     "maxRetryTimeout": 300
   },
   "vcd": {
@@ -40,6 +40,7 @@
     "internalIp": "192.168.4.30",
      "//": "sharedSecret is defined in the edge gateway service configuration", 
     "sharedSecret": "my-secret-string",
+    "//": "The name of a vCD external network",
     "externalNetwork": "my-ext-network",
     "local": {
       "//": "Local definition for a vpn", 

--- a/vcd/sample_vcd_test_config.json
+++ b/vcd/sample_vcd_test_config.json
@@ -14,7 +14,7 @@
     "tfAcceptanceTests": true,
     "//": "If enabled, the test suite will cache the provider connection for up to 20 minutes",
     "//": "and then renew it automatically. This will save some heavy network traffic.",
-    "//": "Disabled by default if UseVcdConnectionCache is not set",
+    "//": "Disabled by default if useVcdConnectionCache is not set",
     "useVcdConnectionCache": true,
     "//": "The Terraform provider default for max retry timeout is 60, which often leads to premature test termination",
     "//": "This value changes the default for the test suite. If no value is provided, it will set to 300",

--- a/vcd/sample_vcd_test_config.json
+++ b/vcd/sample_vcd_test_config.json
@@ -11,7 +11,14 @@
     "allowInsecure": true,
     "//": "tfAcceptanceTests is needed to allow the whole test suite to run",
     "//": "Warning: it may cost time (from 14 to 40 min) and possibly money",
-    "tfAcceptanceTests": false
+    "tfAcceptanceTests": false,
+    "//": "If enabled, the test suite will cache the provider connection for up to 20 minutes",
+    "//": "and then renew it automatically. This will save some heavy network traffic.",
+    "//": "The default is false",
+    "UseVcdConnectionCache": true,
+    "//": "The default for max retry timeout is 60, which often leads to premature test termination",
+    "//": "If no value is provided, the test suite will set the value to 300",
+    "maxRetryTimeout": 300
   },
   "vcd": {
     "//": "This section contains the organization composition",
@@ -33,6 +40,7 @@
     "internalIp": "192.168.4.30",
      "//": "sharedSecret is defined in the edge gateway service configuration", 
     "sharedSecret": "my-secret-string",
+    "externalNetwork": "my-ext-network",
     "local": {
       "//": "Local definition for a vpn", 
       "localIp": "10.15.21.11",


### PR DESCRIPTION
Add option to define timeout for tests
Set a default value of 300 for timeout when option is blank
Add option to enable connection cache for tests
Add missing external network definition in sample file

This addition will allow users to run tests with less recourse to environment variables.