### PR TITLE
Define resource for vdc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 
 * `vcd_vapp_vm` - Ability to add metadata to a VM. For previous behaviour please see `BACKWARDS INCOMPATIBILITIES` ([#158](https://github.com/terraform-providers/terraform-provider-vcd/issues/158))
+* **New Resource:** VDC resource `vcd_vdc` - ([#149](https://github.com/terraform-providers/terraform-provider-vcd/pull/149))
 
 BUG FIXES:
 

--- a/vcd/config.go
+++ b/vcd/config.go
@@ -115,6 +115,9 @@ func (cli *VCDClient) GetOrgAndVdc(orgName, vdcName string) (org govcd.Org, vdc 
 	if err != nil {
 		return govcd.Org{}, govcd.Vdc{}, fmt.Errorf("error retrieving VDC %s: %s", vdcName, err)
 	}
+	if (vdc == govcd.Vdc{}) {
+		return govcd.Org{}, govcd.Vdc{}, fmt.Errorf("error retrieving VDC %s: not found", vdcName)
+	}
 	return org, vdc, err
 }
 

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -43,7 +43,7 @@ type TestConfig struct {
 		Org         string `json:"org"`
 		Vdc         string `json:"vdc"`
 		ProviderVdc struct {
-			ID             string `json:"id"`
+			Name           string `json:"name"`
 			NetworkPool    string `json:"networkPool"`
 			StorageProfile string `json:"storageProfile"`
 		} `json:"providerVdc"`

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -40,8 +40,13 @@ type TestConfig struct {
 		MaxRetryTimeout          int    `json:"maxRetryTimeout"`
 	} `json:"provider"`
 	VCD struct {
-		Org     string `json:"org"`
-		Vdc     string `json:"vdc"`
+		Org         string `json:"org"`
+		Vdc         string `json:"vdc"`
+		ProviderVdc struct {
+			ID             string `json:"id"`
+			NetworkPool    string `json:"networkPool"`
+			StorageProfile string `json:"storageProfile"`
+		} `json:"providerVdc"`
 		Catalog struct {
 			Name        string `json:"name,omitempty"`
 			CatalogItem string `json:"catalogItem,omitempty"`

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -95,6 +95,7 @@ func Provider() terraform.ResourceProvider {
 			"vcd_edgegateway_vpn":  resourceVcdEdgeGatewayVpn(),
 			"vcd_vapp_vm":          resourceVcdVAppVm(),
 			"vcd_org":              resourceOrg(),
+			"vcd_vdc":              resourceVcdVdc(),
 			"vcd_catalog":          resourceVcdCatalog(),
 			"vcd_catalog_item":     resourceVcdCatalogItem(),
 			"vcd_catalog_media":    resourceVcdCatalogMedia(),

--- a/vcd/resource_vcd_vdc.go
+++ b/vcd/resource_vcd_vdc.go
@@ -421,7 +421,7 @@ func getVcdVdcInput(d *schema.ResourceData, vcdClient *VCDClient) (*types.VdcCon
 	}
 
 	if vCpuInMhz, ok := d.GetOk("v_cpu_in_mhz"); ok {
-		params.VCpuInMhz = vCpuInMhz.(int64)
+		params.VCpuInMhz = int64(vCpuInMhz.(int))
 	}
 
 	if isThinProvision, ok := d.GetOk("is_thin_provision"); ok {

--- a/vcd/resource_vcd_vdc.go
+++ b/vcd/resource_vcd_vdc.go
@@ -1,0 +1,423 @@
+package vcd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/vmware/go-vcloud-director/govcd"
+	types "github.com/vmware/go-vcloud-director/types/v56"
+)
+
+func resourceVcdVdc() *schema.Resource {
+	capacityWithUsage := schema.Schema{
+		Type:     schema.TypeSet,
+		Required: true,
+		ForceNew: false,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"units": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"allocated": {
+					Type:     schema.TypeInt,
+					Required: false,
+					Optional: true,
+				},
+				"limit": {
+					Type:     schema.TypeInt,
+					Required: false,
+					Optional: true,
+				},
+				"reserved": {
+					Type:     schema.TypeInt,
+					Required: false,
+					Optional: true,
+				},
+				"used": {
+					Type:     schema.TypeInt,
+					Required: false,
+					Optional: true,
+				},
+				"overhead": {
+					Type:     schema.TypeInt,
+					Required: false,
+					Optional: true,
+				},
+			},
+		},
+	}
+
+	return &schema.Resource{
+		Create: resourceVcdVdcCreate,
+		Delete: resourceVcdVdcDelete,
+		Read:   resourceVcdVdcRead,
+		Update: resourceVcdVdcUpdate,
+
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: false,
+				Optional: true,
+				ForceNew: false,
+			},
+			"allocation_model": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(string)
+					switch v {
+					case
+						"AllocationVApp",
+						"AllocationPool",
+						"ReservationPool":
+						return
+					default:
+						errs = append(errs, fmt.Errorf("%q must be one of {AllocationVApp, AllocationPool, ReservationPool}, got: %s", key, v))
+					}
+					return
+				},
+			},
+			"compute_capacity": &schema.Schema{
+				Required: true,
+				ForceNew: false,
+				Type:     schema.TypeSet,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cpu":    &capacityWithUsage,
+						"memory": &capacityWithUsage,
+					},
+				},
+			},
+			"nic_quota": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: false,
+				Optional: true,
+				ForceNew: false,
+			},
+			"network_quota": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: false,
+				Optional: true,
+				ForceNew: false,
+			},
+			"vm_quota": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: false,
+				Optional: true,
+				ForceNew: false,
+			},
+			"is_enabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Required: false,
+				Optional: true,
+				ForceNew: false,
+			},
+			"storage_profile": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: false,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: false,
+							Optional: true,
+						},
+						"units": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"limit": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"default": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"provider": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"resource_guaranteed_memory": &schema.Schema{
+				Type:     schema.TypeFloat,
+				Required: false,
+				Optional: true,
+				ForceNew: false,
+			},
+			"resource_guaranteed_cpu": &schema.Schema{
+				Type:     schema.TypeFloat,
+				Required: false,
+				Optional: true,
+				ForceNew: false,
+			},
+			"v_cpu_in_mhz": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: false,
+				Optional: true,
+				ForceNew: false,
+			},
+			"is_thin_provision": &schema.Schema{
+				Type:     schema.TypeBool,
+				Required: false,
+				Optional: true,
+				ForceNew: false,
+			},
+			"network_pool": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: false,
+				Optional: true,
+				ForceNew: false,
+			},
+			"provider_vdc": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"uses_fast_provisioning": &schema.Schema{
+				Type:     schema.TypeBool,
+				Required: false,
+				Optional: true,
+				ForceNew: false,
+			},
+			"over_commit_allowed": &schema.Schema{
+				Type:     schema.TypeBool,
+				Required: false,
+				Optional: true,
+				ForceNew: false,
+			},
+			"vm_discovery_enabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Required: false,
+				Optional: true,
+				ForceNew: false,
+			},
+
+			"delete_force": &schema.Schema{
+				Type:        schema.TypeBool,
+				Required:    true,
+				ForceNew:    false,
+				Description: "When destroying use delete_force=True to remove a vdc and any objects it contains, regardless of their state.",
+			},
+			"delete_recursive": &schema.Schema{
+				Type:        schema.TypeBool,
+				Required:    true,
+				ForceNew:    false,
+				Description: "When destroying use delete_recursive=True to remove the vdc and any objects it contains that are in a state that normally allows removal.",
+			},
+		},
+	}
+}
+
+func resourceVcdVdcCreate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[TRACE] vdc creation initiated")
+
+	vcdClient := meta.(*VCDClient)
+
+	// vdc creation is accessible only in administrator API part
+	adminOrg, err := vcdClient.GetAdminOrgFromResource(d)
+	if err != nil {
+		return fmt.Errorf(errorRetrievingOrg, err)
+	}
+
+	params, err := getVcdVdcInput(d, vcdClient)
+	if err != nil {
+		return err
+	}
+
+	task, err := adminOrg.CreateVdc(params)
+	if err != nil {
+		log.Printf("[DEBUG] Error creating vdc: %#v", err)
+		return fmt.Errorf("error creating vdc: %#v", err)
+	}
+
+	d.SetId(d.Get("name").(string))
+	log.Printf("[TRACE] vdc created: %#v", task)
+	return resourceVcdVdcRead(d, meta)
+}
+
+func resourceVcdVdcRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[TRACE] vdc read initiated")
+
+	vcdClient := meta.(*VCDClient)
+
+	adminOrg, err := vcdClient.GetAdminOrgFromResource(d)
+	if err != nil {
+		return fmt.Errorf(errorRetrievingOrg, err)
+	}
+
+	vdc, err := adminOrg.GetVdcByName(d.Id())
+	if err != nil || vdc == (govcd.Vdc{}) {
+		log.Printf("[DEBUG] Unable to find vdc. Removing from tfstate")
+		d.SetId("")
+		return nil
+	}
+
+	log.Printf("[TRACE] vdc read completed: %#v", vdc.Vdc)
+	return nil
+}
+
+//update function for "delete_force", "delete_recursive" no actions needed
+func resourceVcdVdcUpdate(d *schema.ResourceData, m interface{}) error {
+	return nil
+}
+
+func resourceVcdVdcDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[TRACE] vdc delete started")
+
+	vcdClient := meta.(*VCDClient)
+
+	adminOrg, err := vcdClient.GetAdminOrgFromResource(d)
+	if err != nil {
+		return fmt.Errorf(errorRetrievingOrg, err)
+	}
+
+	vdc, err := adminOrg.GetVdcByName(d.Id())
+	if err != nil || vdc == (govcd.Vdc{}) {
+		log.Printf("[DEBUG] Unable to find vdc. Removing from tfstate")
+		d.SetId("")
+		return nil
+	}
+
+	_, err = vdc.Delete(d.Get("delete_force").(bool), d.Get("delete_recursive").(bool))
+	if err != nil {
+		log.Printf("[DEBUG] Error removing vdc %#v", err)
+		return fmt.Errorf("error removing vdc %#v", err)
+	}
+
+	log.Printf("[TRACE] vdc delete completed: %#v", vdc.Vdc)
+	return nil
+}
+
+func capacityWithUsage(d map[string]interface{}) *types.CapacityWithUsage {
+	v := &types.CapacityWithUsage{
+		Units: d["units"].(string),
+	}
+
+	if allocated, ok := d["allocated"]; ok {
+		v.Allocated = int64(allocated.(int))
+	}
+
+	if limit, ok := d["limit"]; ok {
+		v.Limit = int64(limit.(int))
+	}
+
+	if reserved, ok := d["reserved"]; ok {
+		v.Reserved = int64(reserved.(int))
+	}
+
+	if used, ok := d["used"]; ok {
+		v.Used = int64(used.(int))
+	}
+
+	if overhead, ok := d["overhead"]; ok {
+		v.Overhead = int64(overhead.(int))
+	}
+
+	return v
+}
+
+func getVcdVdcInput(d *schema.ResourceData, vcdClient *VCDClient) (*types.VdcConfiguration, error) {
+	computeCapacity := d.Get("compute_capacity").(*schema.Set).List()[0].(map[string]interface{})
+	storageProfileMap := d.Get("storage_profile").(*schema.Set).List()[0].(map[string]interface{})
+
+	params := &types.VdcConfiguration{
+		Name:            d.Get("name").(string),
+		Xmlns:           "http://www.vmware.com/vcloud/v1.5",
+		AllocationModel: d.Get("allocation_model").(string),
+		ComputeCapacity: []*types.ComputeCapacity{
+			&types.ComputeCapacity{
+				CPU:    capacityWithUsage(computeCapacity["cpu"].(*schema.Set).List()[0].(map[string]interface{})),
+				Memory: capacityWithUsage(computeCapacity["memory"].(*schema.Set).List()[0].(map[string]interface{})),
+			},
+		},
+		VdcStorageProfile: &types.VdcStorageProfile{
+			Units:   storageProfileMap["units"].(string),
+			Limit:   int64(storageProfileMap["limit"].(int)),
+			Default: storageProfileMap["default"].(bool),
+			ProviderVdcStorageProfile: &types.Reference{
+				HREF: fmt.Sprintf("%s/admin/pvdcStorageProfile/%s", vcdClient.Client.VCDHREF.String(), storageProfileMap["provider"].(string)),
+			},
+		},
+		ProviderVdcReference: &types.Reference{
+			HREF: fmt.Sprintf("%s/admin/providervdc/%s", vcdClient.Client.VCDHREF.String(), d.Get("provider_vdc").(string)),
+		},
+	}
+
+	if storageEnabled, ok := storageProfileMap["enabled"]; ok {
+		params.VdcStorageProfile.Enabled = storageEnabled.(bool)
+	}
+
+	if description, ok := d.GetOk("description"); ok {
+		params.Description = description.(string)
+	}
+
+	if nicQuota, ok := d.GetOk("nic_quota"); ok {
+		params.NicQuota = nicQuota.(int)
+	}
+
+	if networkQuota, ok := d.GetOk("network_quota"); ok {
+		params.NetworkQuota = networkQuota.(int)
+	}
+
+	if vmQuota, ok := d.GetOk("vm_quota"); ok {
+		params.VmQuota = vmQuota.(int)
+	}
+
+	if isEnabled, ok := d.GetOk("is_enabled"); ok {
+		params.IsEnabled = isEnabled.(bool)
+	}
+
+	if resourceGuaranteedMemory, ok := d.GetOk("resource_guaranteed_memory"); ok {
+		params.ResourceGuaranteedMemory = resourceGuaranteedMemory.(float64)
+	}
+
+	if resourceGuaranteedCpu, ok := d.GetOk("resource_guaranteed_cpu"); ok {
+		params.ResourceGuaranteedCpu = resourceGuaranteedCpu.(float64)
+	}
+
+	if vCpuInMhz, ok := d.GetOk("v_cpu_in_mhz"); ok {
+		params.VCpuInMhz = vCpuInMhz.(int64)
+	}
+
+	if isThinProvision, ok := d.GetOk("is_thin_provision"); ok {
+		params.IsThinProvision = isThinProvision.(bool)
+	}
+
+	if networkPool, ok := d.GetOk("network_pool"); ok {
+		params.NetworkPoolReference = &types.Reference{
+			HREF: fmt.Sprintf("%s/admin/extension/networkPool/%s", vcdClient.Client.VCDHREF.String(), networkPool.(string)),
+		}
+	}
+
+	if usesFastProvisioning, ok := d.GetOk("uses_fast_provisioning"); ok {
+		params.UsesFastProvisioning = usesFastProvisioning.(bool)
+	}
+
+	if overCommitAllowed, ok := d.GetOk("over_commit_allowed"); ok {
+		params.OverCommitAllowed = overCommitAllowed.(bool)
+	}
+
+	if vmDiscoveryEnabled, ok := d.GetOk("vm_discovery_enabled"); ok {
+		params.VmDiscoveryEnabled = vmDiscoveryEnabled.(bool)
+	}
+
+	return params, nil
+}

