### PR TITLE
Improve generation of test snippets

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,7 +20,7 @@ test: fmtcheck
 	cd vcd ; VCD_SHORT_TEST=1 go test -v . -timeout 3m
 
 testacc: fmtcheck
-	if [ ! -f vcd/vcd_test_config.json ] ; then \
+	if [ ! -f vcd/vcd_test_config.jsoni -a -z "${VCD_CONFIG}" ] ; then \
 		echo "ERROR: test configuration file vcd/vcd_test_config.json is missing"; \
 		exit 1; \
 	fi

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,7 +20,7 @@ test: fmtcheck
 	cd vcd ; VCD_SHORT_TEST=1 go test -v . -timeout 3m
 
 testacc: fmtcheck
-	if [ ! -f vcd/vcd_test_config.jsoni -a -z "${VCD_CONFIG}" ] ; then \
+	if [ ! -f vcd/vcd_test_config.json -a -z "${VCD_CONFIG}" ] ; then \
 		echo "ERROR: test configuration file vcd/vcd_test_config.json is missing"; \
 		exit 1; \
 	fi

--- a/README.md
+++ b/README.md
@@ -32,9 +32,6 @@ $ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-vcd
 $ make build
 ```
 
-Using the provider
-----------------------
-## Fill in for each provider
 
 Developing the Provider
 ---------------------------
@@ -50,26 +47,12 @@ $ $GOPATH/bin/terraform-provider-vcd
 ...
 ```
 
-In order to test the provider, you can simply run `make test`.
+See TESTING.md for details on how to test.
 
-```sh
-$ make test
-```
+Using the provider
+----------------------
 
-In order to run the full suite of Acceptance tests, run `make testacc`.
-
-*Note:* Acceptance tests create real resources, and often cost money to run.
-
-```sh
-$ make testacc
-```
-
-The acceptance tests will run against your own vCloud Director setup, using the configuration in your file `./vcd/vcd_test_config.json`
-See the file `./vcd/sample_vcd_test_config.json` for an example of which variables need to be defined.
-
-
-Installing the built provider
-------------------------------
+### Installing the built provider
 
 For a more thorough test using the Terraform client, you may want to transfer the plugin in the Terraform directory. A `make` command can do this for you:
 
@@ -77,5 +60,14 @@ For a more thorough test using the Terraform client, you may want to transfer th
 $ make install
 ```
 
-This command will build the plugin and transfer it to `$HOME/.terraform/plugins`, with a name that includes the version (as taken from the `./VERSION` file).
+This command will build the plugin and transfer it to `$HOME/.terraform.d/plugins`, with a name that includes the version (as taken from the `./VERSION` file).
 
+### Using the new plugin
+
+Once you have installed the plugin as mentioned above, you can simply create a new `config.tf` as defined in [the manual](https://www.terraform.io/docs/providers/vcd/index.html) and run 
+
+```sh
+$ terraform init
+$ terraform plan
+$ terraform apply
+```

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,40 @@
+# Testing terraform-provider-vcd
+
+In order to test the provider, you can simply run `make test`.
+
+```sh
+$ make test
+```
+
+In order to run the full suite of Acceptance tests, run `make testacc`.
+
+*Note:* Acceptance tests create real resources, and often cost money to run.
+
+```sh
+$ make testacc
+```
+
+The acceptance tests will run against your own vCloud Director setup, using the configuration in your file `./vcd/vcd_test_config.json`
+See the file `./vcd/sample_vcd_test_config.json` for an example of which variables need to be defined.
+
+Each test in the suite will write a Terraform configuration file inside `./vcd/test-artifacts`, named after the
+tests. For example: `vcd.TestAccVcdNetworkDirect.tf`
+
+The test suite will try to minimize the amount of resources to create. If no catalog and vApp 
+template (`catalogItem`) are defined in the configuration file, new ones will be created and removed at the end of
+the test. You can choose to preserve catalog and vApp template across runs (use the `preserve` field in the
+configuration file).
+
+There are several environment variables that can affect the tests:
+
+* `TF_ACC=1` enables the acceptance tests. It is also set when you run `make testacc`.
+* `GOVCD_DEBUG=1` enables debug output of the test suite
+* `VCD_SKIP_TEMPLATE_WRITING=1` skips the production of test templates into `./vcd/test-artifacts`
+* `ADD_PROVIDER=1` Adds the full provider definition to the snippets inside `./vcd/test-artifacts`. 
+   **WARNING**: the provider definition includes your vCloud Director credentials.
+* `VCD_CONFIG=FileName` sets the file name for the test configuration file.
+* `REMOVE_ORG_VDC_FROM_TEMPLATE` is a quick way of enabling an alternate testing mode:
+When `REMOVE_ORG_VDC_FROM_TEMPLATE` is set, the terraform
+templates will be changed on-the-fly, to comment out the definitions of org and vdc. This will force the test to
+borrow org and vcd from the provider.
+* `VCD_TEST_SUITE_CLEANUP=1` will clean up testing resources that were created in previous test runs. 

--- a/vcd/sample_vcd_test_config.json
+++ b/vcd/sample_vcd_test_config.json
@@ -80,5 +80,12 @@
     "//": "Size in megabytes",
     "uploadPieceSize": 5,
     "uploadProgress": true
+  },
+  "envVariables" : {
+    "//" : "Environment variables that we want the test to set (or unset)",
+    "GOVCD_DEBUG": "",
+    "VCD_SKIP_TEMPLATE_WRITING": "",
+    "VCD_ADD_PROVIDER": "",
+    "REMOVE_ORG_VDC_FROM_TEMPLATE": ""
   }
 }


### PR DESCRIPTION
When we run the test suite, we generate Terraform scripts that
can later be used for manual tests. The changes in this commit
add elements to the provider portion of the script that make the
manual test setup faster.

To use the improvement, run the tests with the environment variable `VCD_ADD_PROVIDER=1`, and then look into `./vcd/test-artifacts`

* Add usability options to provider snippets
* Add environment variable section to configuration file
* Fix resource creation with short test
* Remove testing instructions from README.md
* Add file TESTING.md
* Improve configuration file detection in GNUmakefile

Note: this is the same as PR #154 (with an additional bug fix), but set against `vwmare-stash-while-pr-is-open` instead of `master`.