### PR TITLE
Improve generation of test snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,6 @@ $ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-vcd
 $ make build
 ```
 
-Using the provider
-----------------------
-## Fill in for each provider
 
 Developing the Provider
 ---------------------------
@@ -50,26 +47,12 @@ $ $GOPATH/bin/terraform-provider-vcd
 ...
 ```
 
-In order to test the provider, you can simply run `make test`.
+See TESTING.md for details on how to test.
 
-```sh
-$ make test
-```
+Using the provider
+----------------------
 
-In order to run the full suite of Acceptance tests, run `make testacc`.
-
-*Note:* Acceptance tests create real resources, and often cost money to run.
-
-```sh
-$ make testacc
-```
-
-The acceptance tests will run against your own vCloud Director setup, using the configuration in your file `./vcd/vcd_test_config.json`
-See the file `./vcd/sample_vcd_test_config.json` for an example of which variables need to be defined.
-
-
-Installing the built provider
-------------------------------
+### Installing the built provider
 
 For a more thorough test using the Terraform client, you may want to transfer the plugin in the Terraform directory. A `make` command can do this for you:
 
@@ -77,5 +60,14 @@ For a more thorough test using the Terraform client, you may want to transfer th
 $ make install
 ```
 
-This command will build the plugin and transfer it to `$HOME/.terraform/plugins`, with a name that includes the version (as taken from the `./VERSION` file).
+This command will build the plugin and transfer it to `$HOME/.terraform.d/plugins`, with a name that includes the version (as taken from the `./VERSION` file).
 
+### Using the new plugin
+
+Once you have installed the plugin as mentioned above, you can simply create a new `config.tf` as defined in [the manual](https://www.terraform.io/docs/providers/vcd/index.html) and run 
+
+```sh
+$ terraform init
+$ terraform plan
+$ terraform apply
+```

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,31 @@
+# Testing terraform-provider-vcd
+
+In order to test the provider, you can simply run `make test`.
+
+```sh
+$ make test
+```
+
+In order to run the full suite of Acceptance tests, run `make testacc`.
+
+*Note:* Acceptance tests create real resources, and often cost money to run.
+
+```sh
+$ make testacc
+```
+
+The acceptance tests will run against your own vCloud Director setup, using the configuration in your file `./vcd/vcd_test_config.json`
+See the file `./vcd/sample_vcd_test_config.json` for an example of which variables need to be defined.
+
+Each test in the suite will write a Terraform configuration file inside `./vcd/test-artifacts`, named after the
+tests. For example: `vcd.TestAccVcdNetworkDirect.tf`
+
+
+There are several environment variables that can affect the tests:
+
+* `TF_ACC=1` enables the acceptance tests
+* `GOVCD_DEBUG=1` enables debug output of the test suite
+* `VCD_SKIP_TEMPLATE_WRITING=1` skips the production of test templates into `./vcd/test-artifacts`
+* `ADD_PROVIDER=1` Adds the full provider definition to the snippets inside `./vcd/test-artifacts`. 
+   **WARNING**: the provider definition includes your vCloud Director credentials.
+* `VCD_CONFIG=FileName` sets the file name for the test configuration file.

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -79,7 +79,7 @@ type TestConfig struct {
 
 const (
 	// This library major version
-	currentProviderVersion   = "2.0"
+	currentProviderVersion = "2.0"
 	// Warning message used for all tests
 	acceptanceTestsSkipped = "Acceptance tests skipped unless env 'TF_ACC' set"
 	// This template will be added to test resource snippets on demand
@@ -239,7 +239,7 @@ func getConfigStruct() TestConfig {
 		// Finds the current directory, through the path of this running test
 		_, currentFilename, _, _ := runtime.Caller(0)
 		currentDirectory := filepath.Dir(currentFilename)
-		config = path.Join( currentDirectory, "vcd_test_config.json")
+		config = path.Join(currentDirectory, "vcd_test_config.json")
 	}
 	// Looks if the configuration file exists before attempting to read it
 	_, err := os.Stat(config)

--- a/vcd/sample_vcd_test_config.json
+++ b/vcd/sample_vcd_test_config.json
@@ -76,8 +76,8 @@
   "envVariables" : {
     "//" : "Environment variables that we want to set (or unset)",
     "GOVCD_DEBUG": "",
-    "VCD_SKIP_TEMPLATE_WRITING": ""
-    "VCD_ADD_PROVIDER": "",
+    "VCD_SKIP_TEMPLATE_WRITING": "",
+    "VCD_ADD_PROVIDER": ""
   }
 
 }

--- a/vcd/sample_vcd_test_config.json
+++ b/vcd/sample_vcd_test_config.json
@@ -72,5 +72,12 @@
     "//": "Size in megabytes",
     "uploadPieceSize": 5,
     "uploadProgress": true
+  },
+  "envVariables" : {
+    "//" : "Environment variables that we want to set (or unset)",
+    "GOVCD_DEBUG": "",
+    "VCD_SKIP_TEMPLATE_WRITING": ""
+    "VCD_ADD_PROVIDER": "",
   }
+
 }

--- a/vcd/sample_vcd_test_config.json
+++ b/vcd/sample_vcd_test_config.json
@@ -74,7 +74,7 @@
     "uploadProgress": true
   },
   "envVariables" : {
-    "//" : "Environment variables that we want to set (or unset)",
+    "//" : "Environment variables that we want the test to set (or unset)",
     "GOVCD_DEBUG": "",
     "VCD_SKIP_TEMPLATE_WRITING": "",
     "VCD_ADD_PROVIDER": ""


### PR DESCRIPTION
When we run the test suite, we generate Terraform scripts that
can later be used for manual tests. The changes in this commit
add elements to the provider portion of the script that make the
manual test setup faster.

To use the improvement, run the tests with the environment variable `VCD_ADD_PROVIDER=1`, and then look into `./vcd/test-artifacts`

Signed-off-by: Giuseppe Maxia <gmaxia@vmware.com>