### PR TITLE
Write changelog for the new version and fix two test issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ IMPROVEMENTS:
 BACKWARDS INCOMPATIBILITIES / NOTES:
 
 * Resource `vcd_network` deprecated in favor of a new name `vcd_network_routed`
-* Previously deprecated provider's parameter `maxRetryTimeout` removed completely in favor of `max_retry_timeout`
+* Previously deprecated parameter `provider.maxRetryTimeout` removed completely in favor of `provider.max_retry_timeout`
 
 TESTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+## 2.0.0 (TODO: date)
+
+Please look for "v2.0+" keyword in documentation which is used to emphasize changes and new features.
+
+ARCHITECTURAL:
+
+* Vendor (vCD Golang SDK) switch from the old govcloudair to the newly supported [go-vcloud-director](https://github.com/vmware/go-vcloud-director)
+
+FEATURES:
+
+* vCD 8.2, 9.0, 9.1 and 9.5 version support
+* Sys admin login support (required to support new higher privileged operations) - `provider.org = "System"` or `provider.sysorg = "System"`
+* Ability to select Org and VDC at resource level - `org` and `vdc` parameters
+* New Org resource - `vcd_org`
+* New Catalog resource - `vcd_catalog`
+* New Catalog item resource (upload OVA) - `vcd_catalog_item`
+* New Catalog media resource (upload ISO) - `vcd_catalog_media`
+* New direct and isolated Org VDC network resources (complements the routed network) - `vcd_network_direct`, `vcd_network_isolated` and `vcd_network_routed`
+* DNAT protocol and ICMP sub type setting - `vcd_dnat.protocol` and `vcd_dnat.icmp_sub_type`
+* Ability to accept EULAs when deploying VM - `vcd_vapp_vm.accept_all_eulas`
+* Setting to log API calls for troubleshooting - `provider.logging` and `provider.logging_file`
+
+IMPROVEMENTS:
+
+* Fixes for guest customization issues
+* Improvements to error handling and error messages
+* New tests and test framework improvements
+* Provisional support for connection caching (disabled by default)
+
+BACKWARDS INCOMPATIBILITIES / NOTES:
+
+* Resource `vcd_network` deprecated in favor of a new name `vcd_network_routed`
+* Previously deprecated provider's parameter `maxRetryTimeout` removed completely in favor of `max_retry_timeout`
+
+TESTS:
+
+* Test configuration is now included in a file (create `vcd_test_config.json` from `sample_vcd_test_config.json`) instead of being defined by environment variables
+
 ## 1.0.1 (Unreleased)
 
 IMPROVEMENTS:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,7 +17,7 @@ testacc: fmtcheck
 		echo "ERROR: test configuration file vcd/vcd_test_config.json is missing"; \
 		exit 1; \
 	fi
-	cd vcd ; TF_ACC=1 go test -v . -timeout 45m
+	cd vcd ; TF_ACC=1 go test -v . -timeout 60m
 
 vet:
 	@echo "go vet ."

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -114,7 +114,7 @@ func dirExists(filename string) bool {
 // Returns true if the current configuration uses a system administrator for connections
 func usingSysAdmin() bool {
 	conn, ok := testAccProvider.Meta().(*VCDClient)
-	if ! ok {
+	if !ok {
 		panic("unable to retrieve connection from provider")
 	}
 	if conn.Client.IsSysAdmin {


### PR DESCRIPTION
Docs:
- Write-up v2.0 provider features to CHANGELOG.md

Tests:
- Extend the total `make testacc` timeout from 45 to 60 mins - now that
  there are more tests, running without cache takes in the vicinity of
  45 mins so there were failures time after time
- Fix a noticed lack of fmt from PR #141 which broke the build

Signed-off-by: Linas Virbalas <lvirbalas@vmware.com>