### PR TITLE
Add tests for multiple entities in vApp

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,13 +16,13 @@ install: build
 	@$(CURDIR)/scripts/install-plugin.sh
 
 test: fmtcheck
-	@$(CURDIR)/scripts/runtest.sh short
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' short"
 
 testacc: fmtcheck
-	@$(CURDIR)/scripts/runtest.sh acceptance
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' acceptance"
 
 testmulti: fmtcheck
-	@$(CURDIR)/scripts/runtest.sh multiple
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' multiple"
 
 
 vet:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,15 +16,14 @@ install: build
 	@$(CURDIR)/scripts/install-plugin.sh
 
 test: fmtcheck
-	go test -i $(TEST) || exit 1
-	cd vcd ; VCD_SHORT_TEST=1 go test -v . -timeout 3m
+	@$(CURDIR)/scripts/runtest.sh short
 
 testacc: fmtcheck
-	if [ ! -f vcd/vcd_test_config.json -a -z "${VCD_CONFIG}" ] ; then \
-		echo "ERROR: test configuration file vcd/vcd_test_config.json is missing"; \
-		exit 1; \
-	fi
-	cd vcd ; TF_ACC=1 go test -v . -timeout 60m
+	@$(CURDIR)/scripts/runtest.sh acceptance
+
+testmulti: fmtcheck
+	@$(CURDIR)/scripts/runtest.sh multiple
+
 
 vet:
 	@echo "go vet ."

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -54,12 +54,12 @@ function check_for_config_file {
 function short_test {
     if [ -n "$VERBOSE" ] 
     then
-        echo " go test -i $(TEST) || exit 1"
+        echo " go test -i ${TEST} || exit 1"
 	    echo "VCD_SHORT_TEST=1 go test -v -timeout 3m ."
     fi
     if [ -z "$DRY_RUN" ]
     then
-	    go test -i $(TEST) || exit 1
+	    go test -i ${TEST} || exit 1
 	    VCD_SHORT_TEST=1 go test -v -timeout 3m .
     fi
 }
@@ -79,16 +79,21 @@ function acceptance_test {
 }
 
 function multiple_test {
+    filter=$1
+    if [ -z "$filter" ]
+    then
+        filter='TestAccVcdV.pp.*Multi'
+    fi
     if [ -n "$VERBOSE" ] 
     then
         echo "# check for config file"
-	    echo "TF_ACC=1 go test -v -timeout 60m -tags 'multivm multinetwork' -run 'TestAccVcdV.pp.*Multi' ."
+	    echo "TF_ACC=1 go test -v -timeout 60m -tags 'multivm multinetwork' -run '$filter' ."
     fi
 
     if [ -z "$DRY_RUN" ]
     then
         check_for_config_file
-	    TF_ACC=1 go test -v -timeout 60m -tags 'multivm multinetwork' -run 'TestAccVcdV.pp.*Multi' .
+	    TF_ACC=1 go test -v -timeout 60m -tags 'multivm multinetwork' -run "$filter" .
     fi
 }
 
@@ -98,6 +103,9 @@ case $wanted in
         ;;
     acceptance)
         acceptance_test