--- a/vcd/resource_vcd_vdc.go
+++ b/vcd/resource_vcd_vdc.go
@@ -102,19 +102,19 @@ func resourceVcdVdc() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "Maximum number of network objects that can be deployed in this vDC. Defaults to 0, which means no networks can be deployed.",
+				Description: "Maximum number of network objects that can be deployed in this VDC. Defaults to 0, which means no networks can be deployed.",
 			},
 			"vm_quota": &schema.Schema{
 				Type:        schema.TypeInt,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "The maximum number of VMs that can be created in this vDC. Includes deployed and undeployed VMs in vApps and vApp templates. Defaults to 0, which specifies an unlimited number.",
+				Description: "The maximum number of VMs that can be created in this VDC. Includes deployed and undeployed VMs in vApps and vApp templates. Defaults to 0, which specifies an unlimited number.",
 			},
 			"is_enabled": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "True if this vDC is enabled for use by the organization vDCs. A vDC is always enabled on creation.",
+				Description: "True if this VDC is enabled for use by the organization VDCs. A VDC is always enabled on creation.",
 			},
 			"storage_profile": &schema.Schema{
 				Type:     schema.TypeSet,
@@ -125,7 +125,7 @@ func resourceVcdVdc() *schema.Resource {
 						"enabled": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Description: "True if this storage profile is enabled for use in the vDC.",
+							Description: "True if this storage profile is enabled for use in the VDC.",
 						},
 						"units": {
 							Type:        schema.TypeString,
@@ -140,28 +140,28 @@ func resourceVcdVdc() *schema.Resource {
 						"default": {
 							Type:        schema.TypeBool,
 							Required:    true,
-							Description: "True if this is default storage profile for this vDC. The default storage profile is used when an object that can specify a storage profile is created with no storage profile specified.",
+							Description: "True if this is default storage profile for this VDC. The default storage profile is used when an object that can specify a storage profile is created with no storage profile specified.",
 						},
 						"provider": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "Reference to a Provider vDC storage profile.",
+							Description: "Reference to a Provider VDC storage profile.",
 						},
 					},
 				},
