### PR TITLE
Retrieve IP for vApps using static-ip-pool

### DIFF
--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -425,14 +425,10 @@ func resourceVcdVAppRead(d *schema.ResourceData, meta interface{}) error {
 
 		log.Printf("[DEBUG] IP has changes, old: %s - new: %s", oldIp, newIp)
 
-		if newIp != "allocated" {
-			log.Printf("[DEBUG] IP is assigned. Lets get it (%s)", d.Get("ip"))
-			ip, err = getVAppIPAddress(d, meta, vdc, org)
-			if err != nil {
-				return err
-			}
-		} else {
-			log.Printf("[DEBUG] IP is 'allocated'")
+		log.Printf("[DEBUG] IP is assigned. Lets get it (%s)", d.Get("ip"))
+		ip, err = getVAppIPAddress(d, meta, vdc, org)
+		if err != nil {
+			return fmt.Errorf("Error retrieve IP: %#v", err)
 		}
 
 		d.Set("ip", ip)


### PR DESCRIPTION
Fix for #50. Maybe someone has more details on the use case for the `if newIp != "allocated"` construct, as it's unclear to me. Getting the IP should at least be done when using `dhcp` or `allocated` when defining the `vcd_vapp`.