### PR TITLE
Check if vApp is RESOLVED before powering it on

### DIFF
--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -374,6 +374,13 @@ func resourceVcdVAppUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if d.Get("power_on").(bool) {
+			// Ensure the vApp is not in UNRESOLVED status before powering on. This happens for
+			// less than a second after it is created.
+			err := vapp.StatusWaitNot("UNRESOLVED", vcdClient.MaxRetryTimeout)
+			if err != nil {
+				return fmt.Errorf("could not get vApp status while powering on: %s", err)
+			}
+
 			task, err := vapp.PowerOn()
 			if err != nil {
 				return fmt.Errorf("error Powering Up: %#v", err)

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -376,7 +376,7 @@ func resourceVcdVAppUpdate(d *schema.ResourceData, meta interface{}) error {
 		if d.Get("power_on").(bool) {
 			// Ensure the vApp is not in UNRESOLVED status before powering on. This happens for
 			// less than a second after it is created.
-			err := vapp.StatusWaitNot("UNRESOLVED", vcdClient.MaxRetryTimeout)
+			err := vapp.BlockWhileStatus("UNRESOLVED", vcdClient.MaxRetryTimeout)
 			if err != nil {
 				return fmt.Errorf("could not get vApp status while powering on: %s", err)
 			}


### PR DESCRIPTION
This PR should solve #68 and also solves crashing acceptance test problem when run on a fast local environment.
It should come together with https://github.com/vmware/go-vcloud-director/pull/169 to satisfy all dependencies.

## The problem
The basis of it is that one cannot trigger power on when the vApp is in "UNRESOLVED" (0) state. It happens for a very short time after a new empty vApp is being created. I'm introducing a blocking method to wait for state change before a power on task.

I have also considered embedding this check into `vapp.PowerOn()` in `go-vcloud-director` to guard any poweron. Do let me know your thoughts. 