-				Description: "Storage profiles supported by this vDC.",
+				Description: "Storage profiles supported by this VDC.",
 			},
 			"resource_guaranteed_memory": &schema.Schema{
 				Type:        schema.TypeFloat,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "Percentage of allocated memory resources guaranteed to vApps deployed in this vDC. For example, if this value is 0.75, then 75% of allocated resources are guaranteed. Required when AllocationModel is AllocationVApp or AllocationPool. Value defaults to 1.0 if the element is empty.",
+				Description: "Percentage of allocated memory resources guaranteed to vApps deployed in this VDC. For example, if this value is 0.75, then 75% of allocated resources are guaranteed. Required when AllocationModel is AllocationVApp or AllocationPool. Value defaults to 1.0 if the element is empty.",
 			},
 			"resource_guaranteed_cpu": &schema.Schema{
 				Type:        schema.TypeFloat,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "Percentage of allocated CPU resources guaranteed to vApps deployed in this vDC. For example, if this value is 0.75, then 75% of allocated resources are guaranteed. Required when AllocationModel is AllocationVApp or AllocationPool. Value defaults to 1.0 if the element is empty.",
+				Description: "Percentage of allocated CPU resources guaranteed to vApps deployed in this VDC. For example, if this value is 0.75, then 75% of allocated resources are guaranteed. Required when AllocationModel is AllocationVApp or AllocationPool. Value defaults to 1.0 if the element is empty.",
 			},
 			"v_cpu_in_mhz": &schema.Schema{
 				Type:        schema.TypeInt,
@@ -179,13 +179,13 @@ func resourceVcdVdc() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "Reference to a network pool in the Provider vDC. Required if this vDC will contain routed or isolated networks.",
+				Description: "Reference to a network pool in the Provider VDC. Required if this VDC will contain routed or isolated networks.",
 			},
 			"provider_vdc": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    false,
-				Description: "A reference to the Provider vDC from which this organization vDC is provisioned.",
+				Description: "A reference to the Provider VDC from which this organization VDC is provisioned.",
 			},
 			"uses_fast_provisioning": &schema.Schema{
 				Type:        schema.TypeBool,
@@ -203,7 +203,7 @@ func resourceVcdVdc() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "True if discovery of vCenter VMs is enabled for resource pools backing this vDC. If left unspecified, the actual behaviour depends on enablement at the organization level and at the system level.",
+				Description: "True if discovery of vCenter VMs is enabled for resource pools backing this VDC. If left unspecified, the actual behaviour depends on enablement at the organization level and at the system level.",
 			},
 
 			"delete_force": &schema.Schema{

--- a/vcd/resource_vcd_vdc.go
+++ b/vcd/resource_vcd_vdc.go
@@ -246,6 +246,12 @@ func resourceVcdVdcCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error creating vdc: %#v", err)
 	}
 
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		log.Printf("[DEBUG] Error waiting for vdc to finish: %#v", err)
+		return fmt.Errorf("error waiting for vdc to finish: %#v", err)
+	}
+
 	d.SetId(d.Get("name").(string))
 	log.Printf("[TRACE] vdc created: %#v", task)
 	return resourceVcdVdcRead(d, meta)