+        ;;
+    multinetwork)
+        multiple_test TestAccVcdVappNetworkMulti
         ;;
     multiple)
         multiple_test

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+if [ ! -d ./vcd ]
+then
+    echo "source directory ./vcd not found"
+    exit 1
+fi
+
+wanted=$1
+
+if [ -n "$DRY_RUN" ]
+then
+    VERBOSE=1
+fi
+
+accepted="[short acceptance multiple]"
+if [ -z "$wanted" ]
+then
+    echo "Syntax: test TYPE"
+    echo "    where TYPE is one of $accepted"
+    exit 1
+fi
+
+# Adding some aliases to the accepted methods
+if [ "$wanted" == "multi" ]
+then
+    wanted=multiple
+fi
+if [ "$wanted" == "acc" ]
+then
+    wanted=acceptance
+fi
+
+# Run test
+echo "==> Run test $wanted"
+
+cd vcd
+
+function check_for_config_file {
+    config_file=vcd_test_config.json
+    if [ -n "${VCD_CONFIG}" ]
+    then
+        echo "Using configuration file from variable \$VCD_CONFIG"
+        config_file=$VCD_CONFIG
+    fi
+	if [ ! -f $config_file ]
+    then
+		echo "ERROR: test configuration file $config_file is missing"; \
+		exit 1
+	fi
+
+}
+
+function short_test {
+    if [ -n "$VERBOSE" ] 
+    then
+        echo " go test -i $(TEST) || exit 1"
+	    echo "VCD_SHORT_TEST=1 go test -v -timeout 3m ."
+    fi
+    if [ -z "$DRY_RUN" ]
+    then
+	    go test -i $(TEST) || exit 1
+	    VCD_SHORT_TEST=1 go test -v -timeout 3m .
+    fi
+}
+
+function acceptance_test {
+    if [ -n "$VERBOSE" ] 
+    then
+        echo "# check for config file"
+	    echo "TF_ACC=1 go test -v -timeout 60m ."
+    fi
+
+    if [ -z "$DRY_RUN" ]
+    then
+        check_for_config_file
+	    TF_ACC=1 go test -v -timeout 60m .
+    fi
+}
+
+function multiple_test {
+    if [ -n "$VERBOSE" ] 
+    then
+        echo "# check for config file"
+	    echo "TF_ACC=1 go test -v -timeout 60m -tags 'multivm multinetwork' -run 'TestAccVcdV.pp.*Multi' ."
+    fi
+
+    if [ -z "$DRY_RUN" ]
+    then
+        check_for_config_file
+	    TF_ACC=1 go test -v -timeout 60m -tags 'multivm multinetwork' -run 'TestAccVcdV.pp.*Multi' .
+    fi
+}
+
+case $wanted in 
+    short)
+        short_test
+        ;;
+    acceptance)
+        acceptance_test
+        ;;
+    multiple)
+        multiple_test
+        ;;
+    *)
+        echo "Unhandled testing method $wanted"
+        echo "Accepted methods: $accepted"
+        exit 1
+esac

--- a/vcd/resource_vcd_vapp_network_multi_test.go
+++ b/vcd/resource_vcd_vapp_network_multi_test.go
@@ -29,9 +29,16 @@ func TestAccVcdVappNetworkMulti(t *testing.T) {
 	}
 
 	const (
-		gatewayMulti1 = "192.168.1.1"
-		gatewayMulti2 = "192.168.2.1"
-		gatewayMulti3 = "192.168.3.1"
+		networkBaseIp1     = "192.168.11"
+		networkBaseIp2     = "192.168.12"
+		networkBaseIp3     = "192.168.13"
+		startStaticAddress = ".11"
+		endStaticAddress   = ".20"
+		startDhcpAddress   = ".21"
+		endDhcpAddress     = ".30"
+		gatewayMulti1      = networkBaseIp1 + ".1"
+		gatewayMulti2      = networkBaseIp2 + ".1"
+		gatewayMulti3      = networkBaseIp3 + ".1"
 	)
 	resourceName1 := "TestVappNetwork1"
 	resourceName2 := "TestVappNetwork2"
