### PR TITLE
Add hardware_assisted_virtualization for vcd_vapp_vm resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 
 * `vcd_vapp_vm` - Ability to add metadata to a VM. For previous behaviour please see `BACKWARDS INCOMPATIBILITIES` ([#158](https://github.com/terraform-providers/terraform-provider-vcd/issues/158))
+* `vcd_vapp_vm` - Ability to enable hardware assisted CPU virtualization for VM. It allows hypervisor nesting. [#219]
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 FEATURES:
 
-* `vcd_vapp_vm` - Ability to add metadata to a VM. For previous behaviour please see `BACKWARDS INCOMPATIBILITIES` ([#158](https://github.com/terraform-providers/terraform-provider-vcd/issues/158))
-* `vcd_vapp_vm` - Ability to enable hardware assisted CPU virtualization for VM. It allows hypervisor nesting. [#219]
+* `vcd_vapp_vm` - Ability to add metadata to a VM. For previous behaviour please see `BACKWARDS INCOMPATIBILITIES` [GH-158]
+* `vcd_vapp_vm` - Ability to enable hardware assisted CPU virtualization for VM. It allows hypervisor nesting. [GH-219]
 
 BUG FIXES:
 
-* `vcd_vapp` - Ability to add metadata to empty vApp. For previous behaviour please see `BACKWARDS INCOMPATIBILITIES` ([#158](https://github.com/terraform-providers/terraform-provider-vcd/issues/158))
+* `vcd_vapp` - Ability to add metadata to empty vApp. For previous behaviour please see `BACKWARDS INCOMPATIBILITIES` [GH-158]
 
 BACKWARDS INCOMPATIBILITIES / NOTES:
 
-* `vcd_vapp` - Metadata is no longer added to first VM in vApp it will be added to vApp directly instead. ([#158](https://github.com/terraform-providers/terraform-provider-vcd/issues/158))
+* `vcd_vapp` - Metadata is no longer added to first VM in vApp it will be added to vApp directly instead. [GH-158]
 
 ## 2.1.0 (March 27, 2019)
 

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.1
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190416112520-dcfd6747a9ce
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190417085158-6cbca97d9053

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,5 @@ go 1.12
 
 require (
 	github.com/hashicorp/terraform v0.11.13
-	github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.1
+	github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.2
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190419085123-885ddab6bd61

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/hashicorp/terraform v0.11.13
 	github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.1
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190411133523-6676eb189c4d

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.1
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190417085158-6cbca97d9053
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190419085123-885ddab6bd61

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.1
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190411133523-6676eb189c4d
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190416112520-dcfd6747a9ce

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/Azure/azure-sdk-for-go v10.3.0-beta+incompatible/go.mod h1:9XXNKU+eRn
 github.com/Azure/go-autorest v9.10.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-ntlmssp v0.0.0-20170803034930-c92175d54006/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170625215350-4fe035839290/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
-github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190419085123-885ddab6bd61 h1:xzir4UhL5dfMjNKVlwXszYgUSzqJPDhrW7IZWl2nE3A=
-github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190419085123-885ddab6bd61/go.mod h1:HonlGxbjJ1NAibWh99eE4/S2l6ZOZ5KJzKK1rh2a9vc=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292/go.mod h1:KYCjqMOeHpNuTOiFQU6WEcTG7poCJrUs0YgyHNtn1no=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
@@ -194,6 +192,8 @@ github.com/terraform-providers/terraform-provider-tls v1.2.0/go.mod h1:Mxe/v5u31
 github.com/ugorji/go v0.0.0-20170107133203-ded73eae5db7/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ulikunitz/xz v0.5.4 h1:zATC2OoZ8H1TZll3FpbX+ikwmadbO699PE06cIkm9oU=
 github.com/ulikunitz/xz v0.5.4/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
+github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.2 h1:yn7aAHwL44SoD7Duco764KjNrceX5r+onBQj2WKnl2o=
+github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.2/go.mod h1:HonlGxbjJ1NAibWh99eE4/S2l6ZOZ5KJzKK1rh2a9vc=
 github.com/xanzy/ssh-agent v0.2.0/go.mod h1:0NyE30eGUDliuLEHJgYte/zncp2zdTStcOnWhgSqHD8=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/Azure/azure-sdk-for-go v10.3.0-beta+incompatible/go.mod h1:9XXNKU+eRn
 github.com/Azure/go-autorest v9.10.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-ntlmssp v0.0.0-20170803034930-c92175d54006/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170625215350-4fe035839290/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
+github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190411133523-6676eb189c4d h1:cawZZmRoov/9hziuFieJWfrKMqAgvMXCQkJMWJT45P0=
+github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190411133523-6676eb189c4d/go.mod h1:HonlGxbjJ1NAibWh99eE4/S2l6ZOZ5KJzKK1rh2a9vc=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292/go.mod h1:KYCjqMOeHpNuTOiFQU6WEcTG7poCJrUs0YgyHNtn1no=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
@@ -91,6 +93,8 @@ github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCS
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.0.0 h1:21MVWPKDphxa7ineQQTrCU5brh7OuVVAzGOCnnCPtE8=
 github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
+github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+DbLISwf2B8WXEolNRA8BGCwI9jws=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
@@ -190,8 +194,6 @@ github.com/terraform-providers/terraform-provider-tls v1.2.0/go.mod h1:Mxe/v5u31
 github.com/ugorji/go v0.0.0-20170107133203-ded73eae5db7/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ulikunitz/xz v0.5.4 h1:zATC2OoZ8H1TZll3FpbX+ikwmadbO699PE06cIkm9oU=
 github.com/ulikunitz/xz v0.5.4/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
-github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.1 h1:wHgUXpPstAD2dbrMFooMjQ8EdTF46Gg2hCPByU+M2SA=
-github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.1/go.mod h1:/Qy3dfRj5kIe/lvYrvkqChkdJZyRJGEmAUVsonAwmVw=
 github.com/xanzy/ssh-agent v0.2.0/go.mod h1:0NyE30eGUDliuLEHJgYte/zncp2zdTStcOnWhgSqHD8=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/Azure/azure-sdk-for-go v10.3.0-beta+incompatible/go.mod h1:9XXNKU+eRn
 github.com/Azure/go-autorest v9.10.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-ntlmssp v0.0.0-20170803034930-c92175d54006/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170625215350-4fe035839290/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
-github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190417085158-6cbca97d9053 h1:xzzeqQY7gih0ZxS8h0ubOwmeosv+XsCtdbiHDlovLHc=
-github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190417085158-6cbca97d9053/go.mod h1:HonlGxbjJ1NAibWh99eE4/S2l6ZOZ5KJzKK1rh2a9vc=
+github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190419085123-885ddab6bd61 h1:xzir4UhL5dfMjNKVlwXszYgUSzqJPDhrW7IZWl2nE3A=
+github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190419085123-885ddab6bd61/go.mod h1:HonlGxbjJ1NAibWh99eE4/S2l6ZOZ5KJzKK1rh2a9vc=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292/go.mod h1:KYCjqMOeHpNuTOiFQU6WEcTG7poCJrUs0YgyHNtn1no=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/Azure/azure-sdk-for-go v10.3.0-beta+incompatible/go.mod h1:9XXNKU+eRn
 github.com/Azure/go-autorest v9.10.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-ntlmssp v0.0.0-20170803034930-c92175d54006/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170625215350-4fe035839290/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
-github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190416112520-dcfd6747a9ce h1:RqiJJF/3Qt9HnujCBEYIGxprxGPXivpChmTcY31UpWY=
-github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190416112520-dcfd6747a9ce/go.mod h1:HonlGxbjJ1NAibWh99eE4/S2l6ZOZ5KJzKK1rh2a9vc=
+github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190417085158-6cbca97d9053 h1:xzzeqQY7gih0ZxS8h0ubOwmeosv+XsCtdbiHDlovLHc=
+github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190417085158-6cbca97d9053/go.mod h1:HonlGxbjJ1NAibWh99eE4/S2l6ZOZ5KJzKK1rh2a9vc=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292/go.mod h1:KYCjqMOeHpNuTOiFQU6WEcTG7poCJrUs0YgyHNtn1no=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/Azure/azure-sdk-for-go v10.3.0-beta+incompatible/go.mod h1:9XXNKU+eRn
 github.com/Azure/go-autorest v9.10.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-ntlmssp v0.0.0-20170803034930-c92175d54006/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170625215350-4fe035839290/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
-github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190411133523-6676eb189c4d h1:cawZZmRoov/9hziuFieJWfrKMqAgvMXCQkJMWJT45P0=
-github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190411133523-6676eb189c4d/go.mod h1:HonlGxbjJ1NAibWh99eE4/S2l6ZOZ5KJzKK1rh2a9vc=
+github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190416112520-dcfd6747a9ce h1:RqiJJF/3Qt9HnujCBEYIGxprxGPXivpChmTcY31UpWY=
+github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190416112520-dcfd6747a9ce/go.mod h1:HonlGxbjJ1NAibWh99eE4/S2l6ZOZ5KJzKK1rh2a9vc=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292/go.mod h1:KYCjqMOeHpNuTOiFQU6WEcTG7poCJrUs0YgyHNtn1no=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -27,22 +27,6 @@ import (
 
 type StringMap map[string]interface{}
 
-// Copy returns a copy of StringMap so that it can be mutated without affecting original map.
-func (strMap StringMap) Copy() StringMap {
-	newCopy := make(StringMap)
-	for key, value := range strMap {
-		newCopy[key] = value
-	}
-	return newCopy
-}
-
-// CopyMutateKey return a copy of StringMap with mutated key.
-func (strMap StringMap) CopyMutateKey(key string, value interface{}) StringMap {
-	newCopy := strMap.Copy()
-	newCopy[key] = value
-	return newCopy
-}
-
 // Structure to get info from a config json file that the user specifies
 type TestConfig struct {
 	Provider struct {

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -27,6 +27,22 @@ import (
 
 type StringMap map[string]interface{}
 
+// Copy returns a copy of StringMap so that it can be mutated without affecting original map.
+func (strMap StringMap) Copy() StringMap {
+	newCopy := make(StringMap)
+	for key, value := range strMap {
+		newCopy[key] = value
+	}
+	return newCopy
+}
+
+// CopyMutateKey return a copy of StringMap with mutated key.
+func (strMap StringMap) CopyMutateKey(key string, value interface{}) StringMap {
+	newCopy := strMap.Copy()
+	newCopy[key] = value
+	return newCopy
+}
+
 // Structure to get info from a config json file that the user specifies
 type TestConfig struct {
 	Provider struct {

--- a/vcd/resource_vcd_inserted_media_test.go
+++ b/vcd/resource_vcd_inserted_media_test.go
@@ -52,8 +52,6 @@ func TestAccVcdMediaInsertBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMediaInserted("vcd_inserted_media."+TestAccVcdMediaInsert),
 					testAccCheckMediaEjected("vcd_inserted_media."+TestAccVcdMediaInsert),
-					resource.TestCheckResourceAttr(
-						"vcd_vapp_vm."+vmNameForInsert, "hardware_assisted_virtualization", "false"),
 				),
 			},
 		},

--- a/vcd/resource_vcd_inserted_media_test.go
+++ b/vcd/resource_vcd_inserted_media_test.go
@@ -52,6 +52,8 @@ func TestAccVcdMediaInsertBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMediaInserted("vcd_inserted_media."+TestAccVcdMediaInsert),
 					testAccCheckMediaEjected("vcd_inserted_media."+TestAccVcdMediaInsert),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_vm."+vmNameForInsert, "hardware_assisted_virtualization", "false"),
 				),
 			},
 		},

--- a/vcd/resource_vcd_network_test.go
+++ b/vcd/resource_vcd_network_test.go
@@ -272,18 +272,6 @@ func testAccCheckVcdNetworkExists(n string, network *govcd.OrgVDCNetwork) resour
 	}
 }
 
-func testAccCheckVcdNetworkIsolatedDestroy(s *terraform.State) error {
-	return testAccCheckVcdNetworkDestroy(s, "vcd_network_isolated")
-}
-
-func testAccCheckVcdNetworkDirectDestroy(s *terraform.State) error {
-	return testAccCheckVcdNetworkDestroy(s, "vcd_network_direct")
-}
-
-func testAccCheckVcdNetworkRoutedDestroy(s *terraform.State) error {
-	return testAccCheckVcdNetworkDestroy(s, "vcd_network_routed")
-}
-
 func testAccCheckVcdNetworkDestroy(s *terraform.State, networkType string) error {
 	conn := testAccProvider.Meta().(*VCDClient)
 

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -240,7 +240,7 @@ func resourceVcdVAppVmCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error changing network: %#v", err)
 	}
-
+	// TODO - add a comment about the VM being powered off before the operation.
 	if d.Get("hardware_assisted_virtualization").(bool) {
 		err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
 			task, err := vm.ToggleHWAssistedVirtualization(true)

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -244,7 +244,7 @@ func resourceVcdVAppVmCreate(d *schema.ResourceData, meta interface{}) error {
 	// powered on in the last stage of create/update cycle
 	if d.Get("expose_hardware_virtualization").(bool) {
 		err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-			task, err := vm.ToggleHWAssistedVirtualization(true)
+			task, err := vm.ToggleHardwareVirtualization(true)
 			if err != nil {
 				return resource.RetryableError(fmt.Errorf("error enabling hardware assisted virtualization: %#v", err))
 			}
@@ -526,7 +526,7 @@ func resourceVcdVAppVmUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		if d.HasChange("expose_hardware_virtualization") {
 			err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-				task, err := vm.ToggleHWAssistedVirtualization(d.Get("expose_hardware_virtualization").(bool))
+				task, err := vm.ToggleHardwareVirtualization(d.Get("expose_hardware_virtualization").(bool))
 				if err != nil {
 					return resource.RetryableError(fmt.Errorf("error changing hardware assisted virtualization: %#v", err))
 				}

--- a/vcd/resource_vcd_vapp_vm_checks_test.go
+++ b/vcd/resource_vcd_vapp_vm_checks_test.go
@@ -1,0 +1,69 @@
+package vcd
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+)
+
+func testAccCheckVcdVAppVmExists(vappName, vmName, node string, vapp *govcd.VApp, vm *govcd.VM) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[node]
+		if !ok {
+			return fmt.Errorf("not found: %s", node)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no VAPP ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*VCDClient)
+		_, vdc, err := conn.GetOrgAndVdc(testConfig.VCD.Org, testConfig.VCD.Vdc)
+		if err != nil {
+			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
+		}
+
+		vapp, err := vdc.FindVAppByName(vappName)
+		if err != nil {
+			return err
+		}
+
+		resp, err := vdc.FindVMByName(vapp, vmName)
+
+		if err != nil {
+			return err
+		}
+
+		*vm = resp
+
+		return nil
+	}
+}
+
+func testAccCheckVcdVAppVmDestroy(vappName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "vcd_vapp" {
+				continue
+			}
+			_, vdc, err := conn.GetOrgAndVdc(testConfig.VCD.Org, testConfig.VCD.Vdc)
+			if err != nil {
+				return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
+			}
+
+			_, err = vdc.FindVAppByName(vappName)
+
+			if err == nil {
+				return fmt.Errorf("VPCs still exist")
+			}
+
+			return nil
+		}
+
+		return nil
+	}
+}

--- a/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
+++ b/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
@@ -1,7 +1,6 @@
 package vcd
 
 import (
-	// "fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -66,19 +65,6 @@ func TestAccVcdVAppVm_HardwareVirtualization(t *testing.T) {
 }
 
 const testAccCheckVcdVAppVm_hardwareVirtualization = `
-resource "vcd_network_routed" "{{.NetworkName}}" {
-  name         = "{{.NetworkName}}"
-  org          = "{{.Org}}"
-  vdc          = "{{.Vdc}}"
-  edge_gateway = "{{.EdgeGateway}}"
-  gateway      = "10.10.104.1"
-
-  static_ip_pool {
-    start_address = "10.10.104.2"
-    end_address   = "10.10.104.254"
-  }
-}
-
 resource "vcd_vapp" "{{.VappName}}" {
   name = "{{.VappName}}"
   org  = "{{.Org}}"
@@ -89,16 +75,12 @@ resource "vcd_vapp_vm" "{{.VmName}}" {
   org           					= "{{.Org}}"
   vdc           					= "{{.Vdc}}"
   vapp_name     					= "${vcd_vapp.{{.VappName}}.name}"
-  network_name  					= "${vcd_network_routed.{{.NetworkName}}.name}"
   name          					= "{{.VmName}}"
   catalog_name  					= "{{.Catalog}}"
   template_name 					= "{{.CatalogItem}}"
   memory        					= 384
   cpus          					= 2
   cpu_cores     					= 1
-  ip            					= "10.10.104.161"
   expose_hardware_virtualization	= "{{.ExposeHardwareVirtualization}}"
-
-  depends_on    = ["vcd_vapp.{{.VappName}}", "vcd_network_routed.{{.NetworkName}}"]
 }
 `

--- a/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
+++ b/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
@@ -1,0 +1,166 @@
+package vcd
+
+import (
+	// "fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	// "github.com/hashicorp/terraform/terraform"
+	// "github.com/vmware/go-vcloud-director/v2/govcd"
+)
+
+var vappNameHardwareVirtualization string = "TestAccVcdVAppHwVirt"
+var vmNameHardwareVirtualization string = "TestAccVcdVAppHwVirt"
+
+func TestAccVcdVAppVm_HardwareVirtualization(t *testing.T) {
+	// var vapp govcd.VApp
+	// var vm govcd.VM
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	var params = StringMap{
+		"Org":         testConfig.VCD.Org,
+		"Vdc":         testConfig.VCD.Vdc,
+		"EdgeGateway": testConfig.Networking.EdgeGateway,
+		"NetworkName": "TestAccVcdVAppVmNetHwVirt",
+		"Catalog":     testSuiteCatalogName,
+		"CatalogItem": testSuiteCatalogOVAItem,
+		"VappName":    vappNameHardwareVirtualization,
+		"VmName":      vmNameHardwareVirtualization,
+	}
+
+	configTextStep0 := templateFill(testAccCheckVcdVAppVm_hardwareVirtualization, params)
+
+	params["ExposeHardwareVirtualization"] = true
+	params["FuncName"] = "step1"
+	configTextStep1 := templateFill(testAccCheckVcdVAppVm_hardwareVirtualization, params)
+
+	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configTextStep0)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVcdVAppVmDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configTextStep0,
+				Check: resource.ComposeTestCheckFunc(
+					// Need to pre a more generic check than this
+					// testAccCheckVcdVAppVmExists("vcd_vapp_vm."+vmNameHardwareVirtualization, &vapp, &vm),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_vm."+vmNameHardwareVirtualization, "name", vmNameHardwareVirtualization),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_vm."+vmNameHardwareVirtualization, "expose_hardware_virtualization", "false"),
+				),
+			},
+			resource.TestStep{
+				Config: configTextStep1,
+				Check: resource.ComposeTestCheckFunc(
+					// Need to pre a more generic check than this
+					// testAccCheckVcdVAppVmExists("vcd_vapp_vm."+vmNameHardwareVirtualization, &vapp, &vm),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_vm."+vmNameHardwareVirtualization, "name", vmNameHardwareVirtualization),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_vm."+vmNameHardwareVirtualization, "expose_hardware_virtualization", "true"),
+				),
+			},
+		},
+	})
+}
+
+// func testAccCheckVcdVAppVmExists(n string, vapp *govcd.VApp, vm *govcd.VM) resource.TestCheckFunc {
+// 	return func(s *terraform.State) error {
+// 		rs, ok := s.RootModule().Resources[n]
+// 		if !ok {
+// 			return fmt.Errorf("not found: %s", n)
+// 		}
+
+// 		if rs.Primary.ID == "" {
+// 			return fmt.Errorf("no VAPP ID is set")
+// 		}
+
+// 		conn := testAccProvider.Meta().(*VCDClient)
+// 		_, vdc, err := conn.GetOrgAndVdc(testConfig.VCD.Org, testConfig.VCD.Vdc)
+// 		if err != nil {
+// 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
+// 		}
+
+// 		vapp, err := vdc.FindVAppByName(vappName2)
+// 		if err != nil {
+// 			return err
+// 		}
+
+// 		resp, err := vdc.FindVMByName(vapp, vmName)
+
+// 		if err != nil {
+// 			return err
+// 		}
+
+// 		*vm = resp
+
+// 		return nil
+// 	}
+// }
+
+// func testAccCheckVcdVAppVmDestroy(s *terraform.State) error {
+// 	conn := testAccProvider.Meta().(*VCDClient)
+
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "vcd_vapp" {
+// 			continue
+// 		}
+// 		_, vdc, err := conn.GetOrgAndVdc(testConfig.VCD.Org, testConfig.VCD.Vdc)
+// 		if err != nil {
+// 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
+// 		}
+
+// 		_, err = vdc.FindVAppByName(vappName2)
+
+// 		if err == nil {
+// 			return fmt.Errorf("VPCs still exist")
+// 		}
+
+// 		return nil
+// 	}
+
+// 	return nil
+// }
+
+const testAccCheckVcdVAppVm_hardwareVirtualization = `
+resource "vcd_network_routed" "{{.NetworkName}}" {
+  name         = "{{.NetworkName}}"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  gateway      = "10.10.103.1"
+
+  static_ip_pool {
+    start_address = "10.10.103.2"
+    end_address   = "10.10.103.254"
+  }
+}
+
+resource "vcd_vapp" "{{.VappName}}" {
+  name = "{{.VappName}}"
+  org  = "{{.Org}}"
+  vdc  = "{{.Vdc}}"
+}
+
+resource "vcd_vapp_vm" "{{.VmName}}" {
+  org           					= "{{.Org}}"
+  vdc           					= "{{.Vdc}}"
+  vapp_name     					= "${vcd_vapp.{{.VappName}}.name}"
+  network_name  					= "${vcd_network_routed.{{.NetworkName}}.name}"
+  name          					= "{{.VmName}}"
+  catalog_name  					= "{{.Catalog}}"
+  template_name 					= "{{.CatalogItem}}"
+  memory        					= 384
+  cpus          					= 2
+  cpu_cores     					= 1
+  ip            					= "10.10.103.161"
+  expose_hardware_virtualization	= "{{.ExposeHardwareVirtualization}}"
+
+  depends_on    = ["vcd_vapp.{{.VappName}}", "vcd_network_routed.{{.NetworkName}}"]
+}
+`

--- a/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
+++ b/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
@@ -72,15 +72,15 @@ resource "vcd_vapp" "{{.VappName}}" {
 }
 
 resource "vcd_vapp_vm" "{{.VmName}}" {
-  org           					= "{{.Org}}"
-  vdc           					= "{{.Vdc}}"
-  vapp_name     					= "${vcd_vapp.{{.VappName}}.name}"
-  name          					= "{{.VmName}}"
-  catalog_name  					= "{{.Catalog}}"
-  template_name 					= "{{.CatalogItem}}"
-  memory        					= 384
-  cpus          					= 2
-  cpu_cores     					= 1
-  expose_hardware_virtualization	= "{{.ExposeHardwareVirtualization}}"
+  org                            = "{{.Org}}"
+  vdc                            = "{{.Vdc}}"
+  vapp_name                      = "${vcd_vapp.{{.VappName}}.name}"
+  name                           = "{{.VmName}}"
+  catalog_name                   = "{{.Catalog}}"
+  template_name                  = "{{.CatalogItem}}"
+  memory                         = 384
+  cpus                           = 2
+  cpu_cores                      = 1
+  expose_hardware_virtualization = "{{.ExposeHardwareVirtualization}}"
 }
 `

--- a/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
+++ b/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
@@ -32,7 +32,7 @@ func TestAccVcdVAppVm_HardwareVirtualization(t *testing.T) {
 	configTextStep0 := templateFill(testAccCheckVcdVAppVm_hardwareVirtualization, params)
 
 	params["ExposeHardwareVirtualization"] = true
-	params["FuncName"] = t.Name() + "step1"
+	params["FuncName"] = t.Name() + "-step1"
 	configTextStep1 := templateFill(testAccCheckVcdVAppVm_hardwareVirtualization, params)
 
 	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configTextStep0)

--- a/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
+++ b/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
@@ -71,11 +71,11 @@ resource "vcd_network_routed" "{{.NetworkName}}" {
   org          = "{{.Org}}"
   vdc          = "{{.Vdc}}"
   edge_gateway = "{{.EdgeGateway}}"
-  gateway      = "10.10.103.1"
+  gateway      = "10.10.104.1"
 
   static_ip_pool {
-    start_address = "10.10.103.2"
-    end_address   = "10.10.103.254"
+    start_address = "10.10.104.2"
+    end_address   = "10.10.104.254"
   }
 }
 
@@ -96,7 +96,7 @@ resource "vcd_vapp_vm" "{{.VmName}}" {
   memory        					= 384
   cpus          					= 2
   cpu_cores     					= 1
-  ip            					= "10.10.103.161"
+  ip            					= "10.10.104.161"
   expose_hardware_virtualization	= "{{.ExposeHardwareVirtualization}}"
 
   depends_on    = ["vcd_vapp.{{.VappName}}", "vcd_network_routed.{{.NetworkName}}"]

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -82,6 +82,9 @@ func testAccCheckVcdVAppVmExists(n string, vapp *govcd.VApp, vm *govcd.VM) resou
 		}
 
 		vapp, err := vdc.FindVAppByName(vappName2)
+		if err != nil {
+			return err
+		}
 
 		resp, err := vdc.FindVMByName(vapp, vmName)
 

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -94,19 +94,19 @@ resource "vcd_vapp" "{{.VappName}}" {
 }
 
 resource "vcd_vapp_vm" "{{.VmName}}" {
-  org           					= "{{.Org}}"
-  vdc           					= "{{.Vdc}}"
-  vapp_name     					= "${vcd_vapp.{{.VappName}}.name}"
-  network_name  					= "${vcd_network_routed.{{.NetworkName}}.name}"
-  name          					= "{{.VmName}}"
-  catalog_name  					= "{{.Catalog}}"
-  template_name 					= "{{.CatalogItem}}"
-  memory        					= 1024
-  cpus          					= 2
-  cpu_cores     					= 1
-  ip            					= "10.10.102.161"
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  vapp_name     = "${vcd_vapp.{{.VappName}}.name}"
+  network_name  = "${vcd_network_routed.{{.NetworkName}}.name}"
+  name          = "{{.VmName}}"
+  catalog_name  = "{{.Catalog}}"
+  template_name = "{{.CatalogItem}}"
+  memory        = 1024
+  cpus          = 2
+  cpu_cores     = 1
+  ip            = "10.10.102.161"
   metadata {
-    vm_metadata 					= "VM Metadata."
+    vm_metadata = "VM Metadata."
   }
 
   disk {

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -23,30 +23,25 @@ func TestAccVcdVAppVm_Basic(t *testing.T) {
 		return
 	}
 	var params = StringMap{
-		"Org":                            testConfig.VCD.Org,
-		"Vdc":                            testConfig.VCD.Vdc,
-		"EdgeGateway":                    testConfig.Networking.EdgeGateway,
-		"NetworkName":                    "TestAccVcdVAppVmNet",
-		"Catalog":                        testSuiteCatalogName,
-		"CatalogItem":                    testSuiteCatalogOVAItem,
-		"VappName":                       vappName2,
-		"VmName":                         vmName,
-		"diskName":                       diskName,
-		"size":                           "5",
-		"busType":                        "SCSI",
-		"busSubType":                     "lsilogicsas",
-		"storageProfileName":             "*",
-		"diskResourceName":               diskResourceName,
-		"HardwareAssistedVirtualization": true,
+		"Org":                testConfig.VCD.Org,
+		"Vdc":                testConfig.VCD.Vdc,
+		"EdgeGateway":        testConfig.Networking.EdgeGateway,
+		"NetworkName":        "TestAccVcdVAppVmNet",
+		"Catalog":            testSuiteCatalogName,
+		"CatalogItem":        testSuiteCatalogOVAItem,
+		"VappName":           vappName2,
+		"VmName":             vmName,
+		"diskName":           diskName,
+		"size":               "5",
+		"busType":            "SCSI",
+		"busSubType":         "lsilogicsas",
+		"storageProfileName": "*",
+		"diskResourceName":   diskResourceName,
 	}
 
-	paramsNoHwAssistedVirtualization := params.CopyMutateKey("HardwareAssistedVirtualization", false)
-
 	configText := templateFill(testAccCheckVcdVAppVm_basic, params)
-	configTextNoHwVirt := templateFill(testAccCheckVcdVAppVm_basic, paramsNoHwAssistedVirtualization)
 
 	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
-	debugPrintf("#[DEBUG] CONFIGURATION without hardwareAssistedVirtualization: %s\n", configTextNoHwVirt)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -64,17 +59,6 @@ func TestAccVcdVAppVm_Basic(t *testing.T) {
 						"vcd_vapp_vm."+vmName, "power_on", "true"),
 					resource.TestCheckResourceAttr(
 						"vcd_vapp_vm."+vmName, "metadata.vm_metadata", "VM Metadata."),
-					resource.TestCheckResourceAttr(
-						"vcd_vapp_vm."+vmName, "hardware_assisted_virtualization", "true"),
-				),
-			},
-			resource.TestStep{
-				Config: configTextNoHwVirt,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"vcd_vapp_vm."+vmName, "power_on", "true"),
-					resource.TestCheckResourceAttr(
-						"vcd_vapp_vm."+vmName, "hardware_assisted_virtualization", "false"),
 				),
 			},
 		},
@@ -184,7 +168,6 @@ resource "vcd_vapp_vm" "{{.VmName}}" {
   metadata {
     vm_metadata 					= "VM Metadata."
   }
-  hardware_assisted_virtualization	="{{.HardwareAssistedVirtualization}}"
 
   disk {
     name = "${vcd_independent_disk.{{.diskResourceName}}.name}"

--- a/vendor/github.com/hashicorp/go-version/version.go
+++ b/vendor/github.com/hashicorp/go-version/version.go
@@ -10,14 +10,25 @@ import (
 )
 
 // The compiled regular expression used to test the validity of a version.
-var versionRegexp *regexp.Regexp
+var (
+	versionRegexp *regexp.Regexp
+	semverRegexp  *regexp.Regexp
+)
 
 // The raw regular expression string used for testing the validity
 // of a version.
-const VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
-	`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-?([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
-	`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
-	`?`
+const (
+	VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
+		`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-?([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
+		`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
+		`?`
+
+	// SemverRegexpRaw requires a separator between version and prerelease
+	SemverRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
+		`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
+		`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
+		`?`
+)
 
 // Version represents a single version.
 type Version struct {
@@ -30,12 +41,24 @@ type Version struct {
 
 func init() {
 	versionRegexp = regexp.MustCompile("^" + VersionRegexpRaw + "$")
+	semverRegexp = regexp.MustCompile("^" + SemverRegexpRaw + "$")
 }
 
 // NewVersion parses the given version and returns a new
 // Version.
 func NewVersion(v string) (*Version, error) {
-	matches := versionRegexp.FindStringSubmatch(v)
+	return newVersion(v, versionRegexp)
+}
+
+// NewSemver parses the given version and returns a new
+// Version that adheres strictly to SemVer specs
+// https://semver.org/
+func NewSemver(v string) (*Version, error) {
+	return newVersion(v, semverRegexp)
+}
+
+func newVersion(v string, pattern *regexp.Regexp) (*Version, error) {
+	matches := pattern.FindStringSubmatch(v)
 	if matches == nil {
 		return nil, fmt.Errorf("Malformed version: %s", v)
 	}

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/api_vcd.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/api_vcd.go
@@ -63,7 +63,7 @@ func (vcdCli *VCDClient) vcdauthorize(user, pass, org string) error {
 		return fmt.Errorf("Authorization is not possible because of these missing items: %v", missing_items)
 	}
 	// No point in checking for errors here
-	req := vcdCli.Client.NewRequest(map[string]string{}, "POST", vcdCli.sessionHREF, nil)
+	req := vcdCli.Client.NewRequest(map[string]string{}, http.MethodPost, vcdCli.sessionHREF, nil)
 	// Set Basic Authentication Header
 	req.SetBasicAuth(user+"@"+org, pass)
 	// Add the Accept header for vCA
@@ -140,7 +140,7 @@ func (vcdCli *VCDClient) Disconnect() error {
 	if vcdCli.Client.VCDToken == "" && vcdCli.Client.VCDAuthHeader == "" {
 		return fmt.Errorf("cannot disconnect, client is not authenticated")
 	}
-	req := vcdCli.Client.NewRequest(map[string]string{}, "DELETE", vcdCli.sessionHREF, nil)
+	req := vcdCli.Client.NewRequest(map[string]string{}, http.MethodDelete, vcdCli.sessionHREF, nil)
 	// Add the Accept header for vCA
 	req.Header.Add("Accept", "application/xml;version="+vcdCli.Client.APIVersion)
 	// Set Authorization Header

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/api_vcd.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/api_vcd.go
@@ -19,44 +19,36 @@ import (
 type VCDClientOption func(*VCDClient) error
 
 type VCDClient struct {
-	Client      Client  // Client for the underlying VCD instance
-	sessionHREF url.URL // HREF for the session API
-	QueryHREF   url.URL // HREF for the query API
-	Mutex       sync.Mutex
+	Client            Client  // Client for the underlying VCD instance
+	sessionHREF       url.URL // HREF for the session API
+	QueryHREF         url.URL // HREF for the query API
+	Mutex             sync.Mutex
+	supportedVersions SupportedVersions // Versions from /api/versions endpoint
 }
 
-type supportedVersions struct {
-	VersionInfo struct {
-		Version  string `xml:"Version"`
-		LoginUrl string `xml:"LoginUrl"`
-	} `xml:"VersionInfo"`
-}
+func (vcdCli *VCDClient) vcdloginurl() error {
+	if err := vcdCli.validateAPIVersion(); err != nil {
+		return fmt.Errorf("could not find valid version for login: %s", err)
+	}
 
-func (vdcCli *VCDClient) vcdloginurl() error {
-	apiEndpoint := vdcCli.Client.VCDHREF
-	apiEndpoint.Path += "/versions"
-	// No point in checking for errors here
-	req := vdcCli.Client.NewRequest(map[string]string{}, "GET", apiEndpoint, nil)
-	resp, err := checkResp(vdcCli.Client.Http.Do(req))
-	if err != nil {
-		return err
+	// find login address matching the API version
+	var neededVersion VersionInfo
+	for _, versionInfo := range vcdCli.supportedVersions.VersionInfos {
+		if versionInfo.Version == vcdCli.Client.APIVersion {
+			neededVersion = versionInfo
+			break
+		}
 	}
-	defer resp.Body.Close()
 
-	supportedVersions := new(supportedVersions)
-	err = decodeBody(resp, supportedVersions)
+	loginUrl, err := url.Parse(neededVersion.LoginUrl)
 	if err != nil {
-		return fmt.Errorf("error decoding versions response: %s", err)
+		return fmt.Errorf("couldn't find a LoginUrl for version %s", vcdCli.Client.APIVersion)
 	}
-	loginUrl, err := url.Parse(supportedVersions.VersionInfo.LoginUrl)
-	if err != nil {
-		return fmt.Errorf("couldn't find a LoginUrl in versions")
-	}
-	vdcCli.sessionHREF = *loginUrl
+	vcdCli.sessionHREF = *loginUrl
 	return nil
 }
 
-func (vdcCli *VCDClient) vcdauthorize(user, pass, org string) error {
+func (vcdCli *VCDClient) vcdauthorize(user, pass, org string) error {
 	var missing_items []string
 	if user == "" {
 		missing_items = append(missing_items, "user")
@@ -71,26 +63,26 @@ func (vdcCli *VCDClient) vcdauthorize(user, pass, org string) error {
 		return fmt.Errorf("Authorization is not possible because of these missing items: %v", missing_items)
 	}
 	// No point in checking for errors here
-	req := vdcCli.Client.NewRequest(map[string]string{}, "POST", vdcCli.sessionHREF, nil)
+	req := vcdCli.Client.NewRequest(map[string]string{}, "POST", vcdCli.sessionHREF, nil)
 	// Set Basic Authentication Header
 	req.SetBasicAuth(user+"@"+org, pass)
 	// Add the Accept header for vCA
-	req.Header.Add("Accept", "application/*+xml;version="+vdcCli.Client.APIVersion)
-	resp, err := checkResp(vdcCli.Client.Http.Do(req))
+	req.Header.Add("Accept", "application/*+xml;version="+vcdCli.Client.APIVersion)
+	resp, err := checkResp(vcdCli.Client.Http.Do(req))
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
 	// Store the authentication header
-	vdcCli.Client.VCDToken = resp.Header.Get("x-vcloud-authorization")
-	vdcCli.Client.VCDAuthHeader = "x-vcloud-authorization"
-	vdcCli.Client.IsSysAdmin = false
+	vcdCli.Client.VCDToken = resp.Header.Get("x-vcloud-authorization")
+	vcdCli.Client.VCDAuthHeader = "x-vcloud-authorization"
+	vcdCli.Client.IsSysAdmin = false
 	if "system" == strings.ToLower(org) {
-		vdcCli.Client.IsSysAdmin = true
+		vcdCli.Client.IsSysAdmin = true
 	}
 	// Get query href
-	vdcCli.QueryHREF = vdcCli.Client.VCDHREF
-	vdcCli.QueryHREF.Path += "/query"
+	vcdCli.QueryHREF = vcdCli.Client.VCDHREF
+	vcdCli.QueryHREF.Path += "/query"
 	return nil
 }
 
@@ -100,7 +92,7 @@ func NewVCDClient(vcdEndpoint url.URL, insecure bool, options ...VCDClientOption
 	// Setting defaults
 	vcdClient := &VCDClient{
 		Client: Client{
-			APIVersion: "27.0", // supported by vCD 8.20, 9.0, 9.1, 9.5
+			APIVersion: "27.0", // supported by vCD 8.20, 9.0, 9.1, 9.5, 9.7
 			VCDHREF:    vcdEndpoint,
 			Http: http.Client{
 				Transport: &http.Transport{
@@ -128,14 +120,15 @@ func NewVCDClient(vcdEndpoint url.URL, insecure bool, options ...VCDClientOption
 }
 
 // Authenticate is an helper function that performs a login in vCloud Director.
-func (vdcCli *VCDClient) Authenticate(username, password, org string) error {
+func (vcdCli *VCDClient) Authenticate(username, password, org string) error {
+
 	// LoginUrl
-	err := vdcCli.vcdloginurl()
+	err := vcdCli.vcdloginurl()
 	if err != nil {
 		return fmt.Errorf("error finding LoginUrl: %s", err)
 	}
 	// Authorize
-	err = vdcCli.vcdauthorize(username, password, org)
+	err = vcdCli.vcdauthorize(username, password, org)
 	if err != nil {
 		return fmt.Errorf("error authorizing: %s", err)
 	}
@@ -143,16 +136,16 @@ func (vdcCli *VCDClient) Authenticate(username, password, org string) error {
 }
 
 // Disconnect performs a disconnection from the vCloud Director API endpoint.
-func (vdcCli *VCDClient) Disconnect() error {
-	if vdcCli.Client.VCDToken == "" && vdcCli.Client.VCDAuthHeader == "" {
+func (vcdCli *VCDClient) Disconnect() error {
+	if vcdCli.Client.VCDToken == "" && vcdCli.Client.VCDAuthHeader == "" {
 		return fmt.Errorf("cannot disconnect, client is not authenticated")
 	}
-	req := vdcCli.Client.NewRequest(map[string]string{}, "DELETE", vdcCli.sessionHREF, nil)
+	req := vcdCli.Client.NewRequest(map[string]string{}, "DELETE", vcdCli.sessionHREF, nil)
 	// Add the Accept header for vCA
-	req.Header.Add("Accept", "application/xml;version="+vdcCli.Client.APIVersion)
+	req.Header.Add("Accept", "application/xml;version="+vcdCli.Client.APIVersion)
 	// Set Authorization Header
-	req.Header.Add(vdcCli.Client.VCDAuthHeader, vdcCli.Client.VCDToken)
-	if _, err := checkResp(vdcCli.Client.Http.Do(req)); err != nil {
+	req.Header.Add(vcdCli.Client.VCDAuthHeader, vcdCli.Client.VCDToken)
+	if _, err := checkResp(vcdCli.Client.Http.Do(req)); err != nil {
 		return fmt.Errorf("error processing session delete for vCloud Director: %s", err)
 	}
 	return nil
@@ -162,6 +155,15 @@ func (vdcCli *VCDClient) Disconnect() error {
 func WithMaxRetryTimeout(timeoutSeconds int) VCDClientOption {
 	return func(vcdClient *VCDClient) error {
 		vcdClient.Client.MaxRetryTimeout = timeoutSeconds
+		return nil
+	}
+}
+
+// WithAPIVersion allows to override default API version. Please be cautious
+// about changing the version as the default specified is the most tested.
+func WithAPIVersion(version string) VCDClientOption {
+	return func(vcdClient *VCDClient) error {
+		vcdClient.Client.APIVersion = version
 		return nil
 	}
 }

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/api_vcd_versions.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/api_vcd_versions.go
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"sort"
+
+	semver "github.com/hashicorp/go-version"
+
+	"github.com/vmware/go-vcloud-director/v2/util"
+)
+
+type VersionInfo struct {
+	Version    string `xml:"Version"`
+	LoginUrl   string `xml:"LoginUrl"`
+	Deprecated bool   `xml:"deprecated,attr,omitempty"`
+}
+
+type VersionInfos []VersionInfo
+
+type SupportedVersions struct {
+	VersionInfos `xml:"VersionInfo"`
+}
+
+// APIVCDMaxVersionIs compares against maximum vCD supported API version from /api/versions (not necessarily
+// the currently used one). This allows to check what is the maximum API version that vCD instance
+// supports and can be used to guess vCD product version. API 31.0 support was first introduced in
+// vCD 9.5 (as per https://code.vmware.com/doc/preview?id=8072). Therefore APIMaxVerIs(">= 31.0")
+// implies that you have vCD 9.5 or newer running inside.
+// It does not require for the client to be authenticated.
+//
+// Format: ">= 27.0, < 32.0", ">= 30.0", "= 27.0"
+//
+// vCD version mapping to API version support https://code.vmware.com/doc/preview?id=8072
+func (vcdCli *VCDClient) APIVCDMaxVersionIs(versionConstraint string) bool {
+	err := vcdCli.vcdFetchSupportedVersions()
+	if err != nil {
+		util.Logger.Printf("[ERROR] could not retrieve supported versions: %s", err)
+		return false
+	}
+
+	util.Logger.Printf("[TRACE] checking max API version against constraints '%s'", versionConstraint)
+	maxVersion, err := vcdCli.maxSupportedVersion()
+	if err != nil {
+		util.Logger.Printf("[ERROR] unable to find max supported version : %s", err)
+		return false
+	}
+
+	isSupported, err := vcdCli.apiVersionMatchesConstraint(maxVersion, versionConstraint)
+	if err != nil {
+		util.Logger.Printf("[ERROR] unable to find max supported version : %s", err)
+		return false
+	}
+
+	return isSupported
+}
+
+// APIClientVersionIs allows to compare against currently used API version VCDClient.Client.APIVersion.
+// Can be useful to validate if a certain feature can be used or not.
+// It does not require for the client to be authenticated.
+//
+// Format: ">= 27.0, < 32.0", ">= 30.0", "= 27.0"
+//
+// vCD version mapping to API version support https://code.vmware.com/doc/preview?id=8072
+func (vcdCli *VCDClient) APIClientVersionIs(versionConstraint string) bool {
+
+	util.Logger.Printf("[TRACE] checking current API version against constraints '%s'", versionConstraint)
+
+	isSupported, err := vcdCli.apiVersionMatchesConstraint(vcdCli.Client.APIVersion, versionConstraint)
+	if err != nil {
+		util.Logger.Printf("[ERROR] unable to find cur supported version : %s", err)
+		return false
+	}
+
+	return isSupported
+}
+
+// vcdFetchSupportedVersions retrieves list of supported versions from
+// /api/versions endpoint and stores them in VCDClient for future uses.
+// It only does it once.
+func (vcdCli *VCDClient) vcdFetchSupportedVersions() error {
+	// Only fetch /versions if it is not stored already
+	numVersions := len(vcdCli.supportedVersions.VersionInfos)
+	if numVersions > 0 {
+		util.Logger.Printf("[TRACE] skipping fetch of versions because %d are stored", numVersions)
+		return nil
+	}
+
+	apiEndpoint := vcdCli.Client.VCDHREF
+	apiEndpoint.Path += "/versions"
+
+	req := vcdCli.Client.NewRequest(map[string]string{}, "GET", apiEndpoint, nil)
+	resp, err := checkResp(vcdCli.Client.Http.Do(req))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	suppVersions := new(SupportedVersions)
+	err = decodeBody(resp, suppVersions)
+	if err != nil {
+		return fmt.Errorf("error decoding versions response: %s", err)
+	}
+
+	vcdCli.supportedVersions = *suppVersions
+
+	return nil
+}
+
+// maxSupportedVersion parses supported version list and returns the highest version in string format.
+func (vcdCli *VCDClient) maxSupportedVersion() (string, error) {
+	versions := make([]*semver.Version, len(vcdCli.supportedVersions.VersionInfos))
+	for index, versionInfo := range vcdCli.supportedVersions.VersionInfos {
+		version, _ := semver.NewVersion(versionInfo.Version)
+		versions[index] = version
+	}
+	// Sort supported versions in order lowest-highest
+	sort.Sort(semver.Collection(versions))
+
+	switch {
+	case len(versions) > 1:
+		return versions[len(versions)-1].Original(), nil
+	case len(versions) == 1:
+		return versions[0].Original(), nil
+	default:
+		return "", fmt.Errorf("could not identify supported versions")
+	}
+}
+
+// vcdCheckSupportedVersion checks if there is at least one specified version exactly matching listed ones.
+// Format example "27.0"
+func (vcdCli *VCDClient) vcdCheckSupportedVersion(version string) (bool, error) {
+	return vcdCli.checkSupportedVersionConstraint(fmt.Sprintf("= %s", version))
+}
+
+// Checks if there is at least one specified version matching the list returned by vCD.
+// Constraint format can be in format ">= 27.0, < 32",">= 30" ,"= 27.0".
+func (vcdCli *VCDClient) checkSupportedVersionConstraint(versionConstraint string) (bool, error) {
+	for _, versionInfo := range vcdCli.supportedVersions.VersionInfos {
+		versionMatch, err := vcdCli.apiVersionMatchesConstraint(versionInfo.Version, versionConstraint)
+		if err != nil {
+			return false, fmt.Errorf("cannot match version: %s", err)
+		}
+
+		if versionMatch {
+			return true, nil
+		}
+	}
+	return false, fmt.Errorf("version %s is not supported", versionConstraint)
+}
+
+func (vcdCli *VCDClient) apiVersionMatchesConstraint(version, versionConstraint string) (bool, error) {
+
+	checkVer, err := semver.NewVersion(version)
+	if err != nil {
+		return false, fmt.Errorf("[ERROR] unable to parse version %s : %s", version, err)
+	}
+	// Create a provided constraint to check against current max version
+	constraints, err := semver.NewConstraint(versionConstraint)
+	if err != nil {
+		return false, fmt.Errorf("[ERROR] unable to parse given version constraint '%s' : %s", versionConstraint, err)
+	}
+	if constraints.Check(checkVer) {
+		return true, nil
+	}
+
+	util.Logger.Printf("[TRACE] API version %s does not satisfy constraints '%s'", checkVer, constraints)
+	return false, nil
+}
+
+// validateAPIVersion fetches API versions
+func (vcdCli *VCDClient) validateAPIVersion() error {
+	err := vcdCli.vcdFetchSupportedVersions()
+	if err != nil {
+		return fmt.Errorf("could not retrieve supported versions: %s", err)
+	}
+
+	// Check if version is supported
+	if ok, err := vcdCli.vcdCheckSupportedVersion(vcdCli.Client.APIVersion); !ok || err != nil {
+		return fmt.Errorf("API version %s is not supported: %s", vcdCli.Client.APIVersion, err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/api_vcd_versions.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/api_vcd_versions.go
@@ -6,6 +6,7 @@ package govcd
 
 import (
 	"fmt"
+	"net/http"
 	"sort"
 
 	semver "github.com/hashicorp/go-version"
@@ -92,22 +93,13 @@ func (vcdCli *VCDClient) vcdFetchSupportedVersions() error {
 	apiEndpoint := vcdCli.Client.VCDHREF
 	apiEndpoint.Path += "/versions"
 
-	req := vcdCli.Client.NewRequest(map[string]string{}, "GET", apiEndpoint, nil)
-	resp, err := checkResp(vcdCli.Client.Http.Do(req))
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
 	suppVersions := new(SupportedVersions)
-	err = decodeBody(resp, suppVersions)
-	if err != nil {
-		return fmt.Errorf("error decoding versions response: %s", err)
-	}
+	_, err := vcdCli.Client.ExecuteRequest(apiEndpoint.String(), http.MethodGet,
+		"", "error fetching versions: %s", nil, suppVersions)
 
 	vcdCli.supportedVersions = *suppVersions
 
-	return nil
+	return err
 }
 
 // maxSupportedVersion parses supported version list and returns the highest version in string format.

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/catalog.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/catalog.go
@@ -109,7 +109,7 @@ func (adminCatalog *AdminCatalog) Update() error {
 		Description: adminCatalog.AdminCatalog.Description,
 	}
 	vcomp := &types.AdminCatalog{
-		Xmlns:       "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:       types.XMLNamespaceVCloud,
 		Catalog:     *reqCatalog,
 		IsPublished: adminCatalog.AdminCatalog.IsPublished,
 	}
@@ -507,7 +507,7 @@ func findFilePath(filesAbsPaths []string, fileName string) string {
 func createItemForUpload(client *Client, createHREF *url.URL, catalogItemName string, itemDescription string) (*url.URL, error) {
 	util.Logger.Printf("[TRACE] createItemForUpload: %s, item name: %v, description: %v \n", createHREF, catalogItemName, itemDescription)
 	reqBody := bytes.NewBufferString(
-		"<UploadVAppTemplateParams xmlns=\"http://www.vmware.com/vcloud/v1.5\" name=\"" + catalogItemName + "\" >" +
+		"<UploadVAppTemplateParams xmlns=\"" + types.XMLNamespaceVCloud + "\" name=\"" + catalogItemName + "\" >" +
 			"<Description>" + itemDescription + "</Description>" +
 			"</UploadVAppTemplateParams>")
 

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/catalog.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/catalog.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -70,7 +71,7 @@ func (catalog *Catalog) Delete(force, recursive bool) error {
 	req := catalog.client.NewRequest(map[string]string{
 		"force":     strconv.FormatBool(force),
 		"recursive": strconv.FormatBool(recursive),
-	}, "DELETE", adminCatalogHREF, nil)
+	}, http.MethodDelete, adminCatalogHREF, nil)
 
 	_, err := checkResp(catalog.client.Http.Do(req))
 
@@ -112,28 +113,11 @@ func (adminCatalog *AdminCatalog) Update() error {
 		Catalog:     *reqCatalog,
 		IsPublished: adminCatalog.AdminCatalog.IsPublished,
 	}
-	adminCatalogHREF, err := url.ParseRequestURI(adminCatalog.AdminCatalog.HREF)
-	if err != nil {
-		return fmt.Errorf("error parsing admin catalog's href: %v", err)
-	}
-	output, err := xml.MarshalIndent(vcomp, "  ", "    ")
-	if err != nil {
-		return fmt.Errorf("error marshalling xml data for update %v", err)
-	}
-	xmlData := bytes.NewBufferString(xml.Header + string(output))
-	req := adminCatalog.client.NewRequest(map[string]string{}, "PUT", *adminCatalogHREF, xmlData)
-	req.Header.Add("Content-Type", "application/vnd.vmware.admin.catalog+xml")
-	resp, err := checkResp(adminCatalog.client.Http.Do(req))
-	if err != nil {
-		return fmt.Errorf("error updating catalog: %s : %s", err, adminCatalogHREF.Path)
-	}
-
 	catalog := &types.AdminCatalog{}
-	if err = decodeBody(resp, catalog); err != nil {
-		return fmt.Errorf("error decoding update response: %s", err)
-	}
+	_, err := adminCatalog.client.ExecuteRequest(adminCatalog.AdminCatalog.HREF, http.MethodPut,
+		"application/vnd.vmware.admin.catalog+xml", "error updating catalog: %s", vcomp, catalog)
 	adminCatalog.AdminCatalog = catalog
-	return nil
+	return err
 }
 
 // Envelope is a ovf description root element. File contains information for vmdk files.
@@ -156,27 +140,12 @@ func (cat *Catalog) FindCatalogItem(catalogItemName string) (CatalogItem, error)
 	for _, catalogItems := range cat.Catalog.CatalogItems {
 		for _, catalogItem := range catalogItems.CatalogItem {
 			if catalogItem.Name == catalogItemName && catalogItem.Type == "application/vnd.vmware.vcloud.catalogItem+xml" {
-				catalogItemHREF, err := url.ParseRequestURI(catalogItem.HREF)
-
-				if err != nil {
-					return CatalogItem{}, fmt.Errorf("error decoding catalog response: %s", err)
-				}
-
-				req := cat.client.NewRequest(map[string]string{}, "GET", *catalogItemHREF, nil)
-
-				resp, err := checkResp(cat.client.Http.Do(req))
-				if err != nil {
-					return CatalogItem{}, fmt.Errorf("error retrieving catalog: %s", err)
-				}
 
 				cat := NewCatalogItem(cat.client)
 
-				if err = decodeBody(resp, cat.CatalogItem); err != nil {
-					return CatalogItem{}, fmt.Errorf("error decoding catalog response: %s", err)
-				}
-
-				// The request was successful
-				return *cat, nil
+				_, err := cat.client.ExecuteRequest(catalogItem.HREF, http.MethodGet,
+					"", "error retrieving catalog: %s", nil, cat.CatalogItem)
+				return *cat, err
 			}
 		}
 	}
@@ -437,18 +406,14 @@ func waitForTempUploadLinks(client *Client, vappTemplateUrl *url.URL, newItemNam
 
 func queryVappTemplate(client *Client, vappTemplateUrl *url.URL, newItemName string) (*types.VAppTemplate, error) {
 	util.Logger.Printf("[TRACE] Querying vapp template: %s\n", vappTemplateUrl)
-	request := client.NewRequest(map[string]string{}, "GET", *vappTemplateUrl, nil)
-	response, err := checkResp(client.Http.Do(request))
+
+	vappTemplateParsed := &types.VAppTemplate{}
+
+	_, err := client.ExecuteRequest(vappTemplateUrl.String(), http.MethodGet,
+		"", "error quering vApp template: %s", nil, vappTemplateParsed)
 	if err != nil {
 		return nil, err
 	}
-
-	vappTemplateParsed := &types.VAppTemplate{}
-	if err = decodeBody(response, vappTemplateParsed); err != nil {
-		return nil, err
-	}
-
-	defer response.Body.Close()
 
 	for _, task := range vappTemplateParsed.Tasks.Task {
 		if "error" == task.Status && newItemName == task.Owner.Name {
@@ -472,7 +437,7 @@ func uploadOvfDescription(client *Client, ovfFile string, ovfUploadUrl *url.URL)
 	var buf bytes.Buffer
 	ovfReader := io.TeeReader(openedFile, &buf)
 
-	request := client.NewRequest(map[string]string{}, "PUT", *ovfUploadUrl, ovfReader)
+	request := client.NewRequest(map[string]string{}, http.MethodPut, *ovfUploadUrl, ovfReader)
 	request.Header.Add("Content-Type", "text/xml")
 
 	_, err = checkResp(client.Http.Do(request))
@@ -546,7 +511,7 @@ func createItemForUpload(client *Client, createHREF *url.URL, catalogItemName st
 			"<Description>" + itemDescription + "</Description>" +
 			"</UploadVAppTemplateParams>")
 
-	request := client.NewRequest(map[string]string{}, "POST", *createHREF, reqBody)
+	request := client.NewRequest(map[string]string{}, http.MethodPost, *createHREF, reqBody)
 	request.Header.Add("Content-Type", "application/vnd.vmware.vcloud.uploadVAppTemplateParams+xml")
 
 	response, err := checkResp(client.Http.Do(request))

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/disk.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/disk.go
@@ -86,7 +86,7 @@ func (vdc *Vdc) CreateDisk(diskCreateParams *types.DiskCreateParams) (Task, erro
 	}
 
 	// Prepare the request payload
-	diskCreateParams.Xmlns = types.NsVCloud
+	diskCreateParams.Xmlns = types.XMLNamespaceVCloud
 
 	disk := NewDisk(vdc.client)
 
@@ -163,7 +163,7 @@ func (disk *Disk) Update(newDiskInfo *types.Disk) (Task, error) {
 
 	// Prepare the request payload
 	xmlPayload := &types.Disk{
-		Xmlns:          types.NsVCloud,
+		Xmlns:          types.XMLNamespaceVCloud,
 		Description:    newDiskInfo.Description,
 		Size:           newDiskInfo.Size,
 		Name:           newDiskInfo.Name,

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/disk.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/disk.go
@@ -5,8 +5,6 @@
 package govcd
 
 import (
-	"bytes"
-	"encoding/xml"
 	"errors"
 	"fmt"
 	"net/http"
@@ -87,35 +85,16 @@ func (vdc *Vdc) CreateDisk(diskCreateParams *types.DiskCreateParams) (Task, erro
 		return Task{}, fmt.Errorf("could not find request URL for create disk in vdc Link")
 	}
 
-	// Parse request URI
-	reqUrl, err := url.ParseRequestURI(createDiskLink.HREF)
-	if err != nil {
-		return Task{}, fmt.Errorf("error parse URI: %s", err)
-	}
-
 	// Prepare the request payload
 	diskCreateParams.Xmlns = types.NsVCloud
 
-	xmlPayload, err := xml.Marshal(diskCreateParams)
-	if err != nil {
-		return Task{}, fmt.Errorf("error xml.Marshal: %s", err)
-	}
-
-	// Send Request
-	reqPayload := bytes.NewBufferString(xml.Header + string(xmlPayload))
-	req := vdc.client.NewRequest(nil, http.MethodPost, *reqUrl, reqPayload)
-	req.Header.Add("Content-Type", createDiskLink.Type)
-	resp, err := checkResp(vdc.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error create disk: %s", err)
-	}
-
-	// Decode response
 	disk := NewDisk(vdc.client)
-	if err = decodeBody(resp, disk.Disk); err != nil {
-		return Task{}, fmt.Errorf("error decoding create disk params response: %s", err)
-	}
 
+	_, err = vdc.client.ExecuteRequest(createDiskLink.HREF, http.MethodPost,
+		createDiskLink.Type, "error create disk: %s", diskCreateParams, disk.Disk)
+	if err != nil {
+		return Task{}, err
+	}
 	// Obtain disk task
 	if disk.Disk.Tasks.Task == nil || len(disk.Disk.Tasks.Task) <= 0 {
 		return Task{}, errors.New("error cannot find disk creation task in API response")
@@ -136,11 +115,11 @@ func (vdc *Vdc) CreateDisk(diskCreateParams *types.DiskCreateParams) (Task, erro
 // Reference: vCloud API Programming Guide for Service Providers vCloud API 30.0 PDF Page 104 - 106,
 // https://vdc-download.vmware.com/vmwb-repository/dcr-public/1b6cf07d-adb3-4dba-8c47-9c1c92b04857/
 // 241956dd-e128-4fcc-8131-bf66e1edd895/vcloud_sp_api_guide_30_0.pdf
-func (d *Disk) Update(newDiskInfo *types.Disk) (Task, error) {
+func (disk *Disk) Update(newDiskInfo *types.Disk) (Task, error) {
 	util.Logger.Printf("[TRACE] Update disk, name: %s, size: %d, HREF: %s \n",
 		newDiskInfo.Name,
 		newDiskInfo.Size,
-		d.Disk.HREF,
+		disk.Disk.HREF,
 	)
 
 	var err error
@@ -154,7 +133,7 @@ func (d *Disk) Update(newDiskInfo *types.Disk) (Task, error) {
 	}
 
 	// Verify the independent disk is not connected to any VM
-	vmRef, err := d.AttachedVM()
+	vmRef, err := disk.AttachedVM()
 	if err != nil {
 		return Task{}, fmt.Errorf("error find attached VM: %s", err)
 	}
@@ -165,7 +144,7 @@ func (d *Disk) Update(newDiskInfo *types.Disk) (Task, error) {
 	var updateDiskLink *types.Link
 
 	// Find the proper link for request
-	for _, diskLink := range d.Disk.Link {
+	for _, diskLink := range disk.Disk.Link {
 		if diskLink.Rel == types.RelEdit && diskLink.Type == types.MimeDisk {
 			util.Logger.Printf("[TRACE] Update disk - found the proper link for request, HREF: %s, name: %s, type: %s,id: %s, rel: %s \n",
 				diskLink.HREF,
@@ -182,43 +161,19 @@ func (d *Disk) Update(newDiskInfo *types.Disk) (Task, error) {
 		return Task{}, fmt.Errorf("could not find request URL for update disk in disk Link")
 	}
 
-	// Parse request URI
-	reqUrl, err := url.ParseRequestURI(updateDiskLink.HREF)
-	if err != nil {
-		return Task{}, fmt.Errorf("error parse URI: %s", err)
-	}
-
 	// Prepare the request payload
-	xmlPayload, err := xml.Marshal(&types.Disk{
+	xmlPayload := &types.Disk{
 		Xmlns:          types.NsVCloud,
 		Description:    newDiskInfo.Description,
 		Size:           newDiskInfo.Size,
 		Name:           newDiskInfo.Name,
 		StorageProfile: newDiskInfo.StorageProfile,
 		Owner:          newDiskInfo.Owner,
-	})
-	if err != nil {
-		return Task{}, fmt.Errorf("error xml.Marshal: %s", err)
-	}
-	util.Logger.Printf("[TRACE] BEFORE UPDATE DISK\n %s\n", prettyDisk(*d.Disk))
-
-	// Send request
-	reqPayload := bytes.NewBufferString(xml.Header + string(xmlPayload))
-	req := d.client.NewRequest(nil, http.MethodPut, *reqUrl, reqPayload)
-	req.Header.Add("Content-Type", updateDiskLink.Type)
-	resp, err := checkResp(d.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error update disk: %s", err)
-	}
-
-	// Decode response
-	task := NewTask(d.client)
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding find disk response: %s", err)
 	}
 
 	// Return the task
-	return *task, nil
+	return disk.client.ExecuteTaskRequest(updateDiskLink.HREF, http.MethodPut,
+		updateDiskLink.Type, "error updating disk: %s", xmlPayload)
 }
 
 // Remove an independent disk
@@ -229,13 +184,13 @@ func (d *Disk) Update(newDiskInfo *types.Disk) (Task, error) {
 // Reference: vCloud API Programming Guide for Service Providers vCloud API 30.0 PDF Page 106 - 107,
 // https://vdc-download.vmware.com/vmwb-repository/dcr-public/1b6cf07d-adb3-4dba-8c47-9c1c92b04857/
 // 241956dd-e128-4fcc-8131-bf66e1edd895/vcloud_sp_api_guide_30_0.pdf
-func (d *Disk) Delete() (Task, error) {
-	util.Logger.Printf("[TRACE] Delete disk, HREF: %s \n", d.Disk.HREF)
+func (disk *Disk) Delete() (Task, error) {
+	util.Logger.Printf("[TRACE] Delete disk, HREF: %s \n", disk.Disk.HREF)
 
 	var err error
 
 	// Verify the independent disk is not connected to any VM
-	vmRef, err := d.AttachedVM()
+	vmRef, err := disk.AttachedVM()
 	if err != nil {
 		return Task{}, fmt.Errorf("error find attached VM: %s", err)
 	}
@@ -246,7 +201,7 @@ func (d *Disk) Delete() (Task, error) {
 	var deleteDiskLink *types.Link
 
 	// Find the proper link for request
-	for _, diskLink := range d.Disk.Link {
+	for _, diskLink := range disk.Disk.Link {
 		if diskLink.Rel == types.RelRemove {
 			util.Logger.Printf("[TRACE] Delete disk - found the proper link for request, HREF: %s, name: %s, type: %s,id: %s, rel: %s \n",
 				diskLink.HREF,
@@ -263,39 +218,21 @@ func (d *Disk) Delete() (Task, error) {
 		return Task{}, fmt.Errorf("could not find request URL for delete disk in disk Link")
 	}
 
-	// Parse request URI
-	reqUrl, err := url.ParseRequestURI(deleteDiskLink.HREF)
-	if err != nil {
-		return Task{}, fmt.Errorf("error parse uri: %s", err)
-	}
-
-	// Make request
-	req := d.client.NewRequest(nil, http.MethodDelete, *reqUrl, nil)
-	resp, err := checkResp(d.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error delete disk: %s", err)
-	}
-
-	// Decode response
-	task := NewTask(d.client)
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding delete disk params response: %s", err)
-	}
-
 	// Return the task
-	return *task, nil
+	return disk.client.ExecuteTaskRequest(deleteDiskLink.HREF, http.MethodDelete,
+		"", "error delete disk: %s", nil)
 }
 
 // Refresh the disk information by disk href
-func (d *Disk) Refresh() error {
-	util.Logger.Printf("[TRACE] Disk refresh, HREF: %s\n", d.Disk.HREF)
+func (disk *Disk) Refresh() error {
+	util.Logger.Printf("[TRACE] Disk refresh, HREF: %s\n", disk.Disk.HREF)
 
-	disk, err := FindDiskByHREF(d.client, d.Disk.HREF)
+	fetchedDisk, err := FindDiskByHREF(disk.client, disk.Disk.HREF)
 	if err != nil {
 		return err
 	}
 
-	d.Disk = disk.Disk
+	disk.Disk = fetchedDisk.Disk
 
 	return nil
 }
@@ -307,14 +244,13 @@ func (d *Disk) Refresh() error {
 // Reference: vCloud API Programming Guide for Service Providers vCloud API 30.0 PDF Page 107,
 // https://vdc-download.vmware.com/vmwb-repository/dcr-public/1b6cf07d-adb3-4dba-8c47-9c1c92b04857/
 // 241956dd-e128-4fcc-8131-bf66e1edd895/vcloud_sp_api_guide_30_0.pdf
-func (d *Disk) AttachedVM() (*types.Reference, error) {
-	util.Logger.Printf("[TRACE] Disk attached VM, HREF: %s\n", d.Disk.HREF)
+func (disk *Disk) AttachedVM() (*types.Reference, error) {
+	util.Logger.Printf("[TRACE] Disk attached VM, HREF: %s\n", disk.Disk.HREF)
 
 	var attachedVMLink *types.Link
-	var err error
 
 	// Find the proper link for request
-	for _, diskLink := range d.Disk.Link {
+	for _, diskLink := range disk.Disk.Link {
 		if diskLink.Type == types.MimeVMs {
 			util.Logger.Printf("[TRACE] Disk attached VM - found the proper link for request, HREF: %s, name: %s, type: %s,id: %s, rel: %s \n",
 				diskLink.HREF,
@@ -332,24 +268,13 @@ func (d *Disk) AttachedVM() (*types.Reference, error) {
 		return nil, fmt.Errorf("could not find request URL for attached vm in disk Link")
 	}
 
-	// Parse request URI
-	reqUrl, err := url.ParseRequestURI(attachedVMLink.HREF)
-	if err != nil {
-		return nil, fmt.Errorf("error parse uri: %s", err)
-	}
-
-	// Send request
-	req := d.client.NewRequest(nil, http.MethodGet, *reqUrl, nil)
-	req.Header.Add("Content-Type", attachedVMLink.Type)
-	resp, err := checkResp(d.client.Http.Do(req))
-	if err != nil {
-		return nil, fmt.Errorf("error attached vms: %s", err)
-	}
-
 	// Decode request
 	var vms = new(types.Vms)
-	if err = decodeBody(resp, vms); err != nil {
-		return nil, fmt.Errorf("error decoding find disk response: %s", err)
+
+	_, err := disk.client.ExecuteRequest(attachedVMLink.HREF, http.MethodGet,
+		attachedVMLink.Type, "error getting attached vms: %s", nil, vms)
+	if err != nil {
+		return nil, err
 	}
 
 	// If disk is not attached to any VM
@@ -372,27 +297,14 @@ func (vdc *Vdc) FindDiskByHREF(href string) (*Disk, error) {
 func FindDiskByHREF(client *Client, href string) (*Disk, error) {
 	util.Logger.Printf("[TRACE] Find disk By HREF: %s\n", href)
 
-	// Parse request URI
-	reqUrl, err := url.ParseRequestURI(href)
-	if err != nil {
-		return nil, fmt.Errorf("error parse URI: %s", err)
-	}
-
-	// Send request
-	req := client.NewRequest(nil, http.MethodGet, *reqUrl, nil)
-	resp, err := checkResp(client.Http.Do(req))
-	if err != nil {
-		return nil, fmt.Errorf("error find disk: %s", err)
-	}
-
-	// Decode response
 	disk := NewDisk(client)
-	if err = decodeBody(resp, disk.Disk); err != nil {
-		return nil, fmt.Errorf("error decoding find disk response: %s", err)
-	}
+
+	_, err := client.ExecuteRequest(href, http.MethodGet,
+		"", "error finding disk: %s", nil, disk.Disk)
 
 	// Return the disk
-	return disk, nil
+	return disk, err
+
 }
 
 // Find independent disk using disk name. Returns VMRecord query return type

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/edgegateway.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/edgegateway.go
@@ -78,7 +78,7 @@ func (eGW *EdgeGateway) AddDhcpPool(network *types.OrgVDCNetwork, dhcppool []int
 	}
 
 	newRules := &types.EdgeGatewayServiceConfiguration{
-		Xmlns:              "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:              types.XMLNamespaceVCloud,
 		GatewayDhcpService: newDchpService,
 	}
 
@@ -164,7 +164,7 @@ func (eGW *EdgeGateway) RemoveNATPortMapping(natType, externalIP, externalPort s
 	newEdgeConfig.NatService = newNatService
 
 	newRules := &types.EdgeGatewayServiceConfiguration{
-		Xmlns:      "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:      types.XMLNamespaceVCloud,
 		NatService: newNatService,
 	}
 
@@ -303,7 +303,7 @@ func (eGW *EdgeGateway) AddNATPortMappingWithUplink(network *types.OrgVDCNetwork
 	newEdgeConfig.NatService = newNatService
 
 	newRules := &types.EdgeGatewayServiceConfiguration{
-		Xmlns:      "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:      types.XMLNamespaceVCloud,
 		NatService: newNatService,
 	}
 
@@ -322,7 +322,7 @@ func (eGW *EdgeGateway) CreateFirewallRules(defaultAction string, rules []*types
 	}
 
 	newRules := &types.EdgeGatewayServiceConfiguration{
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Xmlns: types.XMLNamespaceVCloud,
 		FirewallService: &types.FirewallService{
 			IsEnabled:        true,
 			DefaultAction:    defaultAction,
@@ -617,7 +617,7 @@ func (eGW *EdgeGateway) RemoveIpsecVPN() (Task, error) {
 		fmt.Printf("error: %v\n", err)
 	}
 	ipsecVPNConfig := &types.EdgeGatewayServiceConfiguration{
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Xmlns: types.XMLNamespaceVCloud,
 		GatewayIpsecVpnService: &types.GatewayIpsecVpnService{
 			IsEnabled: false,
 		},

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/edgegateway.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/edgegateway.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -95,7 +94,7 @@ func (eGW *EdgeGateway) AddDhcpPool(network *types.OrgVDCNetwork, dhcppool []int
 		apiEndpoint, _ := url.ParseRequestURI(eGW.EdgeGateway.HREF)
 		apiEndpoint.Path += "/action/configureServices"
 
-		req := eGW.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
+		req := eGW.client.NewRequest(map[string]string{}, http.MethodPost, *apiEndpoint, buffer)
 		util.Logger.Printf("[DEBUG] POSTING TO URL: %s", apiEndpoint.Path)
 		util.Logger.Printf("[DEBUG] XML TO SEND:\n%s", buffer)
 
@@ -169,36 +168,12 @@ func (eGW *EdgeGateway) RemoveNATPortMapping(natType, externalIP, externalPort s
 		NatService: newNatService,
 	}
 
-	output, err := xml.MarshalIndent(newRules, "  ", "    ")
-	if err != nil {
-		return Task{}, fmt.Errorf("error reconfiguring Edge Gateway: %s", err)
-	}
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
 	apiEndpoint, _ := url.ParseRequestURI(eGW.EdgeGateway.HREF)
 	apiEndpoint.Path += "/action/configureServices"
 
-	req := eGW.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
-	util.Logger.Printf("[DEBUG] POSTING TO URL: %s", apiEndpoint.Path)
-	util.Logger.Printf("[DEBUG] XML TO SEND:\n%s", buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml")
-
-	resp, err := checkResp(eGW.client.Http.Do(req))
-	if err != nil {
-		util.Logger.Printf("[DEBUG] Error is: %#v", err)
-		return Task{}, fmt.Errorf("error reconfiguring Edge Gateway: %s", err)
-	}
-
-	task := NewTask(eGW.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
+	// Return the task
+	return eGW.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		"application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml", "error reconfiguring Edge Gateway: %s", newRules)
 
 }
 
@@ -332,37 +307,12 @@ func (eGW *EdgeGateway) AddNATPortMappingWithUplink(network *types.OrgVDCNetwork
 		NatService: newNatService,
 	}
 
-	output, err := xml.MarshalIndent(newRules, "  ", "    ")
-	if err != nil {
-		return Task{}, fmt.Errorf("error reconfiguring Edge Gateway: %s", err)
-	}
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
 	apiEndpoint, _ := url.ParseRequestURI(eGW.EdgeGateway.HREF)
 	apiEndpoint.Path += "/action/configureServices"
 
-	req := eGW.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
-	util.Logger.Printf("[DEBUG] POSTING TO URL: %s", apiEndpoint.Path)
-	util.Logger.Printf("[DEBUG] XML TO SEND:\n%s", buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml")
-
-	resp, err := checkResp(eGW.client.Http.Do(req))
-	if err != nil {
-		util.Logger.Printf("[DEBUG] Error is: %#v", err)
-		return Task{}, fmt.Errorf("error reconfiguring Edge Gateway: %s", err)
-	}
-
-	task := NewTask(eGW.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
-
+	// Return the task
+	return eGW.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		"application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml", "error reconfiguring Edge Gateway: %s", newRules)
 }
 
 func (eGW *EdgeGateway) CreateFirewallRules(defaultAction string, rules []*types.FirewallRule) (Task, error) {
@@ -393,7 +343,7 @@ func (eGW *EdgeGateway) CreateFirewallRules(defaultAction string, rules []*types
 		apiEndpoint, _ := url.ParseRequestURI(eGW.EdgeGateway.HREF)
 		apiEndpoint.Path += "/action/configureServices"
 
-		req := eGW.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
+		req := eGW.client.NewRequest(map[string]string{}, http.MethodPost, *apiEndpoint, buffer)
 		util.Logger.Printf("[DEBUG] POSTING TO URL: %s", apiEndpoint.Path)
 		util.Logger.Printf("[DEBUG] XML TO SEND:\n%s", buffer)
 
@@ -426,25 +376,16 @@ func (eGW *EdgeGateway) Refresh() error {
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	apiEndpoint, _ := url.ParseRequestURI(eGW.EdgeGateway.HREF)
-
-	req := eGW.client.NewRequest(map[string]string{}, "GET", *apiEndpoint, nil)
-
-	resp, err := checkResp(eGW.client.Http.Do(req))
-	if err != nil {
-		return fmt.Errorf("error retrieving Edge Gateway: %s", err)
-	}
+	url := eGW.EdgeGateway.HREF
 
 	// Empty struct before a new unmarshal, otherwise we end up with duplicate
 	// elements in slices.
 	eGW.EdgeGateway = &types.EdgeGateway{}
 
-	if err = decodeBody(resp, eGW.EdgeGateway); err != nil {
-		return fmt.Errorf("error decoding Edge Gateway response: %s", err)
-	}
+	_, err := eGW.client.ExecuteRequest(url, http.MethodGet,
+		"", "error retrieving Edge Gateway: %s", nil, eGW.EdgeGateway)
 
-	// The request was successful
-	return nil
+	return err
 }
 
 func (eGW *EdgeGateway) Remove1to1Mapping(internal, external string) (Task, error) {
@@ -549,35 +490,12 @@ func (eGW *EdgeGateway) Remove1to1Mapping(internal, external string) (Task, erro
 	// Fix
 	newEdgeConfig.NatService.IsEnabled = true
 
-	output, err := xml.MarshalIndent(newEdgeConfig, "  ", "    ")
-	if err != nil {
-		fmt.Printf("error: %v\n", err)
-	}
-
-	util.Logger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
 	apiEndpoint, _ := url.ParseRequestURI(eGW.EdgeGateway.HREF)
 	apiEndpoint.Path += "/action/configureServices"
 
-	req := eGW.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml")
-
-	resp, err := checkResp(eGW.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error reconfiguring Edge Gateway: %s", err)
-	}
-
-	task := NewTask(eGW.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
+	// Return the task
+	return eGW.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		"application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml", "error reconfiguring Edge Gateway: %s", newEdgeConfig)
 
 }
 
@@ -667,35 +585,12 @@ func (eGW *EdgeGateway) Create1to1Mapping(internal, external, description string
 
 	newEdgeConfig.FirewallService.FirewallRule = append(newEdgeConfig.FirewallService.FirewallRule, fwout)
 
-	output, err := xml.MarshalIndent(newEdgeConfig, "  ", "    ")
-	if err != nil {
-		fmt.Printf("error: %v\n", err)
-	}
-
-	util.Logger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
 	apiEndpoint, _ := url.ParseRequestURI(eGW.EdgeGateway.HREF)
 	apiEndpoint.Path += "/action/configureServices"
 
-	req := eGW.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml")
-
-	resp, err := checkResp(eGW.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error reconfiguring Edge Gateway: %s", err)
-	}
-
-	task := NewTask(eGW.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
+	// Return the task
+	return eGW.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		"application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml", "error reconfiguring Edge Gateway: %s", newEdgeConfig)
 
 }
 
@@ -706,40 +601,12 @@ func (eGW *EdgeGateway) AddIpsecVPN(ipsecVPNConfig *types.EdgeGatewayServiceConf
 		fmt.Printf("error: %v\n", err)
 	}
 
-	output, err := xml.MarshalIndent(ipsecVPNConfig, "  ", "    ")
-	if err != nil {
-		return Task{}, fmt.Errorf("error marshaling ipsecVPNConfig compose: %s", err)
-	}
-
-	util.Logger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-	util.Logger.Printf("[DEBUG] ipsecVPN configuration: %s", buffer)
-
 	apiEndpoint, _ := url.ParseRequestURI(eGW.EdgeGateway.HREF)
 	apiEndpoint.Path += "/action/configureServices"
 
-	req := eGW.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml")
-
-	resp, err := checkResp(eGW.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error reconfiguring Edge Gateway: %s", err)
-	}
-
-	if os.Getenv("GOVCD_DEBUG") != "" {
-		util.Logger.Printf("Edge Gateway Service Configuration: %s\n", prettyEdgeGatewayServiceConfiguration(ipsecVPNConfig))
-	}
-
-	task := NewTask(eGW.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
+	// Return the task
+	return eGW.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		"application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml", "error reconfiguring Edge Gateway: %s", ipsecVPNConfig)
 
 }
 

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/media.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/media.go
@@ -132,7 +132,7 @@ func createMedia(client *Client, link, mediaName, mediaDescription string, fileS
 	}
 
 	reqBody := bytes.NewBufferString(
-		"<Media xmlns=\"http://www.vmware.com/vcloud/v1.5\" name=\"" + mediaName + "\" imageType=\"" + "iso" + "\" size=\"" + strconv.FormatInt(fileSize, 10) + "\" >" +
+		"<Media xmlns=\"" + types.XMLNamespaceVCloud + "\" name=\"" + mediaName + "\" imageType=\"" + "iso" + "\" size=\"" + strconv.FormatInt(fileSize, 10) + "\" >" +
 			"<Description>" + mediaDescription + "</Description>" +
 			"</Media>")
 

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/media.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/media.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"strconv"
@@ -135,7 +136,7 @@ func createMedia(client *Client, link, mediaName, mediaDescription string, fileS
 			"<Description>" + mediaDescription + "</Description>" +
 			"</Media>")
 
-	request := client.NewRequest(map[string]string{}, "POST", *uploadUrl, reqBody)
+	request := client.NewRequest(map[string]string{}, http.MethodPost, *uploadUrl, reqBody)
 	request.Header.Add("Content-Type", "application/vnd.vmware.vcloud.media+xml")
 
 	response, err := checkResp(client.Http.Do(request))
@@ -200,23 +201,13 @@ func removeImageOnError(client *Client, media *types.Media, itemName string) {
 func queryMedia(client *Client, mediaUrl string, newItemName string) (*types.Media, error) {
 	util.Logger.Printf("[TRACE] Querying media: %s\n", mediaUrl)
 
-	parsedUrl, err := url.ParseRequestURI(mediaUrl)
-	if err != nil {
-		util.Logger.Printf("[Error] Error parsing url %v: %s", parsedUrl, err)
-	}
-
-	request := client.NewRequest(map[string]string{}, "GET", *parsedUrl, nil)
-	response, err := checkResp(client.Http.Do(request))
-	if err != nil {
-		return nil, err
-	}
-
 	mediaParsed := &types.Media{}
-	if err = decodeBody(response, mediaParsed); err != nil {
+
+	_, err := client.ExecuteRequest(mediaUrl, http.MethodGet,
+		"", "error quering media: %s", nil, mediaParsed)
+	if err != nil {
 		return nil, err
 	}
-
-	defer response.Body.Close()
 
 	for _, task := range mediaParsed.Tasks.Task {
 		if "error" == task.Status && newItemName == task.Owner.Name {
@@ -321,27 +312,9 @@ func RemoveMediaImageIfExists(vdc Vdc, mediaName string) error {
 func (mediaItem *MediaItem) Delete() (Task, error) {
 	util.Logger.Printf("[TRACE] Deleting media item: %#v", mediaItem.MediaItem.Name)
 
-	parsedUrl, err := url.ParseRequestURI(mediaItem.MediaItem.HREF)
-	if err != nil {
-		util.Logger.Printf("[Error] Error parsing url %v: %s", parsedUrl, err)
-	}
-	util.Logger.Printf("[TRACE] Url for deleting media item: %#v and name: %s", parsedUrl, mediaItem.MediaItem.Name)
-
-	req := mediaItem.client.NewRequest(map[string]string{}, "DELETE", *parsedUrl, nil)
-
-	resp, err := checkResp(mediaItem.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error deleting Media item %s: %s", mediaItem.MediaItem.ID, err)
-	}
-
-	task := NewTask(mediaItem.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
+	// Return the task
+	return mediaItem.client.ExecuteTaskRequest(mediaItem.MediaItem.HREF, http.MethodDelete,
+		"", "error deleting Media item: %s", nil)
 }
 
 // Finds media in catalog and returns catalog item

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/org.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/org.go
@@ -166,7 +166,7 @@ func CreateCatalog(client *Client, links types.LinkList, Name, Description strin
 		Description: Description,
 	}
 	vcomp := &types.AdminCatalog{
-		Xmlns:   "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:   types.XMLNamespaceVCloud,
 		Catalog: *reqCatalog,
 	}
 
@@ -375,7 +375,7 @@ func (adminOrg *AdminOrg) Disable() error {
 //   API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/PUT-Organization.html
 func (adminOrg *AdminOrg) Update() (Task, error) {
 	vcomp := &types.AdminOrg{
-		Xmlns:       "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:       types.XMLNamespaceVCloud,
 		Name:        adminOrg.AdminOrg.Name,
 		IsEnabled:   adminOrg.AdminOrg.IsEnabled,
 		FullName:    adminOrg.AdminOrg.FullName,

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/org.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/org.go
@@ -5,10 +5,9 @@
 package govcd
 
 import (
-	"bytes"
-	"encoding/xml"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -45,19 +44,18 @@ func (org *Org) Refresh() error {
 	if *org == (Org{}) {
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
-	orgHREF, _ := url.ParseRequestURI(org.Org.HREF)
-	req := org.client.NewRequest(map[string]string{}, "GET", *orgHREF, nil)
-	resp, err := checkResp(org.client.Http.Do(req))
-	if err != nil {
-		return fmt.Errorf("error performing request: %s", err)
-	}
+
 	// Empty struct before a new unmarshal, otherwise we end up with duplicate
 	// elements in slices.
 	unmarshalledOrg := &types.Org{}
-	if err = decodeBody(resp, unmarshalledOrg); err != nil {
-		return fmt.Errorf("error decoding org response: %s", err)
+
+	_, err := org.client.ExecuteRequest(org.Org.HREF, http.MethodGet,
+		"", "error refreshing organization: %s", nil, unmarshalledOrg)
+	if err != nil {
+		return err
 	}
 	org.Org = unmarshalledOrg
+
 	// The request was successful
 	return nil
 }
@@ -69,28 +67,13 @@ func (org *Org) FindCatalog(catalogName string) (Catalog, error) {
 
 	for _, link := range org.Org.Link {
 		if link.Rel == "down" && link.Type == "application/vnd.vmware.vcloud.catalog+xml" && link.Name == catalogName {
-			orgHREF, err := url.ParseRequestURI(link.HREF)
-
-			if err != nil {
-				return Catalog{}, fmt.Errorf("error decoding org response: %s", err)
-			}
-
-			req := org.client.NewRequest(map[string]string{}, "GET", *orgHREF, nil)
-
-			resp, err := checkResp(org.client.Http.Do(req))
-			if err != nil {
-				return Catalog{}, fmt.Errorf("error retrieving catalog: %s", err)
-			}
 
 			cat := NewCatalog(org.client)
 
-			if err = decodeBody(resp, cat.Catalog); err != nil {
-				return Catalog{}, fmt.Errorf("error decoding catalog response: %s", err)
-			}
+			_, err := org.client.ExecuteRequest(link.HREF, http.MethodGet,
+				"", "error retrieving catalog: %s", nil, cat.Catalog)
 
-			// The request was successful
-			return *cat, nil
-
+			return *cat, err
 		}
 	}
 
@@ -103,22 +86,12 @@ func (org *Org) FindCatalog(catalogName string) (Catalog, error) {
 func (org *Org) GetVdcByName(vdcname string) (Vdc, error) {
 	for _, link := range org.Org.Link {
 		if link.Name == vdcname {
-			vdcHREF, err := url.ParseRequestURI(link.HREF)
-			if err != nil {
-				return Vdc{}, fmt.Errorf("Error parsing url: %v", err)
-			}
-			req := org.client.NewRequest(map[string]string{}, "GET", *vdcHREF, nil)
-			resp, err := checkResp(org.client.Http.Do(req))
-			if err != nil {
-				return Vdc{}, fmt.Errorf("error getting vdc: %s", err)
-			}
-
 			vdc := NewVdc(org.client)
-			if err = decodeBody(resp, vdc.Vdc); err != nil {
-				return Vdc{}, fmt.Errorf("error decoding vdc response: %s", err)
-			}
-			// The request was successful
-			return *vdc, nil
+
+			_, err := org.client.ExecuteRequest(link.HREF, http.MethodGet,
+				"", "error retrieving vdc: %s", nil, vdc.Vdc)
+
+			return *vdc, err
 		}
 	}
 	return Vdc{}, nil
@@ -150,20 +123,18 @@ func (adminOrg *AdminOrg) Refresh() error {
 	if *adminOrg == (AdminOrg{}) {
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
-	adminOrgHREF, _ := url.ParseRequestURI(adminOrg.AdminOrg.HREF)
-	req := adminOrg.client.NewRequest(map[string]string{}, "GET", *adminOrgHREF, nil)
-	resp, err := checkResp(adminOrg.client.Http.Do(req))
-	if err != nil {
-		return fmt.Errorf("error performing request: %s", err)
-	}
+
 	// Empty struct before a new unmarshal, otherwise we end up with duplicate
 	// elements in slices.
 	unmarshalledAdminOrg := &types.AdminOrg{}
-	if err = decodeBody(resp, unmarshalledAdminOrg); err != nil {
-		return fmt.Errorf("error decoding org response: %s", err)
+
+	_, err := adminOrg.client.ExecuteRequest(adminOrg.AdminOrg.HREF, http.MethodGet,
+		"", "error refreshing organization: %s", nil, unmarshalledAdminOrg)
+	if err != nil {
+		return err
 	}
 	adminOrg.AdminOrg = unmarshalledAdminOrg
-	// The request was successful
+
 	return nil
 }
 
@@ -212,28 +183,11 @@ func CreateCatalog(client *Client, links types.LinkList, Name, Description strin
 		return AdminCatalog{}, fmt.Errorf("creating catalog failed to find url")
 	}
 
-	catalogHREF, err := url.ParseRequestURI(createOrgLink.HREF)
-	if err != nil {
-		return AdminCatalog{}, fmt.Errorf("error parsing admin org's href: %v", err)
-	}
-
-	output, _ := xml.MarshalIndent(vcomp, "  ", "    ")
-	xmlData := bytes.NewBufferString(xml.Header + string(output))
-
-	req := client.NewRequest(map[string]string{}, "POST", *catalogHREF, xmlData)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.admin.catalog+xml")
-
-	resp, err := checkResp(client.Http.Do(req))
-	if err != nil {
-		return AdminCatalog{}, fmt.Errorf("error creating catalog: %s : %s", err, catalogHREF.Path)
-	}
 	catalog := NewAdminCatalog(client)
-	if err = decodeBody(resp, catalog.AdminCatalog); err != nil {
-		return AdminCatalog{}, fmt.Errorf("error decoding task response: %s", err)
-	}
-	// Task is within the catalog
-	return *catalog, nil
+	_, err := client.ExecuteRequest(createOrgLink.HREF, http.MethodPost,
+		"application/vnd.vmware.admin.catalog+xml", "error creating catalog: %s", vcomp, catalog.AdminCatalog)
+
+	return *catalog, err
 }
 
 // If user specifies valid vdc name then this returns a vdc object.
@@ -253,22 +207,12 @@ func (adminOrg *AdminOrg) GetVdcByName(vdcname string) (Vdc, error) {
 				vdcHREF = splitByAdminHREF[0] + "/api" + splitByAdminHREF[1]
 			}
 
-			vdcURL, err := url.ParseRequestURI(vdcHREF)
-			if err != nil {
-				return Vdc{}, fmt.Errorf("error parsing url: %v", err)
-			}
-			req := adminOrg.client.NewRequest(map[string]string{}, "GET", *vdcURL, nil)
-			resp, err := checkResp(adminOrg.client.Http.Do(req))
-			if err != nil {
-				return Vdc{}, fmt.Errorf("error getting vdc: %s", err)
-			}
-
 			vdc := NewVdc(adminOrg.client)
-			if err = decodeBody(resp, vdc.Vdc); err != nil {
-				return Vdc{}, fmt.Errorf("error decoding vdc response: %s", err)
-			}
-			// The request was successful
-			return *vdc, nil
+
+			_, err := adminOrg.client.ExecuteRequest(vdcHREF, http.MethodGet,
+				"", "error getting vdc: %s", nil, vdc.Vdc)
+
+			return *vdc, err
 		}
 	}
 	return Vdc{}, nil
@@ -328,29 +272,22 @@ func (org *AdminOrg) CreateVdc(vdcConfiguration *types.VdcConfiguration) (Task, 
 	if err != nil {
 		return Task{}, err
 	}
-	output, err := xml.MarshalIndent(vdcConfiguration, "  ", "    ")
-	if err != nil {
-		return Task{}, fmt.Errorf("error marshalling xml: %s", err)
-	}
-	xmlData := bytes.NewBufferString(xml.Header + string(output))
-	util.Logger.Printf("[TRACE] AdminOrg.CreateVdc - xml payload: %s\n", xmlData)
+
 	vdcCreateHREF, err := url.ParseRequestURI(org.AdminOrg.HREF)
 	if err != nil {
 		return Task{}, fmt.Errorf("error parsing admin org url: %s", err)
 	}
 	vdcCreateHREF.Path += "/vdcsparams"
-	req := org.client.NewRequest(map[string]string{}, "POST", *vdcCreateHREF, xmlData)
-	req.Header.Add("Content-Type", "application/vnd.vmware.admin.createVdcParams+xml")
-	resp, err := checkResp(org.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error instantiating a new VDC: %s", err)
-	}
 
 	adminVdc := NewAdminVdc(org.client)
-	if err = decodeBody(resp, adminVdc.AdminVdc); err != nil {
-		return Task{}, fmt.Errorf("error decoding admin VDC response: %s", err)
+
+	_, err = org.client.ExecuteRequest(vdcCreateHREF.String(), http.MethodPost,
+		"application/vnd.vmware.admin.createVdcParams+xml", "error retrieving vdc: %s", vdcConfiguration, adminVdc.AdminVdc)
+	if err != nil {
+		return Task{}, err
 	}
 
+	// Return the task
 	task := NewTask(org.client)
 	task.Task = adminVdc.AdminVdc.Tasks.Task[0]
 	return *task, nil
@@ -412,7 +349,7 @@ func (adminOrg *AdminOrg) Delete(force bool, recursive bool) error {
 	req := adminOrg.client.NewRequest(map[string]string{
 		"force":     strconv.FormatBool(force),
 		"recursive": strconv.FormatBool(recursive),
-	}, "DELETE", *orgHREF, nil)
+	}, http.MethodDelete, *orgHREF, nil)
 	_, err = checkResp(adminOrg.client.Http.Do(req))
 	if err != nil {
 		return fmt.Errorf("error deleting Org %s: %s", adminOrg.AdminOrg.ID, err)
@@ -428,9 +365,8 @@ func (adminOrg *AdminOrg) Disable() error {
 		return fmt.Errorf("error getting AdminOrg HREF %s : %v", adminOrg.AdminOrg.HREF, err)
 	}
 	orgHREF.Path += "/action/disable"
-	req := adminOrg.client.NewRequest(map[string]string{}, "POST", *orgHREF, nil)
-	_, err = checkResp(adminOrg.client.Http.Do(req))
-	return err
+
+	return adminOrg.client.ExecuteRequestWithoutResponse(orgHREF.String(), http.MethodPost, "", "error disabling organization: %s", nil)
 }
 
 //   Updates the Org definition from current org struct contents.
@@ -445,25 +381,10 @@ func (adminOrg *AdminOrg) Update() (Task, error) {
 		FullName:    adminOrg.AdminOrg.FullName,
 		OrgSettings: adminOrg.AdminOrg.OrgSettings,
 	}
-	output, _ := xml.MarshalIndent(vcomp, "  ", "    ")
-	xmlData := bytes.NewBufferString(xml.Header + string(output))
-	// Update org
-	orgHREF, err := url.ParseRequestURI(adminOrg.AdminOrg.HREF)
-	if err != nil {
-		return Task{}, fmt.Errorf("error getting AdminOrg HREF %s : %v", adminOrg.AdminOrg.HREF, err)
-	}
-	req := adminOrg.client.NewRequest(map[string]string{}, "PUT", *orgHREF, xmlData)
-	req.Header.Add("Content-Type", "application/vnd.vmware.admin.organization+xml")
-	resp, err := checkResp(adminOrg.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error updating Org: %s", err)
-	}
-	// Create Return object
-	task := NewTask(adminOrg.client)
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding task response: %s", err)
-	}
-	return *task, nil
+
+	// Return the task
+	return adminOrg.client.ExecuteTaskRequest(adminOrg.AdminOrg.HREF, http.MethodPut,
+		"application/vnd.vmware.admin.organization+xml", "error updating Org: %s", vcomp)
 }
 
 // Undeploys every vapp within an organization
@@ -510,17 +431,12 @@ func (adminOrg *AdminOrg) getVdcByAdminHREF(adminVdcUrl *url.URL) (*Vdc, error) 
 	vdcURL := adminOrg.client.VCDHREF
 	vdcURL.Path += strings.Split(adminVdcUrl.Path, "/api/admin")[1] //gets id
 
-	req := adminOrg.client.NewRequest(map[string]string{}, "GET", vdcURL, nil)
-	resp, err := checkResp(adminOrg.client.Http.Do(req))
-	if err != nil {
-		return &Vdc{}, fmt.Errorf("error retrieving vdc: %s", err)
-	}
-
 	vdc := NewVdc(adminOrg.client)
-	if err = decodeBody(resp, vdc.Vdc); err != nil {
-		return &Vdc{}, fmt.Errorf("error decoding vdc response: %s", err)
-	}
-	return vdc, nil
+
+	_, err := adminOrg.client.ExecuteRequest(vdcURL.String(), http.MethodGet,
+		"", "error retrieving vdc: %s", nil, vdc.Vdc)
+
+	return vdc, err
 }
 
 // Removes all vdcs in a org
@@ -531,7 +447,7 @@ func (adminOrg *AdminOrg) removeAllOrgVDCs() error {
 		adminVdcUrl := adminOrg.client.VCDHREF
 		adminVdcUrl.Path += "/admin/vdc/" + strings.Split(vdcs.HREF, "/api/vdc/")[1] + "/action/disable"
 
-		req := adminOrg.client.NewRequest(map[string]string{}, "POST", adminVdcUrl, nil)
+		req := adminOrg.client.NewRequest(map[string]string{}, http.MethodPost, adminVdcUrl, nil)
 		_, err := checkResp(adminOrg.client.Http.Do(req))
 		if err != nil {
 			return fmt.Errorf("error disabling vdc: %s", err)
@@ -541,7 +457,7 @@ func (adminOrg *AdminOrg) removeAllOrgVDCs() error {
 		req = adminOrg.client.NewRequest(map[string]string{
 			"recursive": "true",
 			"force":     "true",
-		}, "DELETE", adminVdcUrl, nil)
+		}, http.MethodDelete, adminVdcUrl, nil)
 		resp, err := checkResp(adminOrg.client.Http.Do(req))
 		if err != nil {
 			return fmt.Errorf("error deleting vdc: %s", err)
@@ -569,22 +485,19 @@ func (adminOrg *AdminOrg) removeAllOrgNetworks() error {
 		// Get Network HREF
 		networkHREF := adminOrg.client.VCDHREF
 		networkHREF.Path += "/admin/network/" + strings.Split(networks.HREF, "/api/admin/network/")[1] //gets id
-		req := adminOrg.client.NewRequest(map[string]string{}, "DELETE", networkHREF, nil)
-		resp, err := checkResp(adminOrg.client.Http.Do(req))
+
+		task, err := adminOrg.client.ExecuteTaskRequest(networkHREF.String(), http.MethodDelete,
+			"", "error deleting network: %s", nil)
 		if err != nil {
-			return fmt.Errorf("error deleting newtork: %s, %s", err, networkHREF.Path)
+			return err
 		}
 
-		task := NewTask(adminOrg.client)
-		if err = decodeBody(resp, task.Task); err != nil {
-			return fmt.Errorf("error decoding task response: %s", err)
-		}
 		if task.Task.Status == "error" {
 			return fmt.Errorf("network not properly destroyed")
 		}
 		err = task.WaitTaskCompletion()
 		if err != nil {
-			return fmt.Errorf("Couldn't finish removing network %#v", err)
+			return fmt.Errorf("couldn't finish removing network %#v", err)
 		}
 	}
 	return nil
@@ -599,7 +512,7 @@ func (adminOrg *AdminOrg) removeCatalogs() error {
 		req := adminOrg.client.NewRequest(map[string]string{
 			"force":     "true",
 			"recursive": "true",
-		}, "DELETE", catalogHREF, nil)
+		}, http.MethodDelete, catalogHREF, nil)
 		_, err := checkResp(adminOrg.client.Http.Do(req))
 		if err != nil {
 			return fmt.Errorf("error deleting catalog: %s, %s", err, catalogHREF.Path)
@@ -616,24 +529,17 @@ func (adminOrg *AdminOrg) removeCatalogs() error {
 // perform administrator tasks then function returns an error.
 // API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/GET-Catalog-AdminView.html
 func (adminOrg *AdminOrg) FindAdminCatalog(catalogName string) (AdminCatalog, error) {
-	for _, adminCatalog := range adminOrg.AdminOrg.Catalogs.Catalog {
+	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
 		// Get Catalog HREF
-		if adminCatalog.Name == catalogName {
-			catalogURL, err := url.ParseRequestURI(adminCatalog.HREF)
-			if err != nil {
-				return AdminCatalog{}, fmt.Errorf("error decoding catalog url: %s", err)
-			}
-			req := adminOrg.client.NewRequest(map[string]string{}, "GET", *catalogURL, nil)
-			resp, err := checkResp(adminOrg.client.Http.Do(req))
-			if err != nil {
-				return AdminCatalog{}, fmt.Errorf("error retrieving catalog: %s", err)
-			}
+		if catalog.Name == catalogName {
+
 			adminCatalog := NewAdminCatalog(adminOrg.client)
-			if err = decodeBody(resp, adminCatalog.AdminCatalog); err != nil {
-				return AdminCatalog{}, fmt.Errorf("error decoding catalog response: %s", err)
-			}
+
+			_, err := adminOrg.client.ExecuteRequest(catalog.HREF, http.MethodGet,
+				"", "error retrieving catalog: %s", nil, adminCatalog.AdminCatalog)
+
 			// The request was successful
-			return *adminCatalog, nil
+			return *adminCatalog, err
 		}
 	}
 	return AdminCatalog{}, nil
@@ -649,19 +555,14 @@ func (adminOrg *AdminOrg) FindCatalog(catalogName string) (Catalog, error) {
 		if catalog.Name == catalogName {
 			catalogURL := adminOrg.client.VCDHREF
 			catalogURL.Path += "/catalog/" + strings.Split(catalog.HREF, "/api/admin/catalog/")[1] //gets id
-			req := adminOrg.client.NewRequest(map[string]string{}, "GET", catalogURL, nil)
-			resp, err := checkResp(adminOrg.client.Http.Do(req))
-			if err != nil {
-				return Catalog{}, fmt.Errorf("error retrieving catalog: %s", err)
-			}
+
 			cat := NewCatalog(adminOrg.client)
 
-			if err = decodeBody(resp, cat.Catalog); err != nil {
-				return Catalog{}, fmt.Errorf("error decoding catalog response: %s", err)
-			}
+			_, err := adminOrg.client.ExecuteRequest(catalogURL.String(), http.MethodGet,
+				"", "error retrieving catalog: %s", nil, cat.Catalog)
 
 			// The request was successful
-			return *cat, nil
+			return *cat, err
 		}
 	}
 	return Catalog{}, nil

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/query.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/query.go
@@ -23,19 +23,19 @@ func NewResults(cli *Client) *Results {
 	}
 }
 
-func (vdcCli *VCDClient) Query(params map[string]string) (Results, error) {
+func (vcdCli *VCDClient) Query(params map[string]string) (Results, error) {
 
-	req := vdcCli.Client.NewRequest(params, "GET", vdcCli.QueryHREF, nil)
-	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vdcCli.Client.APIVersion)
+	req := vcdCli.Client.NewRequest(params, "GET", vcdCli.QueryHREF, nil)
+	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vcdCli.Client.APIVersion)
 
-	return getResult(&vdcCli.Client, req)
+	return getResult(&vcdCli.Client, req)
 }
 
-func (vdcCli *VCDClient) QueryWithNotEncodedParams(params map[string]string, notEncodedParams map[string]string) (Results, error) {
-	req := vdcCli.Client.NewRequestWitNotEncodedParams(params, notEncodedParams, "GET", vdcCli.QueryHREF, nil)
-	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vdcCli.Client.APIVersion)
+func (vcdCli *VCDClient) QueryWithNotEncodedParams(params map[string]string, notEncodedParams map[string]string) (Results, error) {
+	req := vcdCli.Client.NewRequestWitNotEncodedParams(params, notEncodedParams, "GET", vcdCli.QueryHREF, nil)
+	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vcdCli.Client.APIVersion)
 
-	return getResult(&vdcCli.Client, req)
+	return getResult(&vcdCli.Client, req)
 }
 
 func (vdc *Vdc) Query(params map[string]string) (Results, error) {

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/query.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/query.go
@@ -25,14 +25,14 @@ func NewResults(cli *Client) *Results {
 
 func (vcdCli *VCDClient) Query(params map[string]string) (Results, error) {
 
-	req := vcdCli.Client.NewRequest(params, "GET", vcdCli.QueryHREF, nil)
+	req := vcdCli.Client.NewRequest(params, http.MethodGet, vcdCli.QueryHREF, nil)
 	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vcdCli.Client.APIVersion)
 
 	return getResult(&vcdCli.Client, req)
 }
 
 func (vcdCli *VCDClient) QueryWithNotEncodedParams(params map[string]string, notEncodedParams map[string]string) (Results, error) {
-	req := vcdCli.Client.NewRequestWitNotEncodedParams(params, notEncodedParams, "GET", vcdCli.QueryHREF, nil)
+	req := vcdCli.Client.NewRequestWitNotEncodedParams(params, notEncodedParams, http.MethodGet, vcdCli.QueryHREF, nil)
 	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vcdCli.Client.APIVersion)
 
 	return getResult(&vcdCli.Client, req)
@@ -41,7 +41,7 @@ func (vcdCli *VCDClient) QueryWithNotEncodedParams(params map[string]string, not
 func (vdc *Vdc) Query(params map[string]string) (Results, error) {
 	queryUrl := vdc.client.VCDHREF
 	queryUrl.Path += "/query"
-	req := vdc.client.NewRequest(params, "GET", queryUrl, nil)
+	req := vdc.client.NewRequest(params, http.MethodGet, queryUrl, nil)
 	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vdc.client.APIVersion)
 
 	return getResult(vdc.client, req)
@@ -50,7 +50,7 @@ func (vdc *Vdc) Query(params map[string]string) (Results, error) {
 func (vdc *Vdc) QueryWithNotEncodedParams(params map[string]string, notEncodedParams map[string]string) (Results, error) {
 	queryUrl := vdc.client.VCDHREF
 	queryUrl.Path += "/query"
-	req := vdc.client.NewRequestWitNotEncodedParams(params, notEncodedParams, "GET", queryUrl, nil)
+	req := vdc.client.NewRequestWitNotEncodedParams(params, notEncodedParams, http.MethodGet, queryUrl, nil)
 	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vdc.client.APIVersion)
 
 	return getResult(vdc.client, req)

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/system.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/system.go
@@ -25,7 +25,7 @@ import (
 // Overall elements must be in the correct order.
 func CreateOrg(vcdClient *VCDClient, name string, fullName string, description string, settings *types.OrgSettings, isEnabled bool) (Task, error) {
 	vcomp := &types.AdminOrg{
-		Xmlns:       "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:       types.XMLNamespaceVCloud,
 		Name:        name,
 		IsEnabled:   isEnabled,
 		FullName:    fullName,

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/system.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/system.go
@@ -5,10 +5,8 @@
 package govcd
 
 import (
-	"bytes"
-	"encoding/xml"
 	"fmt"
-	"net/url"
+	"net/http"
 	"strings"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
@@ -34,23 +32,14 @@ func CreateOrg(vcdClient *VCDClient, name string, fullName string, description s
 		Description: description,
 		OrgSettings: settings,
 	}
-	output, _ := xml.MarshalIndent(vcomp, "  ", "    ")
-	xmlData := bytes.NewBufferString(xml.Header + string(output))
-	// Make Request
+
 	orgCreateHREF := vcdClient.Client.VCDHREF
 	orgCreateHREF.Path += "/admin/orgs"
-	req := vcdClient.Client.NewRequest(map[string]string{}, "POST", orgCreateHREF, xmlData)
-	req.Header.Add("Content-Type", "application/vnd.vmware.admin.organization+xml")
-	resp, err := checkResp(vcdClient.Client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error instantiating a new Org: %s", err)
-	}
 
-	task := NewTask(&vcdClient.Client)
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding task response: %s", err)
-	}
-	return *task, nil
+	// Return the task
+	return vcdClient.Client.ExecuteTaskRequest(orgCreateHREF.String(), http.MethodPost,
+		"application/vnd.vmware.admin.organization+xml", "error instantiating a new Org: %s", vcomp)
+
 }
 
 // If user specifies a valid organization name, then this returns a
@@ -62,20 +51,14 @@ func GetOrgByName(vcdClient *VCDClient, orgName string) (Org, error) {
 	if err != nil {
 		return Org{}, fmt.Errorf("organization '%s' fetch failed: %#v", orgName, err)
 	}
-	orgHREF, err := url.ParseRequestURI(orgUrl)
+	org := NewOrg(&vcdClient.Client)
+
+	_, err = vcdClient.Client.ExecuteRequest(orgUrl, http.MethodGet,
+		"", "error retrieving org list: %s", nil, org.Org)
 	if err != nil {
-		return Org{}, fmt.Errorf("error parsing org href: %v", err)
-	}
-	req := vcdClient.Client.NewRequest(map[string]string{}, "GET", *orgHREF, nil)
-	resp, err := checkResp(vcdClient.Client.Http.Do(req))
-	if err != nil {
-		return Org{}, fmt.Errorf("error retrieving org: %s", err)
+		return Org{}, err
 	}
 
-	org := NewOrg(&vcdClient.Client)
-	if err = decodeBody(resp, org.Org); err != nil {
-		return Org{}, fmt.Errorf("error decoding org response: %s", err)
-	}
 	return *org, nil
 }
 
@@ -93,15 +76,14 @@ func GetAdminOrgByName(vcdClient *VCDClient, orgName string) (AdminOrg, error) {
 	orgHREF := vcdClient.Client.VCDHREF
 	orgHREF.Path += "/admin/org/" + strings.Split(orgUrl, "/api/org/")[1]
 
-	req := vcdClient.Client.NewRequest(map[string]string{}, "GET", orgHREF, nil)
-	resp, err := checkResp(vcdClient.Client.Http.Do(req))
-	if err != nil {
-		return AdminOrg{}, fmt.Errorf("error retrieving org: %s", err)
-	}
 	org := NewAdminOrg(&vcdClient.Client)
-	if err = decodeBody(resp, org.AdminOrg); err != nil {
-		return AdminOrg{}, fmt.Errorf("error decoding org response: %s", err)
+
+	_, err = vcdClient.Client.ExecuteRequest(orgHREF.String(), http.MethodGet,
+		"", "error retrieving org: %s", nil, org.AdminOrg)
+	if err != nil {
+		return AdminOrg{}, err
 	}
+
 	return *org, nil
 }
 
@@ -109,15 +91,15 @@ func GetAdminOrgByName(vcdClient *VCDClient, orgName string) (AdminOrg, error) {
 func getOrgHREF(vcdClient *VCDClient, orgName string) (string, error) {
 	orgListHREF := vcdClient.Client.VCDHREF
 	orgListHREF.Path += "/org"
-	req := vcdClient.Client.NewRequest(map[string]string{}, "GET", orgListHREF, nil)
-	resp, err := checkResp(vcdClient.Client.Http.Do(req))
-	if err != nil {
-		return "", fmt.Errorf("error retrieving org list: %s", err)
-	}
+
 	orgList := new(types.OrgList)
-	if err = decodeBody(resp, orgList); err != nil {
-		return "", fmt.Errorf("error decoding response: %s", err)
+
+	_, err := vcdClient.Client.ExecuteRequest(orgListHREF.String(), http.MethodGet,
+		"", "error retrieving org list: %s", nil, orgList)
+	if err != nil {
+		return "", err
 	}
+
 	// Look for orgName within OrgList
 	for _, org := range orgList.Org {
 		if org.Name == orgName {

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/task.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/task.go
@@ -6,6 +6,7 @@ package govcd
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"time"
@@ -54,7 +55,7 @@ func (task *Task) Refresh() error {
 
 	refreshUrl, _ := url.ParseRequestURI(task.Task.HREF)
 
-	req := task.client.NewRequest(map[string]string{}, "GET", *refreshUrl, nil)
+	req := task.client.NewRequest(map[string]string{}, http.MethodGet, *refreshUrl, nil)
 
 	resp, err := checkResp(task.client.Http.Do(req))
 	if err != nil {
@@ -169,7 +170,7 @@ func (task *Task) CancelTask() error {
 		return err
 	}
 
-	request := task.client.NewRequest(map[string]string{}, "POST", *cancelTaskURL, nil)
+	request := task.client.NewRequest(map[string]string{}, http.MethodPost, *cancelTaskURL, nil)
 	_, err = checkResp(task.client.Http.Do(request))
 	if err != nil {
 		util.Logger.Printf("[Error] Error cancelling task  %v: %s", cancelTaskURL.String(), err)

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/upload.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/upload.go
@@ -113,7 +113,7 @@ func uploadFile(client *Client, filePath string, uDetails uploadDetails) (int64,
 func newFileUploadRequest(requestUrl string, filePart []byte, offset, filePartSize, fileSizeToUpload int64) (*http.Request, error) {
 	util.Logger.Printf("[TRACE] Creating file upload request: %s, %v, %v, %v \n", requestUrl, offset, filePartSize, fileSizeToUpload)
 
-	uploadReq, err := http.NewRequest("PUT", requestUrl, bytes.NewReader(filePart))
+	uploadReq, err := http.NewRequest(http.MethodPut, requestUrl, bytes.NewReader(filePart))
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func createTaskForVcdImport(client *Client, taskHREF string) (Task, error) {
 		return Task{}, err
 	}
 
-	request := client.NewRequest(map[string]string{}, "GET", *taskURL, nil)
+	request := client.NewRequest(map[string]string{}, http.MethodGet, *taskURL, nil)
 	response, err := checkResp(client.Http.Do(request))
 	if err != nil {
 		return Task{}, err

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vapp.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vapp.go
@@ -29,7 +29,7 @@ func NewVApp(cli *Client) *VApp {
 	}
 }
 
-func (vdcCli *VCDClient) NewVApp(client *Client) VApp {
+func (vcdCli *VCDClient) NewVApp(client *Client) VApp {
 	newvapp := NewVApp(client)
 	return *newvapp
 }

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vapp.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vapp.go
@@ -110,9 +110,9 @@ func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName s
 	}
 
 	vcomp := &types.ReComposeVAppParams{
-		Ovf:         "http://schemas.dmtf.org/ovf/envelope/1",
-		Xsi:         "http://www.w3.org/2001/XMLSchema-instance",
-		Xmlns:       "http://www.vmware.com/vcloud/v1.5",
+		Ovf:         types.XMLNamespaceOVF,
+		Xsi:         types.XMLNamespaceXSI,
+		Xmlns:       types.XMLNamespaceVCloud,
 		Deploy:      false,
 		Name:        vapp.VApp.Name,
 		PowerOn:     false,
@@ -140,7 +140,7 @@ func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName s
 				Network:                 orgVdcNetwork.Name,
 				NetworkConnectionIndex:  index,
 				IsConnected:             true,
-				IPAddressAllocationMode: "POOL",
+				IPAddressAllocationMode: types.IPAllocationModePool,
 			},
 		)
 		vcomp.SourcedItem.NetworkAssignment = append(vcomp.SourcedItem.NetworkAssignment,
@@ -157,7 +157,7 @@ func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName s
 				Network:                 vappNetworkName,
 				NetworkConnectionIndex:  len(orgVdcNetworks),
 				IsConnected:             true,
-				IPAddressAllocationMode: "POOL",
+				IPAddressAllocationMode: types.IPAllocationModePool,
 			},
 		)
 		vcomp.SourcedItem.NetworkAssignment = append(vcomp.SourcedItem.NetworkAssignment,
@@ -192,9 +192,9 @@ func (vapp *VApp) RemoveVM(vm VM) error {
 	}
 
 	vcomp := &types.ReComposeVAppParams{
-		Ovf:   "http://schemas.dmtf.org/ovf/envelope/1",
-		Xsi:   "http://www.w3.org/2001/XMLSchema-instance",
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Ovf:   types.XMLNamespaceOVF,
+		Xsi:   types.XMLNamespaceXSI,
+		Xmlns: types.XMLNamespaceVCloud,
 		DeleteItem: &types.DeleteItem{
 			HREF: vm.VM.HREF,
 		},
@@ -286,7 +286,7 @@ func (vapp *VApp) Shutdown() (Task, error) {
 func (vapp *VApp) Undeploy() (Task, error) {
 
 	vu := &types.UndeployVAppParams{
-		Xmlns:               "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:               types.XMLNamespaceVCloud,
 		UndeployPowerAction: "powerOff",
 	}
 
@@ -301,7 +301,7 @@ func (vapp *VApp) Undeploy() (Task, error) {
 func (vapp *VApp) Deploy() (Task, error) {
 
 	vu := &types.DeployVAppParams{
-		Xmlns:   "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:   types.XMLNamespaceVCloud,
 		PowerOn: false,
 	}
 
@@ -336,9 +336,9 @@ func (vapp *VApp) Customize(computername, script string, changeSid bool) (Task, 
 	}
 
 	vu := &types.GuestCustomizationSection{
-		Ovf:   "http://schemas.dmtf.org/ovf/envelope/1",
-		Xsi:   "http://www.w3.org/2001/XMLSchema-instance",
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Ovf:   types.XMLNamespaceOVF,
+		Xsi:   types.XMLNamespaceXSI,
+		Xmlns: types.XMLNamespaceVCloud,
 
 		HREF:                vapp.VApp.Children.VM[0].HREF,
 		Type:                types.MimeGuestCustomizationSection,
@@ -431,10 +431,10 @@ func (vapp *VApp) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *in
 	}
 
 	newcpu := &types.OVFItem{
-		XmlnsRasd:       "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData",
-		XmlnsVCloud:     "http://www.vmware.com/vcloud/v1.5",
-		XmlnsXsi:        "http://www.w3.org/2001/XMLSchema-instance",
-		XmlnsVmw:        "http://www.vmware.com/schema/ovf",
+		XmlnsRasd:       types.XMLNamespaceRASD,
+		XmlnsVCloud:     types.XMLNamespaceVCloud,
+		XmlnsXsi:        types.XMLNamespaceXSI,
+		XmlnsVmw:        types.XMLNamespaceVMW,
 		VCloudHREF:      vapp.VApp.Children.VM[0].HREF + "/virtualHardwareSection/cpu",
 		VCloudType:      types.MimeRasdItem,
 		AllocationUnits: "hertz * 10^6",
@@ -442,7 +442,7 @@ func (vapp *VApp) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *in
 		ElementName:     strconv.Itoa(virtualCpuCount) + " virtual CPU(s)",
 		InstanceID:      4,
 		Reservation:     0,
-		ResourceType:    3,
+		ResourceType:    types.ResourceTypeProcessor,
 		VirtualQuantity: virtualCpuCount,
 		Weight:          0,
 		CoresPerSocket:  coresPerSocket,
@@ -483,7 +483,7 @@ func (vapp *VApp) ChangeStorageProfile(name string) (Task, error) {
 	newProfile := &types.VM{
 		Name:           vapp.VApp.Children.VM[0].Name,
 		StorageProfile: &storageProfileRef,
-		Xmlns:          "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:          types.XMLNamespaceVCloud,
 	}
 
 	// Return the task
@@ -504,7 +504,7 @@ func (vapp *VApp) ChangeVMName(name string) (Task, error) {
 
 	newName := &types.VM{
 		Name:  name,
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Xmlns: types.XMLNamespaceVCloud,
 	}
 
 	// Return the task
@@ -554,8 +554,8 @@ func (vapp *VApp) AddMetadata(key string, value string) (Task, error) {
 // TODO: Support all MetadataTypedValue types with this function
 func addMetadata(client *Client, key string, value string, requestUri string) (Task, error) {
 	newMetadata := &types.MetadataValue{
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
-		Xsi:   "http://www.w3.org/2001/XMLSchema-instance",
+		Xmlns: types.XMLNamespaceVCloud,
+		Xsi:   types.XMLNamespaceXSI,
 		TypedValue: &types.TypedValue{
 			XsiType: "MetadataStringValue",
 			Value:   value,
@@ -594,8 +594,8 @@ func (vapp *VApp) SetOvf(parameters map[string]string) (Task, error) {
 	}
 
 	ovf := &types.ProductSectionList{
-		Xmlns:          "http://www.vmware.com/vcloud/v1.5",
-		Ovf:            "http://schemas.dmtf.org/ovf/envelope/1",
+		Xmlns:          types.XMLNamespaceVCloud,
+		Ovf:            types.XMLNamespaceOVF,
 		ProductSection: vapp.VApp.Children.VM[0].ProductSection,
 	}
 
@@ -621,26 +621,26 @@ func (vapp *VApp) ChangeNetworkConfig(networks []map[string]interface{}, ip stri
 
 	for index, network := range networks {
 		// Determine what type of address is requested for the vApp
-		ipAllocationMode := "NONE"
+		ipAllocationMode := types.IPAllocationModeNone
 		ipAddress := "Any"
 
 		// TODO: Review current behaviour of using DHCP when left blank
 		if ip == "" || ip == "dhcp" || network["ip"] == "dhcp" {
-			ipAllocationMode = "DHCP"
+			ipAllocationMode = types.IPAllocationModeDHCP
 		} else if ip == "allocated" || network["ip"] == "allocated" {
-			ipAllocationMode = "POOL"
+			ipAllocationMode = types.IPAllocationModePool
 		} else if ip == "none" || network["ip"] == "none" {
-			ipAllocationMode = "NONE"
+			ipAllocationMode = types.IPAllocationModeNone
 		} else if ip != "" || network["ip"] != "" {
-			ipAllocationMode = "MANUAL"
+			ipAllocationMode = types.IPAllocationModeManual
 			// TODO: Check a valid IP has been given
 			ipAddress = ip
 		}
 
 		util.Logger.Printf("[DEBUG] Function ChangeNetworkConfig() for %s invoked", network["orgnetwork"])
 
-		networksection.Xmlns = "http://www.vmware.com/vcloud/v1.5"
-		networksection.Ovf = "http://schemas.dmtf.org/ovf/envelope/1"
+		networksection.Xmlns = types.XMLNamespaceVCloud
+		networksection.Ovf = types.XMLNamespaceOVF
 		networksection.Info = "Specifies the available VM network connections"
 
 		networksection.NetworkConnection[index].NeedsCustomization = true
@@ -676,9 +676,9 @@ func (vapp *VApp) ChangeMemorySize(size int) (Task, error) {
 	}
 
 	newMem := &types.OVFItem{
-		XmlnsRasd:       "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData",
-		XmlnsVCloud:     "http://www.vmware.com/vcloud/v1.5",
-		XmlnsXsi:        "http://www.w3.org/2001/XMLSchema-instance",
+		XmlnsRasd:       types.XMLNamespaceRASD,
+		XmlnsVCloud:     types.XMLNamespaceVCloud,
+		XmlnsXsi:        types.XMLNamespaceXSI,
 		VCloudHREF:      vapp.VApp.Children.VM[0].HREF + "/virtualHardwareSection/memory",
 		VCloudType:      types.MimeRasdItem,
 		AllocationUnits: "byte * 2^20",
@@ -686,7 +686,7 @@ func (vapp *VApp) ChangeMemorySize(size int) (Task, error) {
 		ElementName:     strconv.Itoa(size) + " MB of memory",
 		InstanceID:      5,
 		Reservation:     0,
-		ResourceType:    4,
+		ResourceType:    types.ResourceTypeMemory,
 		VirtualQuantity: size,
 		Weight:          0,
 		Link: &types.Link{
@@ -736,7 +736,7 @@ func (vapp *VApp) AddRAWNetworkConfig(orgvdcnetworks []*types.OrgVDCNetwork) (Ta
 					ParentNetwork: &types.Reference{
 						HREF: network.HREF,
 					},
-					FenceMode: "bridged",
+					FenceMode: types.FenceModeBridged,
 				},
 			},
 		)
@@ -773,7 +773,7 @@ func (vapp *VApp) AddIsolatedNetwork(newIsolatedNetworkSettings *VappNetworkSett
 		types.VAppNetworkConfiguration{
 			NetworkName: newIsolatedNetworkSettings.Name,
 			Configuration: &types.NetworkConfiguration{
-				FenceMode:        "isolated",
+				FenceMode:        types.FenceModeIsolated,
 				GuestVlanAllowed: newIsolatedNetworkSettings.GuestVLANAllowed,
 				Features:         networkFeatures,
 				IPScopes: &types.IPScopes{IPScope: types.IPScope{IsInherited: false, Gateway: newIsolatedNetworkSettings.Gateway,
@@ -846,9 +846,9 @@ func (vapp *VApp) RemoveIsolatedNetwork(networkName string) (Task, error) {
 func updateNetworkConfigurations(vapp *VApp, networkConfigurations []types.VAppNetworkConfiguration) (Task, error) {
 	networkConfig := &types.NetworkConfigSection{
 		Info:          "Configuration parameters for logical networks",
-		Ovf:           "http://schemas.dmtf.org/ovf/envelope/1",
+		Ovf:           types.XMLNamespaceOVF,
 		Type:          types.MimeNetworkConfigSection,
-		Xmlns:         "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:         types.XMLNamespaceVCloud,
 		NetworkConfig: networkConfigurations,
 	}
 

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vapp.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vapp.go
@@ -5,10 +5,9 @@
 package govcd
 
 import (
-	"bytes"
-	"encoding/xml"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"time"
@@ -59,17 +58,15 @@ type DhcpSettings struct {
 func (vapp *VApp) getParentVDC() (Vdc, error) {
 	for _, link := range vapp.VApp.Link {
 		if link.Type == "application/vnd.vmware.vcloud.vdc+xml" {
-			getParentUrl, err := url.ParseRequestURI(link.HREF)
-			if err != nil {
-				return Vdc{}, fmt.Errorf("Cannot parse HREF : %v", err)
-			}
-			req := vapp.client.NewRequest(map[string]string{}, "GET", *getParentUrl, nil)
-			resp, err := checkResp(vapp.client.Http.Do(req))
 
 			vdc := NewVdc(vapp.client)
-			if err = decodeBody(resp, vdc.Vdc); err != nil {
-				return Vdc{}, fmt.Errorf("error decoding task response: %s", err)
+
+			_, err := vapp.client.ExecuteRequest(link.HREF, http.MethodGet,
+				"", "error retrieving paren vdc: %s", nil, vdc.Vdc)
+			if err != nil {
+				return Vdc{}, err
 			}
+
 			return *vdc, nil
 		}
 	}
@@ -82,25 +79,16 @@ func (vapp *VApp) Refresh() error {
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	refreshUrl, _ := url.ParseRequestURI(vapp.VApp.HREF)
-
-	req := vapp.client.NewRequest(map[string]string{}, "GET", *refreshUrl, nil)
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return fmt.Errorf("error retrieving task: %s", err)
-	}
-
+	url := vapp.VApp.HREF
 	// Empty struct before a new unmarshal, otherwise we end up with duplicate
 	// elements in slices.
 	vapp.VApp = &types.VApp{}
 
-	if err = decodeBody(resp, vapp.VApp); err != nil {
-		return fmt.Errorf("error decoding task response: %s", err)
-	}
+	_, err := vapp.client.ExecuteRequest(url, http.MethodGet,
+		"", "error refreshing vApp: %s", nil, vapp.VApp)
 
 	// The request was successful
-	return nil
+	return err
 }
 
 // Function create vm in vApp using vApp template
@@ -180,31 +168,13 @@ func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName s
 		)
 	}
 
-	output, _ := xml.MarshalIndent(vcomp, "  ", "    ")
-
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/action/recomposeVApp"
 
-	util.Logger.Printf("[TRACE] Recompose XML: %s", string(output))
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		types.MimeRecomposeVappParams, "error instantiating a new VM: %s", vcomp)
 
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
-	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.recomposeVAppParams+xml")
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error instantiating a new VM: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding task response: %s", err)
-	}
-
-	return *task, nil
 }
 
 func (vapp *VApp) RemoveVM(vm VM) error {
@@ -230,31 +200,18 @@ func (vapp *VApp) RemoveVM(vm VM) error {
 		},
 	}
 
-	output, _ := xml.MarshalIndent(vcomp, "  ", "    ")
-
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/action/recomposeVApp"
 
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
-	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.recomposeVAppParams+xml")
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
+	deleteTask, err := vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		types.MimeRecomposeVappParams, "error removing VM: %s", vcomp)
 	if err != nil {
-		return fmt.Errorf("error instantiating a new vApp: %s", err)
+		return err
 	}
 
-	task = NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return fmt.Errorf("error decoding task response: %s", err)
-	}
-
-	err = task.WaitTaskCompletion()
+	err = deleteTask.WaitTaskCompletion()
 	if err != nil {
-		return fmt.Errorf("Error performing task: %#v", err)
+		return fmt.Errorf("error performing removing VM task: %#v", err)
 	}
 
 	return nil
@@ -270,22 +227,9 @@ func (vapp *VApp) PowerOn() (Task, error) {
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/power/action/powerOn"
 
-	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, nil)
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error powering on vApp: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
-
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		"", "error powering on vApp: %s", nil)
 }
 
 func (vapp *VApp) PowerOff() (Task, error) {
@@ -293,21 +237,9 @@ func (vapp *VApp) PowerOff() (Task, error) {
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/power/action/powerOff"
 
-	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, nil)
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error powering off vApp: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		"", "error powering off vApp: %s", nil)
 
 }
 
@@ -316,22 +248,9 @@ func (vapp *VApp) Reboot() (Task, error) {
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/power/action/reboot"
 
-	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, nil)
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error rebooting vApp: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
-
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		"", "error rebooting vApp: %s", nil)
 }
 
 func (vapp *VApp) Reset() (Task, error) {
@@ -339,22 +258,9 @@ func (vapp *VApp) Reset() (Task, error) {
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/power/action/reset"
 
-	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, nil)
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error resetting vApp: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
-
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		"", "error resetting vApp: %s", nil)
 }
 
 func (vapp *VApp) Suspend() (Task, error) {
@@ -362,22 +268,9 @@ func (vapp *VApp) Suspend() (Task, error) {
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/power/action/suspend"
 
-	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, nil)
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error suspending vApp: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
-
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		"", "error suspending vApp: %s", nil)
 }
 
 func (vapp *VApp) Shutdown() (Task, error) {
@@ -385,22 +278,9 @@ func (vapp *VApp) Shutdown() (Task, error) {
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/power/action/shutdown"
 
-	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, nil)
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error shutting down vApp: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
-
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		"", "error shutting down vApp: %s", nil)
 }
 
 func (vapp *VApp) Undeploy() (Task, error) {
@@ -410,36 +290,12 @@ func (vapp *VApp) Undeploy() (Task, error) {
 		UndeployPowerAction: "powerOff",
 	}
 
-	output, err := xml.MarshalIndent(vu, "  ", "    ")
-	if err != nil {
-		fmt.Printf("error: %v\n", err)
-	}
-
-	util.Logger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/action/undeploy"
 
-	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.undeployVAppParams+xml")
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error undeploy vApp: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
-
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		types.MimeUndeployVappParams, "error undeploy vApp: %s", vu)
 }
 
 func (vapp *VApp) Deploy() (Task, error) {
@@ -449,58 +305,19 @@ func (vapp *VApp) Deploy() (Task, error) {
 		PowerOn: false,
 	}
 
-	output, err := xml.MarshalIndent(vu, "  ", "    ")
-	if err != nil {
-		fmt.Printf("error: %v\n", err)
-	}
-
-	util.Logger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/action/deploy"
 
-	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.deployVAppParams+xml")
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error undeploy vApp: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
-
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		types.MimeDeployVappParams, "error deploy vApp: %s", vu)
 }
 
 func (vapp *VApp) Delete() (Task, error) {
 
-	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
-
-	req := vapp.client.NewRequest(map[string]string{}, "DELETE", *apiEndpoint, nil)
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error deleting vApp: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
-
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(vapp.VApp.HREF, http.MethodDelete,
+		"", "error deleting vApp: %s", nil)
 }
 
 func (vapp *VApp) RunCustomizationScript(computername, script string) (Task, error) {
@@ -524,7 +341,7 @@ func (vapp *VApp) Customize(computername, script string, changeSid bool) (Task, 
 		Xmlns: "http://www.vmware.com/vcloud/v1.5",
 
 		HREF:                vapp.VApp.Children.VM[0].HREF,
-		Type:                "application/vnd.vmware.vcloud.guestCustomizationSection+xml",
+		Type:                types.MimeGuestCustomizationSection,
 		Info:                "Specifies Guest OS Customization Settings",
 		Enabled:             true,
 		ComputerName:        computername,
@@ -532,37 +349,12 @@ func (vapp *VApp) Customize(computername, script string, changeSid bool) (Task, 
 		ChangeSid:           false,
 	}
 
-	output, err := xml.MarshalIndent(vu, "  ", "    ")
-	if err != nil {
-		fmt.Printf("error: %v\n", err)
-	}
-
-	util.Logger.Printf("[DEBUG] VCD Client configuration: %s", output)
-
-	util.Logger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.Children.VM[0].HREF)
 	apiEndpoint.Path += "/guestCustomizationSection/"
 
-	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.guestCustomizationSection+xml")
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error customizing VM: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+		types.MimeGuestCustomizationSection, "error customizing VM: %s", vu)
 }
 
 func (vapp *VApp) GetStatus() (string, error) {
@@ -606,23 +398,11 @@ func (vapp *VApp) GetNetworkConnectionSection() (*types.NetworkConnectionSection
 		return networkConnectionSection, fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	getNetworkUrl, _ := url.ParseRequestURI(vapp.VApp.Children.VM[0].HREF + "/networkConnectionSection/")
-
-	req := vapp.client.NewRequest(map[string]string{}, "GET", *getNetworkUrl, nil)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.networkConnectionSection+xml")
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return networkConnectionSection, fmt.Errorf("error retrieving task: %s", err)
-	}
-
-	if err = decodeBody(resp, networkConnectionSection); err != nil {
-		return networkConnectionSection, fmt.Errorf("error decoding task response: %s", err)
-	}
+	_, err := vapp.client.ExecuteRequest(vapp.VApp.Children.VM[0].HREF+"/networkConnectionSection/", http.MethodGet,
+		types.MimeNetworkConnectionSection, "error retrieving network connection: %s", nil, networkConnectionSection)
 
 	// The request was successful
-	return networkConnectionSection, nil
+	return networkConnectionSection, err
 }
 
 // Sets number of available virtual logical processors
@@ -656,7 +436,7 @@ func (vapp *VApp) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *in
 		XmlnsXsi:        "http://www.w3.org/2001/XMLSchema-instance",
 		XmlnsVmw:        "http://www.vmware.com/schema/ovf",
 		VCloudHREF:      vapp.VApp.Children.VM[0].HREF + "/virtualHardwareSection/cpu",
-		VCloudType:      "application/vnd.vmware.vcloud.rasdItem+xml",
+		VCloudType:      types.MimeRasdItem,
 		AllocationUnits: "hertz * 10^6",
 		Description:     "Number of Virtual CPUs",
 		ElementName:     strconv.Itoa(virtualCpuCount) + " virtual CPU(s)",
@@ -669,38 +449,16 @@ func (vapp *VApp) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *in
 		Link: &types.Link{
 			HREF: vapp.VApp.Children.VM[0].HREF + "/virtualHardwareSection/cpu",
 			Rel:  "edit",
-			Type: "application/vnd.vmware.vcloud.rasdItem+xml",
+			Type: types.MimeRasdItem,
 		},
 	}
-
-	output, err := xml.MarshalIndent(newcpu, "  ", "    ")
-	if err != nil {
-		fmt.Printf("error: %v\n", err)
-	}
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
 
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.Children.VM[0].HREF)
 	apiEndpoint.Path += "/virtualHardwareSection/cpu"
 
-	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.rasdItem+xml")
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error customizing VM: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
-
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+		types.MimeRasdItem, "error changing CPU count: %s", newcpu)
 }
 
 func (vapp *VApp) ChangeStorageProfile(name string) (Task, error) {
@@ -728,37 +486,12 @@ func (vapp *VApp) ChangeStorageProfile(name string) (Task, error) {
 		Xmlns:          "http://www.vmware.com/vcloud/v1.5",
 	}
 
-	output, err := xml.MarshalIndent(newProfile, "  ", "    ")
-	if err != nil {
-		return Task{}, fmt.Errorf("error encoding storage profile change metadata for vApp %s", vapp.VApp.Name)
-	}
-
-	util.Logger.Printf("[DEBUG] VCD Client configuration: %s", output)
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
-	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.Children.VM[0].HREF)
-
-	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.vm+xml")
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error customizing VM: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
-
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(vapp.VApp.Children.VM[0].HREF, http.MethodPut,
+		types.MimeVM, "error changing CPU count: %s", newProfile)
 }
 
+// Deprecated as it changes only first VM's name
 func (vapp *VApp) ChangeVMName(name string) (Task, error) {
 	err := vapp.Refresh()
 	if err != nil {
@@ -769,40 +502,14 @@ func (vapp *VApp) ChangeVMName(name string) (Task, error) {
 		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
 	}
 
-	newname := &types.VM{
+	newName := &types.VM{
 		Name:  name,
 		Xmlns: "http://www.vmware.com/vcloud/v1.5",
 	}
 
-	output, err := xml.MarshalIndent(newname, "  ", "    ")
-	if err != nil {
-		fmt.Printf("error: %v\n", err)
-	}
-
-	util.Logger.Printf("[DEBUG] VCD Client configuration: %s", output)
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
-	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.Children.VM[0].HREF)
-
-	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.vm+xml")
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error customizing VM: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
-
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(vapp.VApp.Children.VM[0].HREF, http.MethodPut,
+		types.MimeVM, "error changing VM name: %s", newName)
 }
 
 // GetMetadata() function calls private function getMetadata() with vapp.client and vapp.VApp.HREF
@@ -814,23 +521,10 @@ func (vapp *VApp) GetMetadata() (*types.Metadata, error) {
 func getMetadata(client *Client, requestUri string) (*types.Metadata, error) {
 	metadata := &types.Metadata{}
 
-	getMetadata, _ := url.ParseRequestURI(requestUri + "/metadata/")
+	_, err := client.ExecuteRequest(requestUri+"/metadata/", http.MethodGet,
+		types.MimeMetaData, "error retrieving metadata: %s", nil, metadata)
 
-	req := client.NewRequest(map[string]string{}, "GET", *getMetadata, nil)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.metadata+xml")
-
-	resp, err := checkResp(client.Http.Do(req))
-	if err != nil {
-		return metadata, fmt.Errorf("error retrieving task: %s", err)
-	}
-
-	if err = decodeBody(resp, metadata); err != nil {
-		return metadata, fmt.Errorf("error decoding task response: %s", err)
-	}
-
-	// The request was successful
-	return metadata, nil
+	return metadata, err
 }
 
 // DeleteMetadata() function calls private function deleteMetadata() with vapp.client and vapp.VApp.HREF
@@ -845,21 +539,9 @@ func deleteMetadata(client *Client, key string, requestUri string) (Task, error)
 	apiEndpoint, _ := url.ParseRequestURI(requestUri)
 	apiEndpoint.Path += "/metadata/" + key
 
-	req := client.NewRequest(map[string]string{}, "DELETE", *apiEndpoint, nil)
-
-	resp, err := checkResp(client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error deleting metadata: %s", err)
-	}
-
-	task := NewTask(client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
+	// Return the task
+	return client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodDelete,
+		"", "error deleting metadata: %s", nil)
 }
 
 // AddMetadata() function calls private function addMetadata() with vapp.client and vapp.VApp.HREF
@@ -871,7 +553,7 @@ func (vapp *VApp) AddMetadata(key string, value string) (Task, error) {
 // Adds metadata (type MetadataStringValue) to the vApp
 // TODO: Support all MetadataTypedValue types with this function
 func addMetadata(client *Client, key string, value string, requestUri string) (Task, error) {
-	newmetadata := &types.MetadataValue{
+	newMetadata := &types.MetadataValue{
 		Xmlns: "http://www.vmware.com/vcloud/v1.5",
 		Xsi:   "http://www.w3.org/2001/XMLSchema-instance",
 		TypedValue: &types.TypedValue{
@@ -880,33 +562,12 @@ func addMetadata(client *Client, key string, value string, requestUri string) (T
 		},
 	}
 
-	output, err := xml.MarshalIndent(newmetadata, "  ", "    ")
-	if err != nil {
-		return Task{}, fmt.Errorf("error adding metadata: %s", err)
-	}
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
 	apiEndpoint, _ := url.ParseRequestURI(requestUri)
 	apiEndpoint.Path += "/metadata/" + key
 
-	req := client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.metadata.value+xml")
-
-	resp, err := checkResp(client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error customizing vApp metadata: %s", err)
-	}
-
-	task := NewTask(client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
+	// Return the task
+	return client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+		types.MimeMetaDataValue, "error adding metadata: %s", newMetadata)
 }
 
 func (vapp *VApp) SetOvf(parameters map[string]string) (Task, error) {
@@ -932,42 +593,18 @@ func (vapp *VApp) SetOvf(parameters map[string]string) (Task, error) {
 		}
 	}
 
-	newmetadata := &types.ProductSectionList{
+	ovf := &types.ProductSectionList{
 		Xmlns:          "http://www.vmware.com/vcloud/v1.5",
 		Ovf:            "http://schemas.dmtf.org/ovf/envelope/1",
 		ProductSection: vapp.VApp.Children.VM[0].ProductSection,
 	}
 
-	output, err := xml.MarshalIndent(newmetadata, "  ", "    ")
-	if err != nil {
-		fmt.Printf("error: %v\n", err)
-	}
-
-	util.Logger.Printf("[DEBUG] NetworkXML: %s", output)
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.Children.VM[0].HREF)
 	apiEndpoint.Path += "/productSections"
 
-	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.productSections+xml")
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error customizing VM Network: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
-
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+		types.MimeProductSection, "error setting ovf: %s", ovf)
 }
 
 func (vapp *VApp) ChangeNetworkConfig(networks []map[string]interface{}, ip string) (Task, error) {
@@ -1017,37 +654,15 @@ func (vapp *VApp) ChangeNetworkConfig(networks []map[string]interface{}, ip stri
 
 	}
 
-	output, err := xml.MarshalIndent(networksection, "  ", "    ")
-	if err != nil {
-		fmt.Printf("error: %v\n", err)
-	}
-
-	util.Logger.Printf("[DEBUG] NetworkXML: %s", output)
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.Children.VM[0].HREF)
 	apiEndpoint.Path += "/networkConnectionSection/"
 
-	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.networkConnectionSection+xml")
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error customizing VM Network: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+		types.MimeNetworkConnectionSection, "error changing network config: %s", networksection)
 }
 
+// Deprecated as it changes only first VM's memory
 func (vapp *VApp) ChangeMemorySize(size int) (Task, error) {
 
 	err := vapp.Refresh()
@@ -1060,12 +675,12 @@ func (vapp *VApp) ChangeMemorySize(size int) (Task, error) {
 		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
 	}
 
-	newmem := &types.OVFItem{
+	newMem := &types.OVFItem{
 		XmlnsRasd:       "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData",
 		XmlnsVCloud:     "http://www.vmware.com/vcloud/v1.5",
 		XmlnsXsi:        "http://www.w3.org/2001/XMLSchema-instance",
 		VCloudHREF:      vapp.VApp.Children.VM[0].HREF + "/virtualHardwareSection/memory",
-		VCloudType:      "application/vnd.vmware.vcloud.rasdItem+xml",
+		VCloudType:      types.MimeRasdItem,
 		AllocationUnits: "byte * 2^20",
 		Description:     "Memory Size",
 		ElementName:     strconv.Itoa(size) + " MB of memory",
@@ -1077,40 +692,16 @@ func (vapp *VApp) ChangeMemorySize(size int) (Task, error) {
 		Link: &types.Link{
 			HREF: vapp.VApp.Children.VM[0].HREF + "/virtualHardwareSection/memory",
 			Rel:  "edit",
-			Type: "application/vnd.vmware.vcloud.rasdItem+xml",
+			Type: types.MimeRasdItem,
 		},
 	}
-
-	output, err := xml.MarshalIndent(newmem, "  ", "    ")
-	if err != nil {
-		return Task{}, fmt.Errorf("error: %v\n", err)
-	}
-
-	util.Logger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
 
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.Children.VM[0].HREF)
 	apiEndpoint.Path += "/virtualHardwareSection/memory"
 
-	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.rasdItem+xml")
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error customizing VM: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
-
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+		types.MimeRasdItem, "error changing memory size: %s", newMem)
 }
 
 func (vapp *VApp) GetNetworkConfig() (*types.NetworkConfigSection, error) {
@@ -1121,23 +712,11 @@ func (vapp *VApp) GetNetworkConfig() (*types.NetworkConfigSection, error) {
 		return networkConfig, fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	getNetworkUrl, _ := url.ParseRequestURI(vapp.VApp.HREF + "/networkConfigSection/")
-
-	req := vapp.client.NewRequest(map[string]string{}, "GET", *getNetworkUrl, nil)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.networkConfigSection+xml")
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return networkConfig, fmt.Errorf("error retrieving task: %s", err)
-	}
-
-	if err = decodeBody(resp, networkConfig); err != nil {
-		return networkConfig, fmt.Errorf("error decoding task response: %s", err)
-	}
+	_, err := vapp.client.ExecuteRequest(vapp.VApp.HREF+"/networkConfigSection/", http.MethodGet,
+		types.MimeNetworkConfigSection, "error retrieving network config: %s", nil, networkConfig)
 
 	// The request was successful
-	return networkConfig, nil
+	return networkConfig, err
 }
 
 // Function adds existing VDC network to vApp
@@ -1268,38 +847,15 @@ func updateNetworkConfigurations(vapp *VApp, networkConfigurations []types.VAppN
 	networkConfig := &types.NetworkConfigSection{
 		Info:          "Configuration parameters for logical networks",
 		Ovf:           "http://schemas.dmtf.org/ovf/envelope/1",
-		Type:          "application/vnd.vmware.vcloud.networkConfigSection+xml",
+		Type:          types.MimeNetworkConfigSection,
 		Xmlns:         "http://www.vmware.com/vcloud/v1.5",
 		NetworkConfig: networkConfigurations,
 	}
 
-	output, err := xml.MarshalIndent(networkConfig, "  ", "    ")
-	if err != nil {
-		fmt.Printf("error: %v\n", err)
-	}
-
-	util.Logger.Printf("[DEBUG] RAWNETWORK Config NetworkXML: %s", output)
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/networkConfigSection/"
 
-	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.networkconfigsection+xml")
-
-	resp, err := checkResp(vapp.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error updating vApp Network: %s", err)
-	}
-
-	task := NewTask(vapp.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
+	// Return the task
+	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+		types.MimeNetworkConfigSection, "error updating vApp Network: %s", networkConfig)
 }

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vapptemplate.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vapptemplate.go
@@ -5,9 +5,8 @@
 package govcd
 
 import (
-	"bytes"
-	"encoding/xml"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
@@ -26,36 +25,26 @@ func NewVAppTemplate(cli *Client) *VAppTemplate {
 }
 
 func (vdc *Vdc) InstantiateVAppTemplate(template *types.InstantiateVAppTemplateParams) error {
-	output, err := xml.MarshalIndent(template, "", "  ")
-	if err != nil {
-		return fmt.Errorf("Error finding VAppTemplate: %#v", err)
-	}
-	requestData := bytes.NewBufferString(xml.Header + string(output))
-
 	vdcHref, err := url.ParseRequestURI(vdc.Vdc.HREF)
 	if err != nil {
 		return fmt.Errorf("error getting vdc href: %v", err)
 	}
 	vdcHref.Path += "/action/instantiateVAppTemplate"
 
-	req := vdc.client.NewRequest(map[string]string{}, "POST", *vdcHref, requestData)
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.instantiateVAppTemplateParams+xml")
-
-	resp, err := checkResp(vdc.client.Http.Do(req))
-	if err != nil {
-		return fmt.Errorf("error instantiating a new template: %s", err)
-	}
-
 	vapptemplate := NewVAppTemplate(vdc.client)
-	if err = decodeBody(resp, vapptemplate.VAppTemplate); err != nil {
-		return fmt.Errorf("error decoding orgvdcnetwork response: %s", err)
+
+	_, err = vdc.client.ExecuteRequest(vdcHref.String(), http.MethodPut,
+		types.MimeInstantiateVappTemplateParams, "error instantiating a new template: %s", template, vapptemplate)
+	if err != nil {
+		return err
 	}
+
 	task := NewTask(vdc.client)
 	for _, taskItem := range vapptemplate.VAppTemplate.Tasks.Task {
 		task.Task = taskItem
 		err = task.WaitTaskCompletion()
 		if err != nil {
-			return fmt.Errorf("Error performing task: %#v", err)
+			return fmt.Errorf("error performing task: %#v", err)
 		}
 	}
 	return nil

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vdc.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vdc.go
@@ -277,9 +277,9 @@ func (vdc *Vdc) FindEdgeGateway(edgegateway string) (EdgeGateway, error) {
 
 func (vdc *Vdc) ComposeRawVApp(name string) error {
 	vcomp := &types.ComposeVAppParams{
-		Ovf:     "http://schemas.dmtf.org/ovf/envelope/1",
-		Xsi:     "http://www.w3.org/2001/XMLSchema-instance",
-		Xmlns:   "http://www.vmware.com/vcloud/v1.5",
+		Ovf:     types.XMLNamespaceOVF,
+		Xsi:     types.XMLNamespaceXSI,
+		Xmlns:   types.XMLNamespaceVCloud,
 		Deploy:  false,
 		Name:    name,
 		PowerOn: false,
@@ -312,9 +312,9 @@ func (vdc *Vdc) ComposeVApp(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate 
 	}
 	// Build request XML
 	vcomp := &types.ComposeVAppParams{
-		Ovf:         "http://schemas.dmtf.org/ovf/envelope/1",
-		Xsi:         "http://www.w3.org/2001/XMLSchema-instance",
-		Xmlns:       "http://www.vmware.com/vcloud/v1.5",
+		Ovf:         types.XMLNamespaceOVF,
+		Xsi:         types.XMLNamespaceXSI,
+		Xmlns:       types.XMLNamespaceVCloud,
 		Deploy:      false,
 		Name:        name,
 		PowerOn:     false,
@@ -345,7 +345,7 @@ func (vdc *Vdc) ComposeVApp(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate 
 			types.VAppNetworkConfiguration{
 				NetworkName: orgvdcnetwork.Name,
 				Configuration: &types.NetworkConfiguration{
-					FenceMode: "bridged",
+					FenceMode: types.FenceModeBridged,
 					ParentNetwork: &types.Reference{
 						HREF: orgvdcnetwork.HREF,
 						Name: orgvdcnetwork.Name,
@@ -359,7 +359,7 @@ func (vdc *Vdc) ComposeVApp(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate 
 				Network:                 orgvdcnetwork.Name,
 				NetworkConnectionIndex:  index,
 				IsConnected:             true,
-				IPAddressAllocationMode: "POOL",
+				IPAddressAllocationMode: types.IPAllocationModePool,
 			},
 		)
 		vcomp.SourcedItem.NetworkAssignment = append(vcomp.SourcedItem.NetworkAssignment,

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vm.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vm.go
@@ -565,7 +565,7 @@ func (vm *VM) ToggleHardwareVirtualization(isEnabled bool) (Task, error) {
 		return Task{}, fmt.Errorf("unable to toggle hardware virtualization: %s", err)
 	}
 	if vmStatus != "POWERED_OFF" {
-		return Task{}, fmt.Errorf("hardware virtualization can be changed on powered of VM, status: %s", vmStatus)
+		return Task{}, fmt.Errorf("hardware virtualization can be changed from powered off state, status: %s", vmStatus)
 	}
 
 	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vm.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vm.go
@@ -560,14 +560,21 @@ func (vm *VM) AnswerQuestion(questionId string, choiceId int) error {
 // CPU virtualization for the VM. It can only be performed on a powered off VM and
 // will return an error otherwise. This is mainly useful for hypervisor nesting.
 func (vm *VM) ToggleHardwareVirtualization(isEnabled bool) (Task, error) {
+	vmStatus, err := vm.GetStatus()
+	if err != nil {
+		return Task{}, fmt.Errorf("unable to toggle hardware virtualization: %s", err)
+	}
+	if vmStatus != "POWERED_OFF" {
+		return Task{}, fmt.Errorf("hardware virtualization can be changed on powered of VM, status: %s", vmStatus)
+	}
+
 	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
 	if isEnabled {
 		apiEndpoint.Path += "/action/enableNestedHypervisor"
-		return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
-			"", "error enabling hypervisor nesting feature for VM: %s", nil)
+	} else {
+		apiEndpoint.Path += "/action/disableNestedHypervisor"
 	}
-
-	apiEndpoint.Path += "/action/disableNestedHypervisor"
+	errMessage := fmt.Sprintf("error toggling hypervisor nesting feature to %t for VM: %%s", isEnabled)
 	return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
-		"", "error disabling hypervisor nesting feature for VM: %s", nil)
+		"", errMessage, nil)
 }

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vm.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vm.go
@@ -5,8 +5,6 @@
 package govcd
 
 import (
-	"bytes"
-	"encoding/xml"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -55,25 +53,17 @@ func (vm *VM) Refresh() error {
 		return fmt.Errorf("cannot refresh VM, Object is empty")
 	}
 
-	refreshUrl, _ := url.ParseRequestURI(vm.VM.HREF)
-
-	req := vm.client.NewRequest(map[string]string{}, "GET", *refreshUrl, nil)
-
-	resp, err := checkResp(vm.client.Http.Do(req))
-	if err != nil {
-		return fmt.Errorf("error retrieving task: %s", err)
-	}
+	refreshUrl := vm.VM.HREF
 
 	// Empty struct before a new unmarshal, otherwise we end up with duplicate
 	// elements in slices.
 	vm.VM = &types.VM{}
 
-	if err = decodeBody(resp, vm.VM); err != nil {
-		return fmt.Errorf("error decoding task response VM: %s", err)
-	}
+	_, err := vm.client.ExecuteRequest(refreshUrl, http.MethodGet,
+		"", "error refreshing VM: %s", nil, vm.VM)
 
 	// The request was successful
-	return nil
+	return err
 }
 
 func (vm *VM) GetNetworkConnectionSection() (*types.NetworkConnectionSection, error) {
@@ -84,59 +74,43 @@ func (vm *VM) GetNetworkConnectionSection() (*types.NetworkConnectionSection, er
 		return networkConnectionSection, fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	getNetworkUrl, _ := url.ParseRequestURI(vm.VM.HREF + "/networkConnectionSection/")
-
-	req := vm.client.NewRequest(map[string]string{}, "GET", *getNetworkUrl, nil)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.networkConnectionSection+xml")
-
-	resp, err := checkResp(vm.client.Http.Do(req))
-	if err != nil {
-		return networkConnectionSection, fmt.Errorf("error retrieving task: %s", err)
-	}
-
-	if err = decodeBody(resp, networkConnectionSection); err != nil {
-		return networkConnectionSection, fmt.Errorf("error decoding task response: %s", err)
-	}
+	_, err := vm.client.ExecuteRequest(vm.VM.HREF+"/networkConnectionSection/", http.MethodGet,
+		types.MimeNetworkConnectionSection, "error retrieving network connection: %s", nil, networkConnectionSection)
 
 	// The request was successful
-	return networkConnectionSection, nil
+	return networkConnectionSection, err
 }
 
 func (cli *Client) FindVMByHREF(vmHREF string) (VM, error) {
 
-	findUrl, err := url.ParseRequestURI(vmHREF)
-
-	if err != nil {
-		return VM{}, fmt.Errorf("error decoding vm HREF: %s", err)
-	}
-
-	// Querying the VApp
-	req := cli.NewRequest(map[string]string{}, "GET", *findUrl, nil)
-
-	resp, err := checkResp(cli.Http.Do(req))
-	if err != nil {
-		return VM{}, fmt.Errorf("error retrieving VM: %s", err)
-	}
-
 	newVm := NewVM(cli)
 
-	if err = decodeBody(resp, newVm.VM); err != nil {
-		return VM{}, fmt.Errorf("error decoding VM response: %s", err)
-	}
+	_, err := cli.ExecuteRequest(vmHREF, http.MethodGet,
+		"", "error retrieving VM: %s", nil, newVm.VM)
 
-	return *newVm, nil
+	return *newVm, err
 
 }
 
-// PowerOn triggers a powerOn action for single VM instance
 func (vm *VM) PowerOn() (Task, error) {
-	return vm.postEmptyAction("/power/action/powerOn")
+
+	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
+	apiEndpoint.Path += "/power/action/powerOn"
+
+	// Return the task
+	return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		"", "error powering on VM: %s", nil)
+
 }
 
-// PowerOff triggers a powerOff action for single VM instance
 func (vm *VM) PowerOff() (Task, error) {
-	return vm.postEmptyAction("/power/action/powerOff")
+
+	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
+	apiEndpoint.Path += "/power/action/powerOff"
+
+	// Return the task
+	return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		"", "error powering off VM: %s", nil)
 }
 
 // Sets number of available virtual logical processors
@@ -158,13 +132,13 @@ func (vm *VM) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *int) (
 		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
 	}
 
-	newcpu := &types.OVFItem{
+	newCpu := &types.OVFItem{
 		XmlnsRasd:       "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData",
 		XmlnsVCloud:     "http://www.vmware.com/vcloud/v1.5",
 		XmlnsXsi:        "http://www.w3.org/2001/XMLSchema-instance",
 		XmlnsVmw:        "http://www.vmware.com/schema/ovf",
 		VCloudHREF:      vm.VM.HREF + "/virtualHardwareSection/cpu",
-		VCloudType:      "application/vnd.vmware.vcloud.rasdItem+xml",
+		VCloudType:      types.MimeRasdItem,
 		AllocationUnits: "hertz * 10^6",
 		Description:     "Number of Virtual CPUs",
 		ElementName:     strconv.Itoa(virtualCpuCount) + " virtual CPU(s)",
@@ -177,37 +151,16 @@ func (vm *VM) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *int) (
 		Link: &types.Link{
 			HREF: vm.VM.HREF + "/virtualHardwareSection/cpu",
 			Rel:  "edit",
-			Type: "application/vnd.vmware.vcloud.rasdItem+xml",
+			Type: types.MimeRasdItem,
 		},
 	}
-
-	output, err := xml.MarshalIndent(newcpu, "  ", "    ")
-	if err != nil {
-		fmt.Printf("error: %v\n", err)
-	}
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
 
 	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
 	apiEndpoint.Path += "/virtualHardwareSection/cpu"
 
-	req := vm.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.rasdItem+xml")
-
-	resp, err := checkResp(vm.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error customizing VM: %s", err)
-	}
-
-	task := NewTask(vm.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
+	// Return the task
+	return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+		types.MimeRasdItem, "error changing CPU count: %s", newCpu)
 
 }
 
@@ -263,35 +216,12 @@ func (vm *VM) ChangeNetworkConfig(networks []map[string]interface{}, ip string) 
 	networkSection.Ovf = "http://schemas.dmtf.org/ovf/envelope/1"
 	networkSection.Info = "Specifies the available VM network connections"
 
-	output, err := xml.MarshalIndent(networkSection, "  ", "    ")
-	if err != nil {
-		fmt.Printf("error: %v\n", err)
-	}
-
-	util.Logger.Printf("[DEBUG] NetworkXML: %s", output)
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
 	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
 	apiEndpoint.Path += "/networkConnectionSection/"
 
-	req := vm.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.networkConnectionSection+xml")
-
-	resp, err := checkResp(vm.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error customizing VM Network: %s", err)
-	}
-
-	task := NewTask(vm.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
+	// Return the task
+	return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+		types.MimeNetworkConnectionSection, "error changing network config: %s", networkSection)
 }
 
 func (vm *VM) ChangeMemorySize(size int) (Task, error) {
@@ -301,12 +231,12 @@ func (vm *VM) ChangeMemorySize(size int) (Task, error) {
 		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
 	}
 
-	newmem := &types.OVFItem{
+	newMem := &types.OVFItem{
 		XmlnsRasd:       "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData",
 		XmlnsVCloud:     "http://www.vmware.com/vcloud/v1.5",
 		XmlnsXsi:        "http://www.w3.org/2001/XMLSchema-instance",
 		VCloudHREF:      vm.VM.HREF + "/virtualHardwareSection/memory",
-		VCloudType:      "application/vnd.vmware.vcloud.rasdItem+xml",
+		VCloudType:      types.MimeRasdItem,
 		AllocationUnits: "byte * 2^20",
 		Description:     "Memory Size",
 		ElementName:     strconv.Itoa(size) + " MB of memory",
@@ -318,40 +248,16 @@ func (vm *VM) ChangeMemorySize(size int) (Task, error) {
 		Link: &types.Link{
 			HREF: vm.VM.HREF + "/virtualHardwareSection/memory",
 			Rel:  "edit",
-			Type: "application/vnd.vmware.vcloud.rasdItem+xml",
+			Type: types.MimeRasdItem,
 		},
 	}
-
-	output, err := xml.MarshalIndent(newmem, "  ", "    ")
-	if err != nil {
-		fmt.Printf("error: %v\n", err)
-	}
-
-	util.Logger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
 
 	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
 	apiEndpoint.Path += "/virtualHardwareSection/memory"
 
-	req := vm.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.rasdItem+xml")
-
-	resp, err := checkResp(vm.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error customizing VM: %s", err)
-	}
-
-	task := NewTask(vm.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
-
+	// Return the task
+	return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+		types.MimeRasdItem, "error changing memory size: %s", newMem)
 }
 
 func (vm *VM) RunCustomizationScript(computername, script string) (Task, error) {
@@ -370,7 +276,7 @@ func (vm *VM) Customize(computername, script string, changeSid bool) (Task, erro
 		Xmlns: "http://www.vmware.com/vcloud/v1.5",
 
 		HREF:                vm.VM.HREF,
-		Type:                "application/vnd.vmware.vcloud.guestCustomizationSection+xml",
+		Type:                types.MimeGuestCustomizationSection,
 		Info:                "Specifies Guest OS Customization Settings",
 		Enabled:             true,
 		ComputerName:        computername,
@@ -378,37 +284,12 @@ func (vm *VM) Customize(computername, script string, changeSid bool) (Task, erro
 		ChangeSid:           false,
 	}
 
-	output, err := xml.MarshalIndent(vu, "  ", "    ")
-	if err != nil {
-		fmt.Printf("error: %v\n", err)
-	}
-
-	util.Logger.Printf("[DEBUG] VCD Client configuration: %s", output)
-
-	util.Logger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
 	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
 	apiEndpoint.Path += "/guestCustomizationSection/"
 
-	req := vm.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.guestCustomizationSection+xml")
-
-	resp, err := checkResp(vm.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error customizing VM: %s", err)
-	}
-
-	task := NewTask(vm.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
+	// Return the task
+	return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+		types.MimeGuestCustomizationSection, "error customizing VM: %s", vu)
 }
 
 func (vm *VM) Undeploy() (Task, error) {
@@ -418,36 +299,12 @@ func (vm *VM) Undeploy() (Task, error) {
 		UndeployPowerAction: "powerOff",
 	}
 
-	output, err := xml.MarshalIndent(vu, "  ", "    ")
-	if err != nil {
-		fmt.Printf("error: %v\n", err)
-	}
-
-	util.Logger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
 	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
 	apiEndpoint.Path += "/action/undeploy"
 
-	req := vm.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.undeployVAppParams+xml")
-
-	resp, err := checkResp(vm.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error undeploy vApp: %s", err)
-	}
-
-	task := NewTask(vm.client)
-
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
-
+	// Return the task
+	return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		types.MimeUndeployVappParams, "error undeploy vApp: %s", vu)
 }
 
 // Attach or detach an independent disk
@@ -458,7 +315,6 @@ func (vm *VM) Undeploy() (Task, error) {
 func (vm *VM) attachOrDetachDisk(diskParams *types.DiskAttachOrDetachParams, rel string) (Task, error) {
 	util.Logger.Printf("[TRACE] Attach or detach disk, href: %s, rel: %s \n", diskParams.Disk.HREF, rel)
 
-	var err error
 	var attachOrDetachDiskLink *types.Link
 	for _, link := range vm.VM.Link {
 		if link.Rel == rel && link.Type == types.MimeDiskAttachOrDetachParams {
@@ -476,32 +332,11 @@ func (vm *VM) attachOrDetachDisk(diskParams *types.DiskAttachOrDetachParams, rel
 		return Task{}, fmt.Errorf("could not find request URL for attach or detach disk in disk Link")
 	}
 
-	reqUrl, err := url.ParseRequestURI(attachOrDetachDiskLink.HREF)
-
 	diskParams.Xmlns = types.NsVCloud
 
-	xmlPayload, err := xml.Marshal(diskParams)
-	if err != nil {
-		return Task{}, fmt.Errorf("error marshal xml: %s", err)
-	}
-
-	// Send request
-	reqPayload := bytes.NewBufferString(xml.Header + string(xmlPayload))
-	req := vm.client.NewRequest(nil, http.MethodPost, *reqUrl, reqPayload)
-	req.Header.Add("Content-Type", attachOrDetachDiskLink.Type)
-	resp, err := checkResp(vm.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error attach or detach disk: %s", err)
-	}
-
-	// Decode response
-	task := NewTask(vm.client)
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	// The request was successful
-	return *task, nil
+	// Return the task
+	return vm.client.ExecuteTaskRequest(attachOrDetachDiskLink.HREF, http.MethodPost,
+		attachOrDetachDiskLink.Type, "error attach or detach disk: %s", diskParams)
 }
 
 // Attach an independent disk
@@ -546,7 +381,7 @@ func (vm *VM) HandleInsertMedia(org *Org, catalogName, mediaName string) (Task, 
 		return Task{}, err
 	}
 
-	task, err := vm.InsertMedia(&types.MediaInsertOrEjectParams{
+	return vm.InsertMedia(&types.MediaInsertOrEjectParams{
 		Media: &types.Reference{
 			HREF: media.CatalogItem.Entity.HREF,
 			Name: media.CatalogItem.Entity.Name,
@@ -554,8 +389,6 @@ func (vm *VM) HandleInsertMedia(org *Org, catalogName, mediaName string) (Task, 
 			Type: media.CatalogItem.Entity.Type,
 		},
 	})
-
-	return task, err
 }
 
 // Helper function which finds media and calls EjectMedia
@@ -625,7 +458,6 @@ func validateMediaParams(mediaParams *types.MediaInsertOrEjectParams) error {
 func (vm *VM) insertOrEjectMedia(mediaParams *types.MediaInsertOrEjectParams, linkRel string) (Task, error) {
 	util.Logger.Printf("[TRACE] Insert or eject media, href: %s, name: %s, , linkRel: %s \n", mediaParams.Media.HREF, mediaParams.Media.Name, linkRel)
 
-	var err error
 	var insertOrEjectMediaLink *types.Link
 	for _, link := range vm.VM.Link {
 		if link.Rel == linkRel && link.Type == types.MimeMediaInsertOrEjectParams {
@@ -639,31 +471,11 @@ func (vm *VM) insertOrEjectMedia(mediaParams *types.MediaInsertOrEjectParams, li
 		return Task{}, fmt.Errorf("could not find request URL for insert or eject media")
 	}
 
-	reqUrl, err := url.ParseRequestURI(insertOrEjectMediaLink.HREF)
-	if err != nil {
-		return Task{}, fmt.Errorf("could not parse request URL for insert or eject media. Error: %#v", err)
-	}
-
 	mediaParams.Xmlns = types.NsVCloud
-	xmlPayload, err := xml.Marshal(mediaParams)
-	if err != nil {
-		return Task{}, fmt.Errorf("error marshal xml: %s", err)
-	}
 
-	reqPayload := bytes.NewBufferString(xml.Header + string(xmlPayload))
-	req := vm.client.NewRequest(nil, http.MethodPost, *reqUrl, reqPayload)
-	req.Header.Add("Content-Type", insertOrEjectMediaLink.Type)
-	resp, err := checkResp(vm.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error insert or eject disk: %s", err)
-	}
-
-	task := NewTask(vm.client)
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	return *task, nil
+	// Return the task
+	return vm.client.ExecuteTaskRequest(insertOrEjectMediaLink.HREF, http.MethodPost,
+		insertOrEjectMediaLink.Type, "error insert or eject media: %s", mediaParams)
 }
 
 // Use the get existing VM question for operation which need additional response
@@ -674,7 +486,7 @@ func (vm *VM) GetQuestion() (types.VmPendingQuestion, error) {
 	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
 	apiEndpoint.Path += "/question"
 
-	req := vm.client.NewRequest(map[string]string{}, "GET", *apiEndpoint, nil)
+	req := vm.client.NewRequest(map[string]string{}, http.MethodGet, *apiEndpoint, nil)
 
 	resp, err := vm.client.Http.Do(req)
 
@@ -737,61 +549,25 @@ func (vm *VM) AnswerQuestion(questionId string, choiceId int) error {
 		ChoiceId:   choiceId,
 	}
 
-	output, err := xml.MarshalIndent(answer, "  ", "    ")
-	if err != nil {
-		fmt.Printf("error: %v\n", err)
-	}
-
-	util.Logger.Printf("[TRACE] AnswerQuestion XML DEBUG \n : %s\n\n", string(output))
-
-	buffer := bytes.NewBufferString(xml.Header + string(output))
-
 	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
 	apiEndpoint.Path += "/question/action/answer"
 
-	req := vm.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
-
-	_, err = checkResp(vm.client.Http.Do(req))
-	if err != nil {
-		return fmt.Errorf("error asnwering question: %s", err)
-	}
-
-	// The request was successful
-	return nil
-
+	return vm.client.ExecuteRequestWithoutResponse(apiEndpoint.String(), http.MethodPost,
+		"", "error asnwering question: %s", answer)
 }
 
-// ToggleHWAssistedVirtualization allows to either enable or disable hardware assisted
+// ToggleHardwareVirtualization allows to either enable or disable hardware assisted
 // CPU virtualization for the VM. It can only be performed on a powered off VM and
 // will return an error otherwise. This is mainly useful for hypervisor nesting.
-func (vm *VM) ToggleHWAssistedVirtualization(isEnabled bool) (Task, error) {
-	// func (vm *VM) ToggleNestedHypervisor(isEnabled bool) (Task, error) {
-	if isEnabled {
-		return vm.postEmptyAction("/action/enableNestedHypervisor")
-	}
-	return vm.postEmptyAction("/action/disableNestedHypervisor")
-}
-
-// postEmptyAction abstracts a common pattern when vm features/states can be actioned with
-// single POST call with empty body and return a Task to track.
-func (vm *VM) postEmptyAction(path string) (Task, error) {
-	if path == "" {
-		return Task{}, fmt.Errorf("cannot perform post operation to empty path")
-	}
+func (vm *VM) ToggleHardwareVirtualization(isEnabled bool) (Task, error) {
 	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
-	apiEndpoint.Path += path
-
-	req := vm.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, nil)
-
-	resp, err := checkResp(vm.client.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error posting to %s for VM: %s", path, err)
+	if isEnabled {
+		apiEndpoint.Path += "/action/enableNestedHypervisor"
+		return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+			"", "error enabling hypervisor nesting feature for VM: %s", nil)
 	}
 
-	task := NewTask(vm.client)
-	if err = decodeBody(resp, task.Task); err != nil {
-		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
-	}
-
-	return *task, nil
+	apiEndpoint.Path += "/action/disableNestedHypervisor"
+	return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		"", "error disabling hypervisor nesting feature for VM: %s", nil)
 }

--- a/vendor/github.com/vmware/go-vcloud-director/v2/types/v56/constants.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/types/v56/constants.go
@@ -43,8 +43,6 @@ const (
 	MimeVDC = "application/vnd.vmware.vcloud.vdc+xml"
 	// MimeVAppTemplate mime for a vapp template
 	MimeVAppTemplate = "application/vnd.vmware.vcloud.vAppTemplate+xml"
-	// MimeInstantiateVAppTemplate mime fore instantiate VApp template params
-	MimeInstantiateVAppTemplate = "application/vnd.vmware.vcloud.instantiateVAppTemplateParams+xml"
 	// MimeVApp mime for a vApp
 	MimeVApp = "application/vnd.vmware.vcloud.vApp+xml"
 	// MimeQueryRecords mime for the query records
@@ -75,19 +73,32 @@ const (
 	MimeMediaInsertOrEjectParams = "application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"
 	// Mime for catalog
 	MimeAdminCatalog = "application/vnd.vmware.admin.catalog+xml"
-)
-
-const (
-	// HTTPGet the http GET method
-	HTTPGet = "GET"
-	// HTTPPost the http POST method
-	HTTPPost = "POST"
-	// HTTPPut the http PUT method
-	HTTPPut = "PUT"
-	// HTTPPatch the http PATCH method
-	HTTPPatch = "PATCH"
-	// HTTPDelete the http DELETE method
-	HTTPDelete = "DELETE"
+	// Mime for networkConnectionSection
+	MimeNetworkConnectionSection = "application/vnd.vmware.vcloud.networkConnectionSection+xml"
+	// Mime for Item
+	MimeRasdItem = "application/vnd.vmware.vcloud.rasdItem+xml"
+	// Mime for guest customization section
+	MimeGuestCustomizationSection = "application/vnd.vmware.vcloud.guestCustomizationSection+xml"
+	// Mime for network config section
+	MimeNetworkConfigSection = "application/vnd.vmware.vcloud.networkconfigsection+xml"
+	// Mime for recompose vApp params
+	MimeRecomposeVappParams = "application/vnd.vmware.vcloud.recomposeVAppParams+xml"
+	// Mime for compose vApp params
+	MimeComposeVappParams = "application/vnd.vmware.vcloud.composeVAppParams+xml"
+	// Mime for undeploy vApp params
+	MimeUndeployVappParams = "application/vnd.vmware.vcloud.undeployVAppParams+xml"
+	// Mime for deploy vApp params
+	MimeDeployVappParams = "application/vnd.vmware.vcloud.deployVAppParams+xml"
+	// Mime for VM
+	MimeVM = "application/vnd.vmware.vcloud.vm+xml"
+	// Mime for instantiate vApp template params
+	MimeInstantiateVappTemplateParams = "application/vnd.vmware.vcloud.instantiateVAppTemplateParams+xml"
+	// Mime for product section
+	MimeProductSection = "application/vnd.vmware.vcloud.productSections+xml"
+	// Mime for metadata
+	MimeMetaData = "application/vnd.vmware.vcloud.metadata+xml"
+	// Mime for metadata value
+	MimeMetaDataValue = "application/vnd.vmware.vcloud.metadata.value+xml"
 )
 
 const (

--- a/vendor/github.com/vmware/go-vcloud-director/v2/types/v56/constants.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/types/v56/constants.go
@@ -22,15 +22,6 @@ const (
 )
 
 const (
-	// NsOvf the ovf xml namespace url
-	NsOvf = "http://schemas.dmtf.org/ovf/envelope/1"
-	// NsXMLSchema the xml schema namespace url
-	NsXMLSchema = "http://www.w3.org/2001/XMLSchema-instance"
-	// NsVCloud vcloud xml namespace url
-	NsVCloud = "http://www.vmware.com/vcloud/v1.5"
-)
-
-const (
 	// MimeOrgList mime for org list
 	MimeOrgList = "application/vnd.vmware.vcloud.orgList+xml"
 	// MimeOrg mime for org
@@ -103,4 +94,42 @@ const (
 
 const (
 	VMsCDResourceSubType = "vmware.cdrom.iso"
+)
+
+// https://blogs.vmware.com/vapp/2009/11/virtual-hardware-in-ovf-part-1.html
+
+const (
+	ResourceTypeOther     int = 0
+	ResourceTypeProcessor int = 3
+	ResourceTypeMemory    int = 4
+	ResourceTypeIDE       int = 5
+	ResourceTypeSCSI      int = 6
+	ResourceTypeEthernet  int = 10
+	ResourceTypeFloppy    int = 14
+	ResourceTypeCD        int = 15
+	ResourceTypeDVD       int = 16
+	ResourceTypeDisk      int = 17
+	ResourceTypeUSB       int = 23
+)
+
+const (
+	FenceModeIsolated = "isolated"
+	FenceModeBridged  = "bridged"
+	FenceModeNAT      = "natRouted"
+)
+
+const (
+	IPAllocationModeDHCP   = "DHCP"
+	IPAllocationModeManual = "MANUAL"
+	IPAllocationModeNone   = "NONE"
+	IPAllocationModePool   = "POOL"
+)
+
+const (
+	XMLNamespaceVCloud = "http://www.vmware.com/vcloud/v1.5"
+	XMLNamespaceOVF    = "http://schemas.dmtf.org/ovf/envelope/1"
+	XMLNamespaceVMW    = "http://www.vmware.com/schema/ovf"
+	XMLNamespaceXSI    = "http://www.w3.org/2001/XMLSchema-instance"
+	XMLNamespaceRASD   = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData"
+	XMLNamespaceVSSD   = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData"
 )

--- a/vendor/github.com/vmware/go-vcloud-director/v2/util/logging.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/util/logging.go
@@ -360,7 +360,7 @@ func FuncNameCallStack() string {
 	fpcs := make([]uintptr, 10)
 	runtime.Callers(0, fpcs)
 	// Removes the function names from the reflect stack itself and the ones from the API management
-	removeReflect := regexp.MustCompile(`^ runtime.call|reflect.Value|\bNewRequest\b|NewRequestWitNotEncodedParams`)
+	removeReflect := regexp.MustCompile(`^ runtime.call|reflect.Value|\bNewRequest\b|NewRequestWitNotEncodedParams|ExecuteRequest|ExecuteRequestWithoutResponse|ExecuteTaskRequest`)
 	var stackStr []string
 	// Gets up to 10 functions from the stack
 	for N := 0; N < len(fpcs) && N < 10; N++ {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -157,7 +157,7 @@ github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
 github.com/ulikunitz/xz/internal/hash
-# github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.1 => github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190417085158-6cbca97d9053
+# github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.1 => github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190419085123-885ddab6bd61
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -157,7 +157,7 @@ github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
 github.com/ulikunitz/xz/internal/hash
-# github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.1 => github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190411133523-6676eb189c4d
+# github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.1 => github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190416112520-dcfd6747a9ce
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -157,7 +157,7 @@ github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
 github.com/ulikunitz/xz/internal/hash
-# github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.1 => github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190416112520-dcfd6747a9ce
+# github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.1 => github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190417085158-6cbca97d9053
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -71,7 +71,7 @@ github.com/hashicorp/go-plugin
 github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-uuid v1.0.0
 github.com/hashicorp/go-uuid
-# github.com/hashicorp/go-version v1.0.0
+# github.com/hashicorp/go-version v1.1.0
 github.com/hashicorp/go-version
 # github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
 github.com/hashicorp/hcl
@@ -157,7 +157,7 @@ github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
 github.com/ulikunitz/xz/internal/hash
-# github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.1
+# github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.1 => github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190411133523-6676eb189c4d
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -157,7 +157,7 @@ github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
 github.com/ulikunitz/xz/internal/hash
-# github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.1 => github.com/Didainius/go-vcloud-director/v2 v2.2.0-alpha.1.0.20190419085123-885ddab6bd61
+# github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.2
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util

--- a/website/docs/r/vapp_vm.html.markdown
+++ b/website/docs/r/vapp_vm.html.markdown
@@ -109,9 +109,9 @@ The following arguments are supported:
 * `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations
 * `vdc` - (Optional; *v2.0+*) The name of VDC to use, optional if defined at provider level
 * `disk` - (Optional; *v2.1+*) Independent disk attachment configuration. Details below
-* `expose_hardware_virtualization` - (Optional; *v2.2+*) Boolean for exposing full CPU virtualization to the guest operating. It
-system so that applications that require hardware virtualization can run on virtual machines without binary translation or
-paravirtualization. Useful for hypervisor nesting provided underlying hardware supports it. Default is `false`.
+* `expose_hardware_virtualization` - (Optional; *v2.2+*) Boolean for exposing full CPU virtualization to the
+guest operating system so that applications that require hardware virtualization can run on virtual machines without binary
+translation or paravirtualization. Useful for hypervisor nesting provided underlying hardware supports it. Default is `false`.
 
 Independent disk support the following attributes:
 

--- a/website/docs/r/vapp_vm.html.markdown
+++ b/website/docs/r/vapp_vm.html.markdown
@@ -109,9 +109,9 @@ The following arguments are supported:
 * `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations
 * `vdc` - (Optional; *v2.0+*) The name of VDC to use, optional if defined at provider level
 * `disk` - (Optional; *v2.1+*) Independent disk attachment configuration. Details below
-* `hardware_assisted_virtualization` - (Optional; *v2.2+*) Boolean for exposing full CPU virtualization to the guest operating
+* `expose_hardware_virtualization` - (Optional; *v2.2+*) Boolean for exposing full CPU virtualization to the guest operating. It
 system so that applications that require hardware virtualization can run on virtual machines without binary translation or
-paravirtualization. Useful for hypervisor nesting. Default is `false`.
+paravirtualization. Useful for hypervisor nesting provided underlying hardware supports it. Default is `false`.
 
 Independent disk support the following attributes:
 

--- a/website/docs/r/vapp_vm.html.markdown
+++ b/website/docs/r/vapp_vm.html.markdown
@@ -109,6 +109,9 @@ The following arguments are supported:
 * `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations
 * `vdc` - (Optional; *v2.0+*) The name of VDC to use, optional if defined at provider level
 * `disk` - (Optional; *v2.1+*) Independent disk attachment configuration. Details below
+* `hardware_assisted_virtualization` - (Optional; *v2.2+*) Boolean for exposing full CPU virtualization to the guest operating
+system so that applications that require hardware virtualization can run on virtual machines without binary translation or
+paravirtualization. Useful for hypervisor nesting. Default is `false`.
 
 Independent disk support the following attributes:
 


### PR DESCRIPTION
Closes #219.
It allows to enable [hardware assisted CPU virtualization](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-2A98801C-68E8-47AF-99ED-00C63E4857F6.html) which is mainly used for hypervisor nesting (ESXi on ESXi) scenarios. It is a very much needed feature for establishing environment LAB.

In addition to this there are few more tidy-ups added:
* ~~`type StringMap` has two attached methods `Copy()` and `CopyMutateKey(key string, value interface{})` for convenience while writing multistep acceptance tests while altering single key in configParams.~~
* A few code cleanups in 1b230e3, 114dbb1,  6efc369
* Changed checked functions `testAccCheckVcdVAppVmExists` and `testAccCheckVcdVAppVmDestroy` to accept vApp and VM names instead of hardcoded ones.

~~One issue which is spotted is that if a test has multiple steps the `test-artifacts` file will get overwritten with the latest version (which can mask error while troubleshooting multistep acceptance tests). I did not change it there, but my proposal would be to:~~
~~*Flush `test-artifacts` directory on new test run~~
~~*During test run while writing the `.tf` file check if it exists. If it does then increment it's name with something like `testName-stepX.tf`. That way the original file for step0 would be called as it was called, but the subsequent steps would be clearly distinguishable.~~
Using `FuncName` to split test-artifact files.

Full test suite run on vCD 9.5

**Note**. go.mod is temporary pointed to my fork to make Travis work. It will be changed before merge.