@@ -296,7 +302,7 @@ func resourceVcdVdcDelete(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	_, err = vdc.Delete(d.Get("delete_force").(bool), d.Get("delete_recursive").(bool))
+	err = vdc.DeleteWait(d.Get("delete_force").(bool), d.Get("delete_recursive").(bool))
 	if err != nil {
 		log.Printf("[DEBUG] Error removing vdc %#v", err)
 		return fmt.Errorf("error removing vdc %#v", err)

--- a/vcd/resource_vcd_vdc.go
+++ b/vcd/resource_vcd_vdc.go
@@ -6,8 +6,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/vmware/go-vcloud-director/govcd"
-	types "github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	types "github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 func resourceVcdVdc() *schema.Resource {

--- a/vcd/resource_vcd_vdc.go
+++ b/vcd/resource_vcd_vdc.go
@@ -1,6 +1,7 @@
 package vcd
 
 import (
+	"errors"
 	"fmt"
 	"log"
 
@@ -339,23 +340,23 @@ func capacityWithUsage(d map[string]interface{}) *types.CapacityWithUsage {
 func getVcdVdcInput(d *schema.ResourceData, vcdClient *VCDClient) (*types.VdcConfiguration, error) {
 	computeCapacityList := d.Get("compute_capacity").(*schema.Set).List()
 	if len(computeCapacityList) == 0 {
-		return &types.VdcConfiguration{}, errors.new("No compute_capacity field")
+		return &types.VdcConfiguration{}, errors.New("No compute_capacity field")
 	}
 	computeCapacity := computeCapacityList[0].(map[string]interface{})
 
 	storageProfileList := d.Get("storage_profile").(*schema.Set).List()
 	if len(storageProfileList) == 0 {
-		return &types.VdcConfiguration{}, errors.new("No storage_profile field")
+		return &types.VdcConfiguration{}, errors.New("No storage_profile field")
 	}
 	storageProfileMap := storageProfileList[0].(map[string]interface{})
 
 	cpuCapacityList := computeCapacity["cpu"].(*schema.Set).List()
 	if len(cpuCapacityList) == 0 {
-		return &types.VdcConfiguration{}, errors.new("No cpu field in compute_capacity")
+		return &types.VdcConfiguration{}, errors.New("No cpu field in compute_capacity")
 	}
 	memoryCapacityList := computeCapacity["memory"].(*schema.Set).List()
 	if len(memoryCapacityList) == 0 {
-		return &types.VdcConfiguration{}, errors.new("No memory field in compute_capacity")
+		return &types.VdcConfiguration{}, errors.New("No memory field in compute_capacity")
 	}
 
 	params := &types.VdcConfiguration{

--- a/vcd/resource_vcd_vdc.go
+++ b/vcd/resource_vcd_vdc.go
@@ -17,33 +17,34 @@ func resourceVcdVdc() *schema.Resource {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"units": {
-					Type:     schema.TypeString,
-					Required: true,
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "Units in which capacity is allocated. For CPU capacity, one of: {MHz, GHz}.  For memory capacity, one of: {MB, GB}.",
 				},
 				"allocated": {
-					Type:     schema.TypeInt,
-					Required: false,
-					Optional: true,
+					Type:        schema.TypeInt,
+					Optional:    true,
+					Description: "Capacity that is committed to be available.",
 				},
 				"limit": {
-					Type:     schema.TypeInt,
-					Required: false,
-					Optional: true,
+					Type:        schema.TypeInt,
+					Optional:    true,
+					Description: "Capacity limit relative to the value specified for Allocation. It must not be less than that value. If it is greater than that value, it implies overprovisioning.",
 				},
 				"reserved": {
-					Type:     schema.TypeInt,
-					Required: false,
-					Optional: true,
+					Type:        schema.TypeInt,
+					Optional:    true,
+					Description: "Capacity reserved",
 				},
 				"used": {
-					Type:     schema.TypeInt,
-					Required: false,
-					Optional: true,
+					Type:        schema.TypeInt,
+					Optional:    true,
+					Description: "Capacity used. If the VDC AllocationModel is ReservationPool, this number represents the percentage of the reservation that is in use. For all other allocation models, it represents the percentage of the allocation that is in use.",
 				},
 				"overhead": {
-					Type:     schema.TypeInt,
-					Required: false,
-					Optional: true,
+					Type:        schema.TypeInt,
+					Optional:    true,
+					Description: "Number of Units allocated to system resources such as vShield Manager virtual machines and shadow virtual machines provisioned from this Provider VDC.",
 				},
 			},
 		},
@@ -57,39 +58,27 @@ func resourceVcdVdc() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"org": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Organization to create the VDC in",
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: false,
 			},
-
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: false,
 				Optional: true,
 				ForceNew: false,
 			},
 			"allocation_model": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: false,
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					v := val.(string)
-					switch v {
-					case
-						"AllocationVApp",
-						"AllocationPool",
-						"ReservationPool":
-						return
-					default:
-						errs = append(errs, fmt.Errorf("%q must be one of {AllocationVApp, AllocationPool, ReservationPool}, got: %s", key, v))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     false,
+				ValidateFunc: validateAllocationModel,
+				Description:  "The allocation model used by this VDC; must be one of {AllocationVApp, AllocationPool, ReservationPool}",
 			},
 			"compute_capacity": &schema.Schema{
 				Required: true,
@@ -101,30 +90,31 @@ func resourceVcdVdc() *schema.Resource {
 						"memory": &capacityWithUsage,
 					},
 				},
+				Description: "The compute capacity allocated to this VDC.",
 			},
 			"nic_quota": &schema.Schema{
-				Type:     schema.TypeInt,
-				Required: false,
-				Optional: true,
-				ForceNew: false,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				ForceNew:    false,
+				Description: "Maximum number of virtual NICs allowed in this VDC. Defaults to 0, which specifies an unlimited number.",
 			},
 			"network_quota": &schema.Schema{
-				Type:     schema.TypeInt,
-				Required: false,
-				Optional: true,
-				ForceNew: false,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				ForceNew:    false,
+				Description: "Maximum number of network objects that can be deployed in this vDC. Defaults to 0, which means no networks can be deployed.",
 			},
 			"vm_quota": &schema.Schema{
-				Type:     schema.TypeInt,
-				Required: false,
-				Optional: true,
-				ForceNew: false,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				ForceNew:    false,
+				Description: "The maximum number of VMs that can be created in this vDC. Includes deployed and undeployed VMs in vApps and vApp templates. Defaults to 0, which specifies an unlimited number.",
 			},
 			"is_enabled": &schema.Schema{
-				Type:     schema.TypeBool,
-				Required: false,
-				Optional: true,
-				ForceNew: false,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    false,
+				Description: "True if this vDC is enabled for use by the organization vDCs. A vDC is always enabled on creation.",
 			},
 			"storage_profile": &schema.Schema{
 				Type:     schema.TypeSet,
@@ -133,81 +123,87 @@ func resourceVcdVdc() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
-							Type:     schema.TypeBool,
-							Required: false,
-							Optional: true,
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "True if this storage profile is enabled for use in the vDC.",
 						},
 						"units": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Units used to define Limit.",
 						},
 						"limit": {
-							Type:     schema.TypeInt,
-							Required: true,
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: "Maximum number of Units allocated for this storage profile. A value of 0 specifies unlimited Units.",
 						},
 						"default": {
-							Type:     schema.TypeBool,
-							Required: true,
+							Type:        schema.TypeBool,
+							Required:    true,
+							Description: "True if this is default storage profile for this vDC. The default storage profile is used when an object that can specify a storage profile is created with no storage profile specified.",
 						},
 						"provider": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Reference to a Provider vDC storage profile.",
 						},
 					},
 				},
+				Description: "Storage profiles supported by this vDC.",
 			},
 			"resource_guaranteed_memory": &schema.Schema{
-				Type:     schema.TypeFloat,
-				Required: false,
-				Optional: true,
-				ForceNew: false,
+				Type:        schema.TypeFloat,
+				Optional:    true,
+				ForceNew:    false,
+				Description: "Percentage of allocated memory resources guaranteed to vApps deployed in this vDC. For example, if this value is 0.75, then 75% of allocated resources are guaranteed. Required when AllocationModel is AllocationVApp or AllocationPool. Value defaults to 1.0 if the element is empty.",
 			},
 			"resource_guaranteed_cpu": &schema.Schema{
-				Type:     schema.TypeFloat,
-				Required: false,
-				Optional: true,
-				ForceNew: false,
+				Type:        schema.TypeFloat,
+				Optional:    true,
+				ForceNew:    false,
+				Description: "Percentage of allocated CPU resources guaranteed to vApps deployed in this vDC. For example, if this value is 0.75, then 75% of allocated resources are guaranteed. Required when AllocationModel is AllocationVApp or AllocationPool. Value defaults to 1.0 if the element is empty.",
 			},
 			"v_cpu_in_mhz": &schema.Schema{
-				Type:     schema.TypeInt,
-				Required: false,
-				Optional: true,
-				ForceNew: false,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				ForceNew:    false,
+				Description: "Specifies the clock frequency, in Megahertz, for any virtual CPU that is allocated to a VM. A VM with 2 vCPUs will consume twice as much of this value. Ignored for ReservationPool. Required when AllocationModel is AllocationVApp or AllocationPool, and may not be less than 256 MHz. Defaults to 1000 MHz if the element is empty or missing.",
 			},
 			"is_thin_provision": &schema.Schema{
-				Type:     schema.TypeBool,
-				Required: false,
-				Optional: true,
-				ForceNew: false,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    false,
+				Description: "Boolean to request thin provisioning. Request will be honored only if the underlying datastore supports it. Thin provisioning saves storage space by committing it on demand. This allows over-allocation of storage.",
 			},
 			"network_pool": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: false,