@@ -54,21 +61,21 @@ func TestAccVcdVappNetworkMulti(t *testing.T) {
 		"dns2":              dns2,
 		"dnsSuffix":         dnsSuffix,
 		"guestVlanAllowed":  guestVlanAllowed,
-		"startAddress1":     "192.168.1.10",
-		"endAddress1":       "192.168.1.20",
-		"startAddress2":     "192.168.2.10",
-		"endAddress2":       "192.168.2.20",
-		"startAddress3":     "192.168.3.10",
-		"endAddress3":       "192.168.3.20",
+		"startAddress1":     networkBaseIp1 + startStaticAddress,
+		"endAddress1":       networkBaseIp1 + endStaticAddress,
+		"startAddress2":     networkBaseIp2 + startStaticAddress,
+		"endAddress2":       networkBaseIp2 + endStaticAddress,
+		"startAddress3":     networkBaseIp3 + startStaticAddress,
+		"endAddress3":       networkBaseIp3 + endStaticAddress,
 		"vappName":          vappNameForNetworkMulti,
 		"maxLeaseTime":      "7200",
 		"defaultLeaseTime":  "3600",
-		"dhcpStartAddress1": "192.168.1.21",
-		"dhcpEndAddress1":   "192.168.1.22",
-		"dhcpStartAddress2": "192.168.2.21",
-		"dhcpEndAddress2":   "192.168.2.22",
-		"dhcpStartAddress3": "192.168.3.21",
-		"dhcpEndAddress3":   "192.168.3.22",
+		"dhcpStartAddress1": networkBaseIp1 + startDhcpAddress,
+		"dhcpEndAddress1":   networkBaseIp1 + endDhcpAddress,
+		"dhcpStartAddress2": networkBaseIp2 + startDhcpAddress,
+		"dhcpEndAddress2":   networkBaseIp2 + endDhcpAddress,
+		"dhcpStartAddress3": networkBaseIp3 + startDhcpAddress,
+		"dhcpEndAddress3":   networkBaseIp3 + endDhcpAddress,
 		"dhcpEnabled":       "true",
 	}
 

