### PR TITLE
Change protocol to be non case sensitive

### DIFF
--- a/vcd/structure.go
+++ b/vcd/structure.go
@@ -41,6 +41,7 @@ func expandFirewallRules(d *schema.ResourceData, gateway *types.EdgeGateway) ([]
 		prefix := fmt.Sprintf("rule.%d", i)
 
 		var protocol *types.FirewallRuleProtocols
+		// Allow upper and lower case protocol names
 		switch strings.ToLower(d.Get(prefix + ".protocol").(string)) {
 		case "tcp":
 			protocol = &types.FirewallRuleProtocols{

--- a/vcd/structure.go
+++ b/vcd/structure.go
@@ -3,6 +3,7 @@ package vcd
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -40,7 +41,7 @@ func expandFirewallRules(d *schema.ResourceData, gateway *types.EdgeGateway) ([]
 		prefix := fmt.Sprintf("rule.%d", i)
 
 		var protocol *types.FirewallRuleProtocols
-		switch d.Get(prefix + ".protocol").(string) {
+		switch strings.ToLower(d.Get(prefix + ".protocol").(string)) {
 		case "tcp":
 			protocol = &types.FirewallRuleProtocols{
 				TCP: true,


### PR DESCRIPTION
Currently protocol in tf script has to be in lower cases and don't show error but use default "any". Change allow to write in upper/lower case - so is more convenient and expected behaviour.

Ref: #151 