-				Optional: true,
-				ForceNew: false,
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    false,
+				Description: "Reference to a network pool in the Provider vDC. Required if this vDC will contain routed or isolated networks.",
 			},
 			"provider_vdc": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: false,
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    false,
+				Description: "A reference to the Provider vDC from which this organization vDC is provisioned.",
 			},
 			"uses_fast_provisioning": &schema.Schema{
-				Type:     schema.TypeBool,
-				Required: false,
-				Optional: true,
-				ForceNew: false,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    false,
+				Description: "Boolean to request fast provisioning. Request will be honored only if the underlying datastore supports it. Fast provisioning can reduce the time it takes to create virtual machines by using vSphere linked clones. If you disable fast provisioning, all provisioning operations will result in full clones.",
 			},
 			"over_commit_allowed": &schema.Schema{
-				Type:     schema.TypeBool,
-				Required: false,
-				Optional: true,
-				ForceNew: false,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    false,
+				Description: "Set to false to disallow creation of the VDC if the AllocationModel is AllocationPool or ReservationPool and the ComputeCapacity you specified is greater than what the backing Provider VDC can supply. Defaults to true if empty or missing.",
 			},
 			"vm_discovery_enabled": &schema.Schema{
-				Type:     schema.TypeBool,
-				Required: false,
-				Optional: true,
-				ForceNew: false,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    false,
+				Description: "True if discovery of vCenter VMs is enabled for resource pools backing this vDC. If left unspecified, the actual behaviour depends on enablement at the organization level and at the system level.",
 			},
 
 			"delete_force": &schema.Schema{
@@ -226,6 +222,7 @@ func resourceVcdVdc() *schema.Resource {
 	}
 }
 
+// Creates a new vdc from a resource definition
 func resourceVcdVdcCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[TRACE] vdc creation initiated")
 
@@ -253,6 +250,7 @@ func resourceVcdVdcCreate(d *schema.ResourceData, meta interface{}) error {
 	return resourceVcdVdcRead(d, meta)
 }
 
+// Fetches information about an existing vdc for a data definition
 func resourceVcdVdcRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[TRACE] vdc read initiated")
 
@@ -279,6 +277,7 @@ func resourceVcdVdcUpdate(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
+// Deletes a vdc, optionally removing all objects in it as well
 func resourceVcdVdcDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[TRACE] vdc delete started")
 
@@ -306,37 +305,58 @@ func resourceVcdVdcDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
+// helper for tranforming the compute capacity section of the resource input into the VdcConfiguration structure
 func capacityWithUsage(d map[string]interface{}) *types.CapacityWithUsage {
-	v := &types.CapacityWithUsage{
+	capacity := &types.CapacityWithUsage{
 		Units: d["units"].(string),
 	}
 
 	if allocated, ok := d["allocated"]; ok {
-		v.Allocated = int64(allocated.(int))
+		capacity.Allocated = int64(allocated.(int))
 	}
 
 	if limit, ok := d["limit"]; ok {
-		v.Limit = int64(limit.(int))
+		capacity.Limit = int64(limit.(int))
 	}
 
 	if reserved, ok := d["reserved"]; ok {
-		v.Reserved = int64(reserved.(int))
+		capacity.Reserved = int64(reserved.(int))
 	}
 
 	if used, ok := d["used"]; ok {
-		v.Used = int64(used.(int))
+		capacity.Used = int64(used.(int))
 	}
 
 	if overhead, ok := d["overhead"]; ok {
-		v.Overhead = int64(overhead.(int))
+		capacity.Overhead = int64(overhead.(int))
 	}
 
-	return v
+	return capacity
 }
 
+// helper for tranforming the resource input into the VdcConfiguration structure
+// any cast operations or default values should be done here so that the create method is simple
 func getVcdVdcInput(d *schema.ResourceData, vcdClient *VCDClient) (*types.VdcConfiguration, error) {
-	computeCapacity := d.Get("compute_capacity").(*schema.Set).List()[0].(map[string]interface{})
-	storageProfileMap := d.Get("storage_profile").(*schema.Set).List()[0].(map[string]interface{})
+	computeCapacityList := d.Get("compute_capacity").(*schema.Set).List()
+	if len(computeCapacityList) == 0 {
+		return &types.VdcConfiguration{}, errors.new("No compute_capacity field")
+	}
+	computeCapacity := computeCapacityList[0].(map[string]interface{})
+
+	storageProfileList := d.Get("storage_profile").(*schema.Set).List()
+	if len(storageProfileList) == 0 {
+		return &types.VdcConfiguration{}, errors.new("No storage_profile field")
+	}
+	storageProfileMap := storageProfileList[0].(map[string]interface{})
+
+	cpuCapacityList := computeCapacity["cpu"].(*schema.Set).List()
+	if len(cpuCapacityList) == 0 {
+		return &types.VdcConfiguration{}, errors.new("No cpu field in compute_capacity")
+	}
+	memoryCapacityList := computeCapacity["memory"].(*schema.Set).List()
+	if len(memoryCapacityList) == 0 {
+		return &types.VdcConfiguration{}, errors.new("No memory field in compute_capacity")
+	}
 
 	params := &types.VdcConfiguration{
 		Name:            d.Get("name").(string),
@@ -344,8 +364,8 @@ func getVcdVdcInput(d *schema.ResourceData, vcdClient *VCDClient) (*types.VdcCon
 		AllocationModel: d.Get("allocation_model").(string),
 		ComputeCapacity: []*types.ComputeCapacity{
 			&types.ComputeCapacity{
-				CPU:    capacityWithUsage(computeCapacity["cpu"].(*schema.Set).List()[0].(map[string]interface{})),
-				Memory: capacityWithUsage(computeCapacity["memory"].(*schema.Set).List()[0].(map[string]interface{})),
+				CPU:    capacityWithUsage(cpuCapacityList[0].(map[string]interface{})),
+				Memory: capacityWithUsage(memoryCapacityList[0].(map[string]interface{})),
 			},
 		},
 		VdcStorageProfile: &types.VdcStorageProfile{
@@ -420,4 +440,19 @@ func getVcdVdcInput(d *schema.ResourceData, vcdClient *VCDClient) (*types.VdcCon
 	}
 
 	return params, nil
+}
+
+// validates the input allocation model is a legitimate option
+func validateAllocationModel(val interface{}, key string) (warns []string, errs []error) {
+	v := val.(string)
+	switch v {
+	case
+		"AllocationVApp",
+		"AllocationPool",
+		"ReservationPool":
+		return
+	default:
+		errs = append(errs, fmt.Errorf("%q must be one of {AllocationVApp, AllocationPool, ReservationPool}, got: %s", key, v))
+	}
+	return
 }

--- a/vcd/resource_vcd_vdc.go
+++ b/vcd/resource_vcd_vdc.go
@@ -14,13 +14,14 @@ func resourceVcdVdc() *schema.Resource {
 	capacityWithUsage := schema.Schema{
 		Type:     schema.TypeSet,
 		Required: true,
-		ForceNew: false,
+		ForceNew: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"units": {
-					Type:        schema.TypeString,
-					Required:    true,
-					Description: "Units in which capacity is allocated. For CPU capacity, one of: {MHz, GHz}.  For memory capacity, one of: {MB, GB}.",
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validateUnits,
+					Description:  "Units in which capacity is allocated. For CPU capacity, one of: {MHz, GHz}.  For memory capacity, one of: {MB, GB}.",
 				},
 				"allocated": {
 					Type:        schema.TypeInt,
@@ -60,30 +61,30 @@ func resourceVcdVdc() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"org": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				ForceNew:    true,
 				Description: "Organization to create the VDC in",
 			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: false,
+				ForceNew: true,
 			},
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: false,
+				ForceNew: true,
 			},
 			"allocation_model": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     false,
+				ForceNew:     true,
 				ValidateFunc: validateAllocationModel,
 				Description:  "The allocation model used by this VDC; must be one of {AllocationVApp, AllocationPool, ReservationPool}",
 			},
 			"compute_capacity": &schema.Schema{
 				Required: true,
-				ForceNew: false,
+				ForceNew: true,
 				Type:     schema.TypeSet,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -96,31 +97,31 @@ func resourceVcdVdc() *schema.Resource {
 			"nic_quota": &schema.Schema{
 				Type:        schema.TypeInt,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Description: "Maximum number of virtual NICs allowed in this VDC. Defaults to 0, which specifies an unlimited number.",
 			},
 			"network_quota": &schema.Schema{
 				Type:        schema.TypeInt,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Description: "Maximum number of network objects that can be deployed in this VDC. Defaults to 0, which means no networks can be deployed.",
 			},
 			"vm_quota": &schema.Schema{
 				Type:        schema.TypeInt,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Description: "The maximum number of VMs that can be created in this VDC. Includes deployed and undeployed VMs in vApps and vApp templates. Defaults to 0, which specifies an unlimited number.",
 			},
 			"is_enabled": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Description: "True if this VDC is enabled for use by the organization VDCs. A VDC is always enabled on creation.",
 			},
 			"storage_profile": &schema.Schema{
 				Type:     schema.TypeSet,
 				Required: true,
-				ForceNew: false,
+				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
@@ -155,68 +156,68 @@ func resourceVcdVdc() *schema.Resource {
 			"resource_guaranteed_memory": &schema.Schema{
 				Type:        schema.TypeFloat,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Description: "Percentage of allocated memory resources guaranteed to vApps deployed in this VDC. For example, if this value is 0.75, then 75% of allocated resources are guaranteed. Required when AllocationModel is AllocationVApp or AllocationPool. Value defaults to 1.0 if the element is empty.",
 			},
 			"resource_guaranteed_cpu": &schema.Schema{
 				Type:        schema.TypeFloat,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Description: "Percentage of allocated CPU resources guaranteed to vApps deployed in this VDC. For example, if this value is 0.75, then 75% of allocated resources are guaranteed. Required when AllocationModel is AllocationVApp or AllocationPool. Value defaults to 1.0 if the element is empty.",
 			},
 			"v_cpu_in_mhz": &schema.Schema{
 				Type:        schema.TypeInt,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Description: "Specifies the clock frequency, in Megahertz, for any virtual CPU that is allocated to a VM. A VM with 2 vCPUs will consume twice as much of this value. Ignored for ReservationPool. Required when AllocationModel is AllocationVApp or AllocationPool, and may not be less than 256 MHz. Defaults to 1000 MHz if the element is empty or missing.",
 			},
 			"is_thin_provision": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Description: "Boolean to request thin provisioning. Request will be honored only if the underlying datastore supports it. Thin provisioning saves storage space by committing it on demand. This allows over-allocation of storage.",
 			},
 			"network_pool": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Description: "Reference to a network pool in the Provider VDC. Required if this VDC will contain routed or isolated networks.",
 			},
 			"provider_vdc": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Description: "A reference to the Provider VDC from which this organization VDC is provisioned.",
 			},
 			"uses_fast_provisioning": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Description: "Boolean to request fast provisioning. Request will be honored only if the underlying datastore supports it. Fast provisioning can reduce the time it takes to create virtual machines by using vSphere linked clones. If you disable fast provisioning, all provisioning operations will result in full clones.",
 			},
 			"over_commit_allowed": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Description: "Set to false to disallow creation of the VDC if the AllocationModel is AllocationPool or ReservationPool and the ComputeCapacity you specified is greater than what the backing Provider VDC can supply. Defaults to true if empty or missing.",
 			},
 			"vm_discovery_enabled": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Description: "True if discovery of vCenter VMs is enabled for resource pools backing this VDC. If left unspecified, the actual behaviour depends on enablement at the organization level and at the system level.",
 			},
 
 			"delete_force": &schema.Schema{
 				Type:        schema.TypeBool,
 				Required:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Description: "When destroying use delete_force=True to remove a vdc and any objects it contains, regardless of their state.",
 			},
 			"delete_recursive": &schema.Schema{
 				Type:        schema.TypeBool,
 				Required:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Description: "When destroying use delete_recursive=True to remove the vdc and any objects it contains that are in a state that normally allows removal.",
 			},
 		},
@@ -447,6 +448,22 @@ func getVcdVdcInput(d *schema.ResourceData, vcdClient *VCDClient) (*types.VdcCon
 	}
 
 	return params, nil
+}
+
+// validates the input units is a legitimate option
+func validateUnits(val interface{}, key string) (warns []string, errs []error) {
+	v := val.(string)
+	switch v {
+	case
+		"MHz",
+		"GHz",
+		"MB",
+		"GB":
+		return
+	default:
+		errs = append(errs, fmt.Errorf("%q must be one of {MHz, GHz} for CPU or {MB, GB} for memory, got: %s", key, v))
+	}
+	return
 }
 
 // validates the input allocation model is a legitimate option