--- a/vcd/resource_vcd_vapp_network_multi_test.go
+++ b/vcd/resource_vcd_vapp_network_multi_test.go
@@ -1,0 +1,282 @@
+// +build multinetwork
+
+package vcd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+const (
+	vappNetworkName1        = "TestVappNetwork1"
+	vappNetworkName2        = "TestVappNetwork2"
+	vappNetworkName3        = "TestVappNetwork3"
+	vappNameForNetworkMulti = "TestAccVappForNetworkMulti"
+)
+
+// Creates a VM with three vApp networks
+// To execute this test, rungo test -v -timeout 0 -tags multinetwork -run TestAccVcdVappNetworkMulti .
+//
+func TestAccVcdVappNetworkMulti(t *testing.T) {
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	const (
+		gatewayMulti1 = "192.168.1.1"
+		gatewayMulti2 = "192.168.2.1"
+		gatewayMulti3 = "192.168.3.1"
+	)
+	resourceName1 := "TestVappNetwork1"
+	resourceName2 := "TestVappNetwork2"
+	resourceName3 := "TestVappNetwork3"
+
+	var params = StringMap{
+		"Org":               testConfig.VCD.Org,
+		"Vdc":               testConfig.VCD.Vdc,
+		"resourceName1":     resourceName1,
+		"resourceName2":     resourceName2,
+		"resourceName3":     resourceName3,
+		"vappNetworkName1":  vappNetworkName1,
+		"vappNetworkName2":  vappNetworkName2,
+		"vappNetworkName3":  vappNetworkName3,
+		"gateway1":          gatewayMulti1,
+		"gateway2":          gatewayMulti2,
+		"gateway3":          gatewayMulti3,
+		"netmask":           netmask,
+		"dns1":              dns1,
+		"dns2":              dns2,
+		"dnsSuffix":         dnsSuffix,
+		"guestVlanAllowed":  guestVlanAllowed,
+		"startAddress1":     "192.168.1.10",
+		"endAddress1":       "192.168.1.20",
+		"startAddress2":     "192.168.2.10",
+		"endAddress2":       "192.168.2.20",
+		"startAddress3":     "192.168.3.10",
+		"endAddress3":       "192.168.3.20",
+		"vappName":          vappNameForNetworkMulti,
+		"maxLeaseTime":      "7200",
+		"defaultLeaseTime":  "3600",
+		"dhcpStartAddress1": "192.168.1.21",
+		"dhcpEndAddress1":   "192.168.1.22",
+		"dhcpStartAddress2": "192.168.2.21",
+		"dhcpEndAddress2":   "192.168.2.22",
+		"dhcpStartAddress3": "192.168.3.21",
+		"dhcpEndAddress3":   "192.168.3.22",
+		"dhcpEnabled":       "true",
+	}
+
+	configText := templateFill(testAccCheckVappNetworkMulti, params)
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVappNetworkMultiDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVappNetworkMultiExists("vcd_vapp_network."+resourceName1),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_network."+resourceName1, "gateway", gatewayMulti1),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_network."+resourceName2, "gateway", gatewayMulti2),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_network."+resourceName3, "gateway", gatewayMulti3),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_network."+resourceName1, "netmask", netmask),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_network."+resourceName1, "dns1", dns1),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_network."+resourceName1, "dns2", dns2),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_network."+resourceName1, "dns_suffix", dnsSuffix),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_network."+resourceName1, "guest_vlan_allowed", guestVlanAllowed),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVappNetworkMultiExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no vapp network ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		status, err := isVappNetworkMultiFound(conn, rs)
+		if err != nil {
+			return err
+		}
+
+		if status != "installed" {
+			return fmt.Errorf("vApp network was not installed. Status: %s", status)
+		}
+
+		return nil
+	}
+}
+
+// TODO: In future this can be improved to check if network delete only,
+// when test suite will create vApp which can be reused
+func testAccCheckVappNetworkMultiDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*VCDClient)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vcd_vapp" {
+			continue
+		}
+
+		_, err := isVappNetworkMultiFound(conn, rs)
+		if err != nil && !strings.Contains(err.Error(), "can't find vApp:") {
+			return fmt.Errorf("vapp %s still exist and error: %#v", itemName, err)
+		}
+	}
+
+	return nil
+}
+
+func isVappNetworkMultiFound(conn *VCDClient, rs *terraform.ResourceState) (string, error) {
+	_, vdc, err := conn.GetOrgAndVdc(testConfig.VCD.Org, testConfig.VCD.Vdc)
+	if err != nil {
+		return "uninstalled", fmt.Errorf(errorRetrievingOrgAndVdc, err)
+	}
+
+	vapp, err := vdc.FindVAppByName(vappNameForNetworkMulti)
+	if err != nil {
+		return "uninstalled", fmt.Errorf("error retrieving vApp: %s, %#v", rs.Primary.ID, err)
+	}
+
+	networkConfig, err := vapp.GetNetworkConfig()
+	if err != nil {
+		return "uninstalled", fmt.Errorf("error retrieving network config from vApp: %#v", err)
+	}
+
+	var foundNetworks int
+	for _, vappNetworkConfig := range networkConfig.NetworkConfig {
+		if vappNetworkConfig.Configuration.IPScopes.IPScope.DNSSuffix == dnsSuffix {
+			switch vappNetworkConfig.NetworkName {
+			case vappNetworkName1:
+				foundNetworks += 10
+			case vappNetworkName2:
+				foundNetworks += 100
+			case vappNetworkName3:
+				foundNetworks += 1000
+			}
+		}
+	}
+
+	if foundNetworks == 1110 {
+		return "installed", nil
+	} else {
+		if foundNetworks > 0 {
+			return "partial", nil
+		}
+	}
+	return "uninstalled", nil
+}
+
+const testAccCheckVappNetworkMulti = `
+resource "vcd_vapp" "{{.vappName}}" {
+  name = "{{.vappName}}"
+  org  = "{{.Org}}"
+  vdc  = "{{.Vdc}}"
+}
+
+resource "vcd_vapp_network" "{{.resourceName1}}" {
+  org                = "{{.Org}}"
+  vdc                = "{{.Vdc}}"
+  name               = "{{.vappNetworkName1}}"
+  vapp_name          = "{{.vappName}}"
+  gateway            = "{{.gateway1}}"
+  netmask            = "{{.netmask}}"
+  dns1               = "{{.dns1}}"
+  dns2               = "{{.dns2}}"
+  dns_suffix         = "{{.dnsSuffix}}"
+  guest_vlan_allowed = "{{.guestVlanAllowed}}"
+
+  static_ip_pool {
+    start_address = "{{.startAddress1}}"
+    end_address   = "{{.endAddress1}}"
+  }
+
+  dhcp_pool {
+    max_lease_time     = "{{.maxLeaseTime}}"
+    default_lease_time = "{{.defaultLeaseTime}}"
+    start_address      = "{{.dhcpStartAddress1}}"
+    end_address        = "{{.dhcpEndAddress1}}"
+    enabled            = "{{.dhcpEnabled}}"
+  }
+
+  depends_on = ["vcd_vapp.{{.vappName}}"]
+}
+
+resource "vcd_vapp_network" "{{.resourceName2}}" {
+  org                = "{{.Org}}"
+  vdc                = "{{.Vdc}}"
+  name               = "{{.vappNetworkName2}}"
+  vapp_name          = "{{.vappName}}"
+  gateway            = "{{.gateway2}}"
+  netmask            = "{{.netmask}}"
+  dns1               = "{{.dns1}}"
+  dns2               = "{{.dns2}}"
+  dns_suffix         = "{{.dnsSuffix}}"
+  guest_vlan_allowed = "{{.guestVlanAllowed}}"
+
+  static_ip_pool {
+    start_address = "{{.startAddress2}}"
+    end_address   = "{{.endAddress2}}"
+  }
+
+  dhcp_pool {
+    max_lease_time     = "{{.maxLeaseTime}}"
+    default_lease_time = "{{.defaultLeaseTime}}"
+    start_address      = "{{.dhcpStartAddress2}}"
+    end_address        = "{{.dhcpEndAddress2}}"
+    enabled            = "{{.dhcpEnabled}}"
+  }
+
+  depends_on = ["vcd_vapp.{{.vappName}}"]
+}
+
+resource "vcd_vapp_network" "{{.resourceName3}}" {
+  org                = "{{.Org}}"
+  vdc                = "{{.Vdc}}"
+  name               = "{{.vappNetworkName3}}"
+  vapp_name          = "{{.vappName}}"
+  gateway            = "{{.gateway3}}"
+  netmask            = "{{.netmask}}"
+  dns1               = "{{.dns1}}"
+  dns2               = "{{.dns2}}"
+  dns_suffix         = "{{.dnsSuffix}}"
+  guest_vlan_allowed = "{{.guestVlanAllowed}}"
+
+  static_ip_pool {
+    start_address = "{{.startAddress3}}"
+    end_address   = "{{.endAddress3}}"
+  }
+
+  dhcp_pool {
+    max_lease_time     = "{{.maxLeaseTime}}"
+    default_lease_time = "{{.defaultLeaseTime}}"
+    start_address      = "{{.dhcpStartAddress3}}"
+    end_address        = "{{.dhcpEndAddress3}}"
+    enabled            = "{{.dhcpEnabled}}"
+  }
+
+  depends_on = ["vcd_vapp.{{.vappName}}"]
+}
+`

