### PR TITLE
Upgrade govcd to 2.1.1 and change vapp network parameter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.12
 
 require (
 	github.com/hashicorp/terraform v0.11.13
-	github.com/vmware/go-vcloud-director/v2 v2.1.0
+	github.com/vmware/go-vcloud-director/v2 v2.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/terraform-providers/terraform-provider-tls v1.2.0/go.mod h1:Mxe/v5u31
 github.com/ugorji/go v0.0.0-20170107133203-ded73eae5db7/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ulikunitz/xz v0.5.4 h1:zATC2OoZ8H1TZll3FpbX+ikwmadbO699PE06cIkm9oU=
 github.com/ulikunitz/xz v0.5.4/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
-github.com/vmware/go-vcloud-director/v2 v2.1.0 h1:rgjFdaZ4p91uVvRWbPV4/a/forYSpghrJ/bj/+76KbA=
-github.com/vmware/go-vcloud-director/v2 v2.1.0/go.mod h1:/Qy3dfRj5kIe/lvYrvkqChkdJZyRJGEmAUVsonAwmVw=
+github.com/vmware/go-vcloud-director/v2 v2.1.1 h1:N8uRiQ7C+QhsUZsUEMEa8zU4qKKHPZ1c7jkl4qDqeuk=
+github.com/vmware/go-vcloud-director/v2 v2.1.1/go.mod h1:/Qy3dfRj5kIe/lvYrvkqChkdJZyRJGEmAUVsonAwmVw=
 github.com/xanzy/ssh-agent v0.2.0/go.mod h1:0NyE30eGUDliuLEHJgYte/zncp2zdTStcOnWhgSqHD8=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=

--- a/vcd/resource_vcd_vapp_network.go
+++ b/vcd/resource_vcd_vapp_network.go
@@ -72,7 +72,6 @@ func resourceVcdVappNetwork() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
-				Default:  false,
 			},
 
 			"dhcp_pool": &schema.Schema{
@@ -153,14 +152,18 @@ func resourceVcdVappNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 	staticIpRanges := expandIPRange(d.Get("static_ip_pool").(*schema.Set).List())
 
 	vappNetworkSettings := &govcd.VappNetworkSettings{
-		Name:             d.Get("name").(string),
-		Gateway:          d.Get("gateway").(string),
-		NetMask:          d.Get("netmask").(string),
-		DNS1:             d.Get("dns1").(string),
-		DNS2:             d.Get("dns2").(string),
-		DNSSuffix:        d.Get("dns_suffix").(string),
-		StaticIPRanges:   staticIpRanges.IPRange,
-		GuestVLANAllowed: d.Get("guest_vlan_allowed").(bool),
+		Name:           d.Get("name").(string),
+		Gateway:        d.Get("gateway").(string),
+		NetMask:        d.Get("netmask").(string),
+		DNS1:           d.Get("dns1").(string),
+		DNS2:           d.Get("dns2").(string),
+		DNSSuffix:      d.Get("dns_suffix").(string),
+		StaticIPRanges: staticIpRanges.IPRange,
+	}
+
+	if _, ok := d.GetOk("guest_vlan_allowed"); ok {
+		convertedValue := d.Get("guest_vlan_allowed").(bool)
+		vappNetworkSettings.GuestVLANAllowed = &convertedValue
 	}
 
 	if dhcp, ok := d.GetOk("dhcp_pool"); ok && len(dhcp.(*schema.Set).List()) > 0 {
@@ -233,7 +236,7 @@ func resourceVappNetworkRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("dns2", c.IPScopes.IPScope.DNS2)
 			d.Set("dnsSuffix", c.IPScopes.IPScope.DNSSuffix)
 		}
-		d.Set("guestVlanAllowed", c.GuestVlanAllowed)
+		d.Set("guest_vlan_allowed", &c.GuestVlanAllowed)
 	}
 
 	return nil

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vapp.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vapp.go
@@ -42,7 +42,7 @@ type VappNetworkSettings struct {
 	DNS1             string
 	DNS2             string
 	DNSSuffix        string
-	GuestVLANAllowed bool
+	GuestVLANAllowed *bool
 	StaticIPRanges   []*types.IPRange
 	DhcpSettings     *DhcpSettings
 }

--- a/vendor/github.com/vmware/go-vcloud-director/v2/types/v56/types.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/types/v56/types.go
@@ -208,7 +208,7 @@ type NetworkConfiguration struct {
 	FenceMode                      string           `xml:"FenceMode"`
 	RetainNetInfoAcrossDeployments bool             `xml:"RetainNetInfoAcrossDeployments,omitempty"`
 	Features                       *NetworkFeatures `xml:"Features,omitempty"`
-	GuestVlanAllowed               bool             `xml:"GuestVlanAllowed,omitempty"`
+	GuestVlanAllowed               *bool            `xml:"GuestVlanAllowed,omitempty"`
 	// TODO: Not Implemented
 	// RouterInfo                     RouterInfo           `xml:"RouterInfo,omitempty"`
 	// SyslogServerSettings           SyslogServerSettings `xml:"SyslogServerSettings,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -157,7 +157,7 @@ github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
 github.com/ulikunitz/xz/internal/hash
-# github.com/vmware/go-vcloud-director/v2 v2.1.0
+# github.com/vmware/go-vcloud-director/v2 v2.1.1
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util

--- a/website/docs/r/vapp_network.html.markdown
+++ b/website/docs/r/vapp_network.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 * `dns1` - (Optional) First DNS server to use. Default is `8.8.8.8`.
 * `dns2` - (Optional) Second DNS server to use. Default is `8.8.4.4`.
 * `dns_suffix` - (Optional) A FQDN for the virtual machines on this network.
-* `guest_vlan_allowed` (Optional) True if Network allows guest VLAN tagging. Default is false. This value supported from vCD version 9.0
+* `guest_vlan_allowed` (Optional) True if Network allows guest VLAN tagging. This value supported from vCD version 9.0
 * `static_ip_pool` - (Optional) A range of IPs permitted to be used as static IPs for virtual machines; see [IP Pools](#ip-pools) below for details.
 * `dhcp_pool` - (Optional) A range of IPs to issue to virtual machines that don't have a static IP; see [IP Pools](#ip-pools) below for details.
 


### PR DESCRIPTION
Upgrade govcd to 2.1.1 and change vapp network parameter to be not sent if not provided. This allows to support vCD 8.2 version