--- a/vcd/resource_vcd_vdc_test.go
+++ b/vcd/resource_vcd_vdc_test.go
@@ -18,7 +18,7 @@ func TestAccVcdVdcBasic(t *testing.T) {
 		"VdcName":                   TestAccVcdVdc,
 		"OrgName":                   testConfig.VCD.Org,
 		"AllocationModel":           "ReservationPool",
-		"ProviderVdc":               testConfig.VCD.ProviderVdc.ID,
+		"ProviderVdc":               testConfig.VCD.ProviderVdc.Name,
 		"NetworkPool":               testConfig.VCD.ProviderVdc.NetworkPool,
 		"ProviderVdcStorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
 	}
@@ -54,7 +54,7 @@ func TestAccVcdVdcBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"vcd_vdc."+TestAccVcdVdc, "network_pool", testConfig.VCD.ProviderVdc.NetworkPool),
 					resource.TestCheckResourceAttr(
-						"vcd_vdc."+TestAccVcdVdc, "provider_vdc", testConfig.VCD.ProviderVdc.ID),
+						"vcd_vdc."+TestAccVcdVdc, "provider_vdc", testConfig.VCD.ProviderVdc.Name),
 					resource.TestCheckResourceAttr(
 						"vcd_vdc."+TestAccVcdVdc, "is_enabled", "true"),
 					resource.TestCheckResourceAttr(

--- a/vcd/resource_vcd_vdc_test.go
+++ b/vcd/resource_vcd_vdc_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/vmware/go-vcloud-director/govcd"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
 )
 
 var TestAccVcdVdc = "TestAccVcdVdcBasic"