--- a/vcd/resource_vcd_vapp_network_multi_test.go
+++ b/vcd/resource_vcd_vapp_network_multi_test.go
@@ -19,7 +19,8 @@ const (
 )
 
 // Creates a VM with three vApp networks
-// To execute this test, rungo test -v -timeout 0 -tags multinetwork -run TestAccVcdVappNetworkMulti .
+// To execute this test, run
+// go test -v -timeout 0 -tags multinetwork -run TestAccVcdVappNetworkMulti .
 //
 func TestAccVcdVappNetworkMulti(t *testing.T) {
 	if vcdShortTest {

--- a/vcd/resource_vcd_vapp_raw_multi_test.go
+++ b/vcd/resource_vcd_vapp_raw_multi_test.go
@@ -1,0 +1,172 @@
+// +build multivm
+
+package vcd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+)
+
+// Extends TestAccVcdVAppRawM with multiple VMs
+// To execute this test, run
+// go test -v -timeout 0 -tags multivm -run TestAccVcdVAppRawMulti .
+func TestAccVcdVAppRawMulti(t *testing.T) {
+	var vapp govcd.VApp
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	var params = StringMap{
+		"Org":         testConfig.VCD.Org,
+		"Vdc":         testConfig.VCD.Vdc,
+		"EdgeGateway": testConfig.Networking.EdgeGateway,
+		"NetworkName": "TestAccVcdVAppRawNet",
+		"Catalog":     testSuiteCatalogName,
+		"CatalogItem": testSuiteCatalogOVAItem,
+		"VappName":    "TestAccVcdVAppRawVapp",
+		"VmName1":     "TestAccVcdVAppRawVm1",
+		"VmName2":     "TestAccVcdVAppRawVm2",
+		"VmName3":     "TestAccVcdVAppRawVm3",
+	}
+	configText := templateFill(testAccCheckVcdVAppRawMulti, params)
+	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVcdVAppRawMultiDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVcdVAppRawMultiExists(fmt.Sprintf("vcd_vapp.%s", params["VappName"].(string)), &vapp),
+					resource.TestCheckResourceAttr(
+						fmt.Sprintf("vcd_vapp.%s", params["VappName"].(string)), "name", params["VappName"].(string)),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVcdVAppRawMultiExists(n string, vapp *govcd.VApp) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no VAPP ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*VCDClient)
+		_, vdc, err := conn.GetOrgAndVdc(testConfig.VCD.Org, testConfig.VCD.Vdc)
+		if err != nil {
+			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
+		}
+
+		resp, err := vdc.FindVAppByName(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*vapp = resp
+
+		return nil
+	}
+}
+
+func testAccCheckVcdVAppRawMultiDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*VCDClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vcd_vapp" {
+			continue
+		}
+		_, vdc, err := conn.GetOrgAndVdc(testConfig.VCD.Org, testConfig.VCD.Vdc)
+		if err != nil {
+			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
+		}
+
+		_, err = vdc.FindVAppByName(rs.Primary.ID)
+
+		if err == nil {
+			return fmt.Errorf("VPCs still exist")
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+const testAccCheckVcdVAppRawMulti = `
+resource "vcd_network_routed" "{{.NetworkName}}" {
+  name         = "{{.NetworkName}}"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  gateway      = "10.10.102.1"
+
+  static_ip_pool {
+    start_address = "10.10.102.2"
+    end_address   = "10.10.102.254"
+  }
+}
+
+resource "vcd_vapp" "{{.VappName}}" {
+  org  = "{{.Org}}"
+  vdc  = "{{.Vdc}}"
+  name = "{{.VappName}}"
+}
+
+resource "vcd_vapp_vm" "{{.VmName1}}" {
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  vapp_name     = "${vcd_vapp.{{.VappName}}.name}"
+  name          = "{{.VmName1}}"
+  catalog_name  = "{{.Catalog}}"
+  template_name = "{{.CatalogItem}}"
+  memory        = 1024
+  cpus          = 1
+
+  network_name = "${vcd_network_routed.{{.NetworkName}}.name}"
+  ip           = "10.10.102.161"
+  depends_on   = ["vcd_vapp.{{.VappName}}"]
+}
+
+resource "vcd_vapp_vm" "{{.VmName2}}" {
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  vapp_name     = "${vcd_vapp.{{.VappName}}.name}"
+  name          = "{{.VmName2}}"
+  catalog_name  = "{{.Catalog}}"
+  template_name = "{{.CatalogItem}}"
+  memory        = 1024
+  cpus          = 1
+
+  network_name = "${vcd_network_routed.{{.NetworkName}}.name}"
+  ip           = "10.10.102.162"
+  depends_on   = ["vcd_vapp.{{.VappName}}"]
+}
+
+resource "vcd_vapp_vm" "{{.VmName3}}" {
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  vapp_name     = "${vcd_vapp.{{.VappName}}.name}"
+  name          = "{{.VmName3}}"
+  catalog_name  = "{{.Catalog}}"
+  template_name = "{{.CatalogItem}}"
+  memory        = 1024
+  cpus          = 1
+
+  network_name = "${vcd_network_routed.{{.NetworkName}}.name}"
+  ip           = "10.10.102.163"
+  depends_on   = ["vcd_vapp.{{.VappName}}"]
+}
+`

--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -1,0 +1,214 @@
+// +build multivm
+
+package vcd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+)
+
+// To execute this test, run
+// go test -v -timeout 0 -tags multivm -run TestAccVcdVappVM .
+// Extends TestAccVcdVappVM with multiple VMs
+func TestAccVcdVAppVmMulti(t *testing.T) {
+	var (
+		vapp              govcd.VApp
+		vm                govcd.VM
+		diskResourceNameM string = "TestAccVcdVAppVmMulti"
+		vappName2         string = "TestAccVcdVAppVmVappM"
+		diskName          string = "TestAccVcdIndependentDiskMulti"
+		vmName1           string = "TestAccVcdVAppVmVm1"
+		vmName2           string = "TestAccVcdVAppVmVm2"
+		vmName3           string = "TestAccVcdVAppVmVm3"
+	)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	var params = StringMap{
+		"Org":                testConfig.VCD.Org,
+		"Vdc":                testConfig.VCD.Vdc,
+		"EdgeGateway":        testConfig.Networking.EdgeGateway,
+		"NetworkName":        "TestAccVcdVAppVmNet",
+		"Catalog":            testSuiteCatalogName,
+		"CatalogItem":        testSuiteCatalogOVAItem,
+		"VappName":           vappName2,
+		"VmName1":            vmName1,
+		"VmName2":            vmName2,
+		"VmName3":            vmName3,
+		"diskName":           diskName,
+		"size":               "5",
+		"busType":            "SCSI",
+		"busSubType":         "lsilogicsas",
+		"storageProfileName": "*",
+		"diskResourceName":   diskResourceNameM,
+	}
+
+	configText := templateFill(testAccCheckVcdVAppVmMulti, params)
+	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVcdVAppVmMultiDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVcdVAppVmMultiExists("vcd_vapp_vm."+vmName, &vapp, &vm),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_vm."+vmName, "name", vmName),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_vm."+vmName, "ip", "10.10.102.161"),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp_vm."+vmName, "power_on", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVcdVAppVmMultiExists(n string, vapp *govcd.VApp, vm *govcd.VM) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no VAPP ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*VCDClient)
+		_, vdc, err := conn.GetOrgAndVdc(testConfig.VCD.Org, testConfig.VCD.Vdc)
+		if err != nil {
+			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
+		}
+
+		vapp, err := vdc.FindVAppByName(vappName2)
+
+		resp, err := vdc.FindVMByName(vapp, vmName)
+
+		if err != nil {
+			return err
+		}
+
+		*vm = resp
+
+		return nil
+	}
+}
+
+func testAccCheckVcdVAppVmMultiDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*VCDClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vcd_vapp" {
+			continue
+		}
+		_, vdc, err := conn.GetOrgAndVdc(testConfig.VCD.Org, testConfig.VCD.Vdc)
+		if err != nil {
+			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
+		}
+
+		_, err = vdc.FindVAppByName(vappName2)
+
+		if err == nil {
+			return fmt.Errorf("VPCs still exist")
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+const testAccCheckVcdVAppVmMulti = `
+resource "vcd_network_routed" "{{.NetworkName}}" {
+  name         = "{{.NetworkName}}"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  gateway      = "10.10.102.1"
+
+  static_ip_pool {
+    start_address = "10.10.102.2"
+    end_address   = "10.10.102.254"
+  }
+}
+
+resource "vcd_independent_disk" "{{.diskResourceName}}" {
+  org             = "{{.Org}}"
+  vdc             = "{{.Vdc}}"
+  name            = "{{.diskName}}"
+  size            = "{{.size}}"
+  bus_type        = "{{.busType}}"
+  bus_sub_type    = "{{.busSubType}}"
+  storage_profile = "{{.storageProfileName}}"
+}
+
+resource "vcd_vapp" "{{.VappName}}" {
+  name = "{{.VappName}}"
+  org  = "{{.Org}}"
+  vdc  = "{{.Vdc}}"
+}
+
+resource "vcd_vapp_vm" "{{.VmName1}}" {
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  vapp_name     = "${vcd_vapp.{{.VappName}}.name}"
+  network_name  = "${vcd_network_routed.{{.NetworkName}}.name}"
+  name          = "{{.VmName1}}"
+  catalog_name  = "{{.Catalog}}"
+  template_name = "{{.CatalogItem}}"
+  memory        = 1024
+  cpus          = 2
+  cpu_cores     = 1
+  ip            = "10.10.102.161"
+
+  disk {
+    name = "${vcd_independent_disk.{{.diskResourceName}}.name}"
+    bus_number = 1
+    unit_number = 0
+  }
+
+  depends_on    = ["vcd_vapp.{{.VappName}}","vcd_independent_disk.{{.diskResourceName}}", "vcd_network_routed.{{.NetworkName}}"]
+}
+
+resource "vcd_vapp_vm" "{{.VmName2}}" {
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  vapp_name     = "${vcd_vapp.{{.VappName}}.name}"
+  network_name  = "${vcd_network_routed.{{.NetworkName}}.name}"
+  name          = "{{.VmName2}}"
+  catalog_name  = "{{.Catalog}}"
+  template_name = "{{.CatalogItem}}"
+  memory        = 1024
+  cpus          = 2
+  cpu_cores     = 1
+  ip            = "10.10.102.162"
+
+  depends_on    = ["vcd_vapp.{{.VappName}}", "vcd_network_routed.{{.NetworkName}}"]
+}
+
+resource "vcd_vapp_vm" "{{.VmName3}}" {
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  vapp_name     = "${vcd_vapp.{{.VappName}}.name}"
+  network_name  = "${vcd_network_routed.{{.NetworkName}}.name}"
+  name          = "{{.VmName3}}"
+  catalog_name  = "{{.Catalog}}"
+  template_name = "{{.CatalogItem}}"
+  memory        = 1024
+  cpus          = 2
+  cpu_cores     = 1
+  ip            = "10.10.102.163"
+
+  depends_on    = ["vcd_vapp.{{.VappName}}", "vcd_network_routed.{{.NetworkName}}"]
+}
+
+`

--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // To execute this test, run
-// go test -v -timeout 0 -tags multivm -run TestAccVcdVappVM .
+// go test -v -timeout 0 -tags multivm -run TestAccVcdVAppVmMulti .
 // Extends TestAccVcdVappVM with multiple VMs
 func TestAccVcdVAppVmMulti(t *testing.T) {
 	var (


### PR DESCRIPTION
The purpose of this addition is to have tests with multiple entities in a vApp. We have realized that vApp operations are serialized, but Terraform executes them in parallel. These tests will fail now, but they will be useful when we have a fix for the way operations are handled now, and we can test that the improved implementation works as expected.

To avoid breaking current tests, these tests with multiple entities are walled behind build tags. These special tests won't work unless the tags are mentioned in the test run command.

Examples of how to run the tests:
```
go test -v -timeout 0 -tags multivm -run TestAccVcdVAppNetworkMulti .
go test -v -timeout 0 -tags multivm -run TestAccVcdVappVmMulti .
go test -v -timeout 0 -tags multinetwork -run TestAccVcdVappRawMulti .
```
Or:

```
go test -v -timeout 0 -tags 'multivm multinetwork ' -run 'TestAccVcdV.pp.*Multi' .
```
Or:
```
make testmulti
```

These tests should help in the resolution of the above stated problem. Here are a few facts that I observed while running these tests with logs enabled. The function `resource.Retry` gets called several times during the tests. 

For the network test it only gets called a few times, and the test succeeds almost always:
```
grep -i retry go-vcloud-director.log | wc -l
     5
```

For the VM tests, the retry call runs several hundred times, and the test almost always fails, although it may not fail always for the same reason.
```
grep -i retry go-vcloud-director.log | wc -l
     326
```