--- a/vcd/resource_vcd_vdc_test.go
+++ b/vcd/resource_vcd_vdc_test.go
@@ -1,0 +1,171 @@
+package vcd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/vmware/go-vcloud-director/govcd"
+)
+
+var TestAccVcdVdc = "TestAccVcdVdcBasic"
+
+func TestAccVcdVdcBasic(t *testing.T) {
+
+	var vdc govcd.Vdc
+	var params = StringMap{
+		"VdcName":                   TestAccVcdVdc,
+		"OrgName":                   testConfig.VCD.Org,
+		"AllocationModel":           "ReservationPool",
+		"ProviderVdc":               testConfig.VCD.ProviderVdc.ID,
+		"NetworkPool":               testConfig.VCD.ProviderVdc.NetworkPool,
+		"ProviderVdcStorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
+	}
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	if !usingSysAdmin() {
+		t.Skip("TestAccVcdVdcBasic requires system admin privileges")
+		return
+	}
+
+	configText := templateFill(testAccCheckVcdVdc_basic, params)
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVdcDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVcdVdcExists("vcd_vdc."+TestAccVcdVdc, &vdc),
+					resource.TestCheckResourceAttr(
+						"vcd_vdc."+TestAccVcdVdc, "name", TestAccVcdVdc),
+					resource.TestCheckResourceAttr(
+						"vcd_vdc."+TestAccVcdVdc, "org", testConfig.VCD.Org),
+					resource.TestCheckResourceAttr(
+						"vcd_vdc."+TestAccVcdVdc, "allocation_model", "ReservationPool"),
+					resource.TestCheckResourceAttr(
+						"vcd_vdc."+TestAccVcdVdc, "network_pool", testConfig.VCD.ProviderVdc.NetworkPool),
+					resource.TestCheckResourceAttr(
+						"vcd_vdc."+TestAccVcdVdc, "provider_vdc", testConfig.VCD.ProviderVdc.ID),
+					resource.TestCheckResourceAttr(
+						"vcd_vdc."+TestAccVcdVdc, "is_enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"vcd_vdc."+TestAccVcdVdc, "is_thin_provision", "true"),
+					resource.TestCheckResourceAttr(
+						"vcd_vdc."+TestAccVcdVdc, "uses_fast_provisioning", "true"),
+					resource.TestCheckResourceAttr(
+						"vcd_vdc."+TestAccVcdVdc, "delete_force", "true"),
+					resource.TestCheckResourceAttr(
+						"vcd_vdc."+TestAccVcdVdc, "delete_recursive", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVcdVdcExists(name string, vdc *govcd.Vdc) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no VDC ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		adminOrg, err := conn.GetAdminOrg(testConfig.VCD.Org)
+		if err != nil {
+			return fmt.Errorf(errorRetrievingOrg, testConfig.VCD.Org+" and error: "+err.Error())
+		}
+
+		newVdc, err := adminOrg.GetVdcByName(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("vdc %s does not exist (%#v)", rs.Primary.ID, newVdc)
+		}
+
+		vdc = &newVdc
+		return nil
+	}
+}
+
+func testAccCheckVdcDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*VCDClient)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vcd_vdc" && rs.Primary.Attributes["name"] != TestAccVcdVdc {
+			continue
+		}
+
+		adminOrg, err := conn.GetAdminOrg(testConfig.VCD.Org)
+		if err != nil {
+			return fmt.Errorf(errorRetrievingOrg, testConfig.VCD.Org+" and error: "+err.Error())
+		}
+
+		vdc, err := adminOrg.GetVdcByName(rs.Primary.ID)
+
+		if vdc != (govcd.Vdc{}) {
+			return fmt.Errorf("vdc %s still exists", rs.Primary.ID)
+		}
+		if err != nil {
+			return fmt.Errorf("vdc %s still exists or other error: %#v", rs.Primary.ID, err)
+		}
+
+	}
+
+	return nil
+}
+
+const testAccCheckVcdVdc_basic = `
+resource "vcd_vdc" "{{.VdcName}}" {
+  name = "{{.VdcName}}"
+  org  = "{{.OrgName}}"
+
+  allocation_model = "{{.AllocationModel}}"
+  network_pool     = "{{.NetworkPool}}"
+  provider_vdc     = "{{.ProviderVdc}}"
+
+  compute_capacity {
+    cpu {
+      units     = "MHz"
+      allocated = 2048
+      limit     = 2048
+      reserved  = 2048
+      used      = 0
+      overhead  = 0
+    }
+
+    memory {
+      units     = "MB"
+      allocated = 2048
+      limit     = 2048
+      reserved  = 2048
+      used      = 0
+      overhead  = 0
+    }
+  }
+
+  storage_profile {
+    enabled  = true
+    units    = "MB"
+    limit    = 10240
+    default  = true
+    provider = "{{.ProviderVdcStorageProfile}}"
+  }
+
+  is_enabled             = true
+  is_thin_provision      = true
+  uses_fast_provisioning = true
+  delete_force           = true
+  delete_recursive       = true
+}
+`

--- a/vcd/sample_vcd_test_config.json
+++ b/vcd/sample_vcd_test_config.json
@@ -31,9 +31,9 @@
       "//catalogItem": "existingOvaNameInCatalog"
     },
     "providerVdc": {
-      "id": "<uuid>",
-      "storageProfile": "<uuid>",
-      "networkPool": "<uuid>"
+      "name": "my-provider-vdc",
+      "storageProfile": "my-storage-profile",
+      "networkPool": "my-network-pool"
     }
   },
   "networking": {

--- a/vcd/sample_vcd_test_config.json
+++ b/vcd/sample_vcd_test_config.json
@@ -29,6 +29,11 @@
     "//catalog": {
       "//name": "existingCatalogName",
       "//catalogItem": "existingOvaNameInCatalog"
+    },
+    "providerVdc": {
+      "id": "<uuid>",
+      "storageProfile": "<uuid>",
+      "networkPool": "<uuid>"
     }
   },
   "networking": {

--- a/website/docs/r/vdc.html.markdown
+++ b/website/docs/r/vdc.html.markdown
@@ -72,7 +72,7 @@ resource "vcd_vdc" "my-vdc" {
 
 The following arguments are supported:
 
-* `org` - (Required) Organization to create the VDC in
+* `org` - (Optional; *v2.0+*) Organization to create the VDC in, optional if defined at provider level
 * `name` - (Required) VDC name
 * `description` - (Optional) VDC friendly description
 * `allocation_model` - (Required) The allocation model used by this VDC; must be one of {AllocationVApp, AllocationPool, ReservationPool}

--- a/website/docs/r/vdc.html.markdown
+++ b/website/docs/r/vdc.html.markdown
@@ -76,7 +76,7 @@ The following arguments are supported:
 * `name` - (Required) VDC name
 * `description` - (Optional) VDC friendly description
 * `allocation_model` - (Required) The allocation model used by this VDC; must be one of {AllocationVApp, AllocationPool, ReservationPool}
-* `compute_capacity` - (Required) The compute capacity allocated to this VDC.
+* `compute_capacity` - (Required) The compute capacity allocated to this VDC.  See [Compute Capacity](#computecapacity) below for details.
 * `nic_quota` - (Optional) Maximum number of virtual NICs allowed in this VDC. Defaults to 0, which specifies an unlimited number.
 * `network_quota` - (Optional) Maximum number of network objects that can be deployed in this VDC. Defaults to 0, which means no networks can be deployed.
 * `vm_quota` - (Optional) The maximum number of VMs that can be created in this VDC. Includes deployed and undeployed VMs in vApps and vApp templates. Defaults to 0, which specifies an unlimited number.

--- a/website/docs/r/vdc.html.markdown
+++ b/website/docs/r/vdc.html.markdown
@@ -1,0 +1,124 @@
+---
+layout: "vcd"
+page_title: "vCloudDirector: vcd_vdc"
+sidebar_current: "docs-vcd-resource-vdc"
+description: |-
+  Provides a vCloud Director Organization resource. This can be used to create and delete an VDC.
+---
+
+# vcd\_vdc
+
+Provides a vCloud Director VDC resource. This can be used to create and delete a VDC.
+Requires system administrator privileges.
+
+Supported in provider *v2.0+*
+
+## Example Usage
+
+```hcl
+provider "vcd" {
+  user     = "${var.admin_user}"
+  password = "${var.admin_password}"
+  vdc      = "System"
+  url      = "https://AcmeVcd/api"
+}
+
+resource "vcd_vdc" "my-vdc" {
+  name        = "my-vdc"
+  description = "The pride of my work"
+  org         = "my-org"
+
+  allocation_model = "ReservationPool"
+  network_pool     = "<uuid>"
+  provider_vdc     = "<uuid>"
+
+  compute_capacity {
+    cpu {
+      units     = "MHz"
+      allocated = 2048
+      limit     = 2048
+      reserved  = 2048
+      used      = 0
+      overhead  = 0
+    }
+
+    memory {
+      units     = "MB"
+      allocated = 2048
+      limit     = 2048
+      reserved  = 2048
+      used      = 0
+      overhead  = 0
+    }
+  }
+
+  storage_profile {
+    enabled  = true
+    units    = "MB"
+    limit    = 10240
+    default  = true
+    provider = "<uuid>"
+  }
+
+  is_enabled             = true
+  is_thin_provision      = true
+  uses_fast_provisioning = true
+  delete_force           = true
+  delete_recursive       = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Required) Organization to create the VDC in
+* `name` - (Required) VDC name
+* `description` - (Optional) VDC friendly description
+* `allocation_model` - (Required) The allocation model used by this VDC; must be one of {AllocationVApp, AllocationPool, ReservationPool}
+* `compute_capacity` - (Required) The compute capacity allocated to this VDC.
+* `nic_quota` - (Optional) Maximum number of virtual NICs allowed in this VDC. Defaults to 0, which specifies an unlimited number.
+* `network_quota` - (Optional) Maximum number of network objects that can be deployed in this VDC. Defaults to 0, which means no networks can be deployed.
+* `vm_quota` - (Optional) The maximum number of VMs that can be created in this VDC. Includes deployed and undeployed VMs in vApps and vApp templates. Defaults to 0, which specifies an unlimited number.
+* `is_enabled` - (Optional) True if this VDC is enabled for use by the organization VDCs. A VDC is always enabled on creation.
+* `storage_profile` - (Required) Storage profiles supported by this VDC.  See [Storage Profile](#storageprofile) below for details.
+* `resource_guaranteed_memory` - (Optional) Percentage of allocated memory resources guaranteed to vApps deployed in this VDC. For example, if this value is 0.75, then 75% of allocated resources are guaranteed. Required when AllocationModel is AllocationVApp or AllocationPool. Value defaults to 1.0 if the element is empty.
+* `resource_guaranteed_cpu` - (Optional) Percentage of allocated CPU resources guaranteed to vApps deployed in this VDC. For example, if this value is 0.75, then 75% of allocated resources are guaranteed. Required when AllocationModel is AllocationVApp or AllocationPool. Value defaults to 1.0 if the element is empty.
+* `v_cpu_in_mhz` - (Optional) Specifies the clock frequency, in Megahertz, for any virtual CPU that is allocated to a VM. A VM with 2 vCPUs will consume twice as much of this value. Ignored for ReservationPool. Required when AllocationModel is AllocationVApp or AllocationPool, and may not be less than 256 MHz. Defaults to 1000 MHz if the element is empty or missing.
+* `is_thin_provision` - (Optional) Boolean to request thin provisioning. Request will be honored only if the underlying datastore supports it. Thin provisioning saves storage space by committing it on demand. This allows over-allocation of storage.
+* `network_pool` - (Optional) Reference to a network pool in the Provider VDC. Required if this VDC will contain routed or isolated networks.
+* `provider_vdc` - (Required) A reference to the Provider VDC from which this organization VDC is provisioned.
+* `uses_fast_provisioning` - (Optional) Boolean to request fast provisioning. Request will be honored only if the underlying datastore supports it. Fast provisioning can reduce the time it takes to create virtual machines by using vSphere linked clones. If you disable fast provisioning, all provisioning operations will result in full clones.
+* `over_commit_allowed` - (Optional) Set to false to disallow creation of the VDC if the AllocationModel is AllocationPool or ReservationPool and the ComputeCapacity you specified is greater than what the backing Provider VDC can supply. Defaults to true if empty or missing.
+* `vm_discovery_enabled` - (Optional) True if discovery of vCenter VMs is enabled for resource pools backing this VDC. If left unspecified, the actual behaviour depends on enablement at the organization level and at the system level.
+* `delete_force` - (Required) When destroying use `delete_force=True` to remove a vdc and any objects it contains, regardless of their state.
+* `delete_recursive` - (Required) When destroying use `delete_recursive=True` to remove the vdc and any objects it contains that are in a state that normally allows removal.
+
+
+<a id="stoageprofile"></a>
+## Storage Profile
+
+* `enabled` - (Optional) True if this storage profile is enabled for use in the VDC.
+* `units` - (Required) Units used to define Limit.
+* `limit` - (Required) Maximum number of Units allocated for this storage profile. A value of 0 specifies unlimited Units.
+* `default` - (Required) True if this is default storage profile for this VDC. The default storage profile is used when an object that can specify a storage profile is created with no storage profile specified.
+* `provider` - (Required) Reference to a Provider VDC storage profile.
+
+<a id="computecapacity"></a>
+## Compute Capacity
+
+Capacity must be specified twice, once for `memory` and another for `cpu`.  Each has the same structure:
+
+* `units` - (Required) Units in which capacity is allocated. For CPU capacity, one of: {MHz, GHz}.  For memory capacity, one of: {MB, GB}.
+* `allocated` - (Optional) Capacity that is committed to be available.
+* `limit` - (Optional) Capacity limit relative to the value specified for Allocation. It must not be less than that value. If it is greater than that value, it implies overprovisioning.
+* `reserved` - (Optional) Capacity reserved
+* `used` - (Optional) Capacity used. If the VDC AllocationModel is ReservationPool, this number represents the percentage of the reservation that is in use. For all other allocation models, it represents the percentage of the allocation that is in use.
+* `overhead` - (Optional) Number of Units allocated to system resources such as vShield Manager virtual machines and shadow virtual machines provisioned from this Provider VDC.
+
+
+## Sources
+
+* [CreateVdcParamsType](https://code.vmware.com/apis/287/vcloud#/doc/doc/types/CreateVdcParamsType.html)
+* [VDC Creation](https://code.vmware.com/apis/287/vcloud#/doc/doc/operations/POST-CreateVdcParams.html)
+* [VDC Deletion](https://code.vmware.com/apis/287/vcloud#/doc/doc/operations/DELETE-Vdc-AdminView.html)

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -64,6 +64,9 @@
             <li<%= sidebar_current("docs-vcd-resource-vapp-vm") %>>
               <a href="/docs/providers/vcd/r/vapp_vm.html">vcd_vapp_vm</a>
             </li>
+            <li<%= sidebar_current("docs-vcd-resource-vdc") %>>
+              <a href="/docs/providers/vcd/r/vdc.html">vcd_vdc</a>
+            </li>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
This is very much a work in progress at the moment, but I have been able to successfully `terraform apply` and `terraform destroy` a `vcd_vdc` resource.  I am creating the PR at this stage so folks know it's being worked on.

The `Update` function is intentionally blank right now because I did not add it in https://github.com/vmware/go-vcloud-director/pull/117.  Either I will need to go back to that before this gets too far, or we'll hide this feature until it all gets added in subsequent PRs.  I'll aim for the former option but naturally it will take a bit longer.

I haven't started on the tests yet but they will be written :smile: .   I think this is the right branch to target, at least for now such that the diff is correct, but I figure it'll change based on the status of the Christmas present.