### PR TITLE
Add support for network name property in vcd_snat and vcd_dnat resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 FEATURES:
 
 * `vcd_vapp_vm` - Ability to add metadata to a VM. For previous behaviour please see `BACKWARDS INCOMPATIBILITIES` ([#158](https://github.com/terraform-providers/terraform-provider-vcd/issues/158))
-* `vcd_snat` and `vcd_dnat` - now supports organization network name. For previous behaviour please see `BACKWARDS INCOMPATIBILITIES` 
+* `vcd_snat` and `vcd_dnat` - now supports organization network name. Until major version increase it's optional, later will be required field.  
 
 BUG FIXES:
 
@@ -12,7 +12,6 @@ BUG FIXES:
 BACKWARDS INCOMPATIBILITIES / NOTES:
 
 * `vcd_vapp` - Metadata is no longer added to first VM in vApp it will be added to vApp directly instead. ([#158](https://github.com/terraform-providers/terraform-provider-vcd/issues/158))
-* `vcd_snat` and `vcd_dnat` network is no longer selected as first one in edge gateway, but now explicitly required to be defined.
 
 ## 2.1.0 (March 27, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 
 * `vcd_vapp_vm` - Ability to add metadata to a VM. For previous behaviour please see `BACKWARDS INCOMPATIBILITIES` ([#158](https://github.com/terraform-providers/terraform-provider-vcd/issues/158))
+* `vcd_snat` and `vcd_dnat` - now supports organization network name. For previous behaviour please see `BACKWARDS INCOMPATIBILITIES` 
 
 BUG FIXES:
 
@@ -11,6 +12,7 @@ BUG FIXES:
 BACKWARDS INCOMPATIBILITIES / NOTES:
 
 * `vcd_vapp` - Metadata is no longer added to first VM in vApp it will be added to vApp directly instead. ([#158](https://github.com/terraform-providers/terraform-provider-vcd/issues/158))
+* `vcd_snat` and `vcd_dnat` network is no longer selected as first one in edge gateway, but now explicitly required to be defined.
 
 ## 2.1.0 (March 27, 2019)
 

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.12
 
 require (
 	github.com/hashicorp/terraform v0.11.13
-	github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.2
+	github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.3
 )

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/terraform-providers/terraform-provider-tls v1.2.0/go.mod h1:Mxe/v5u31
 github.com/ugorji/go v0.0.0-20170107133203-ded73eae5db7/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ulikunitz/xz v0.5.4 h1:zATC2OoZ8H1TZll3FpbX+ikwmadbO699PE06cIkm9oU=
 github.com/ulikunitz/xz v0.5.4/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
-github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.2 h1:yn7aAHwL44SoD7Duco764KjNrceX5r+onBQj2WKnl2o=
-github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.2/go.mod h1:HonlGxbjJ1NAibWh99eE4/S2l6ZOZ5KJzKK1rh2a9vc=
+github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.3 h1:lkjVNunejxzqANJoIhkgSzqiaLcOfa3kKELSPu5NLRg=
+github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.3/go.mod h1:HonlGxbjJ1NAibWh99eE4/S2l6ZOZ5KJzKK1rh2a9vc=
 github.com/xanzy/ssh-agent v0.2.0/go.mod h1:0NyE30eGUDliuLEHJgYte/zncp2zdTStcOnWhgSqHD8=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=

--- a/vcd/resource_vcd_catalog_media.go
+++ b/vcd/resource_vcd_catalog_media.go
@@ -89,12 +89,7 @@ func resourceVcdMediaCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error uploading new catalog media: %#v", err)
 	}
 
-	var terraformStdout *os.File
-	if v := flag.Lookup("test.v"); v == nil || v.Value.String() != "true" {
-		terraformStdout = os.NewFile(uintptr(4), "stdout")
-	} else {
-		terraformStdout = os.Stdout
-	}
+	terraformStdout := GetTerraformStdout()
 
 	if d.Get("show_upload_progress").(bool) {
 		for {
@@ -134,6 +129,16 @@ func resourceVcdMediaCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[TRACE] Catalog media created: %#v", mediaName)
 	return resourceVcdMediaRead(d, meta)
+}
+
+func GetTerraformStdout() *os.File {
+	var terraformStdout *os.File
+	if v := flag.Lookup("test.v"); v == nil || v.Value.String() != "true" {
+		terraformStdout = os.NewFile(uintptr(4), "stdout")
+	} else {
+		terraformStdout = os.Stdout
+	}
+	return terraformStdout
 }
 
 func resourceVcdMediaRead(d *schema.ResourceData, meta interface{}) error {

--- a/vcd/resource_vcd_dnat.go
+++ b/vcd/resource_vcd_dnat.go
@@ -106,7 +106,7 @@ func resourceVcdDNATCreate(d *schema.ResourceData, meta interface{}) error {
 	if nil != providedNetworkName && "" != providedNetworkName {
 		orgVdcnetwork, err = getNetwork(d, vcdClient, providedNetworkName.(string))
 	} else {
-		_, _ = fmt.Fprint(GetTerraformStdout(), "This resource will require network_name in the next major version %\n")
+		_, _ = fmt.Fprint(GetTerraformStdout(), "WARNING: This resource will require network_name in the next major version \n")
 	}
 	if err != nil {
 		return fmt.Errorf("unable to find orgVdcnetwork: %s, err: %s", providedNetworkName.(string), err)

--- a/vcd/resource_vcd_dnat.go
+++ b/vcd/resource_vcd_dnat.go
@@ -106,6 +106,8 @@ func resourceVcdDNATCreate(d *schema.ResourceData, meta interface{}) error {
 	providedNetworkName := d.Get("network_name")
 	if nil != providedNetworkName && "" != providedNetworkName {
 		orgVdcnetwork, err = getNetwork(d, vcdClient, providedNetworkName.(string))
+	} else {
+		_, _ = fmt.Fprint(GetTerraformStdout(), "This resource will require network_name in the next major version %\n")
 	}
 	if err != nil {
 		return fmt.Errorf("unable to find orgVdcnetwork: %s, err: %s", providedNetworkName.(string), err)

--- a/vcd/resource_vcd_dnat.go
+++ b/vcd/resource_vcd_dnat.go
@@ -103,7 +103,7 @@ func resourceVcdDNATCreate(d *schema.ResourceData, meta interface{}) error {
 
 	var orgVdcnetwork *types.OrgVDCNetwork
 	providedNetworkName := d.Get("network_name")
-	if nil != providedNetworkName && "" != providedNetworkName {
+	if nil != providedNetworkName && "" != providedNetworkName.(string) {
 		orgVdcnetwork, err = getNetwork(d, vcdClient, providedNetworkName.(string))
 	} else {
 		_, _ = fmt.Fprint(GetTerraformStdout(), "WARNING: This resource will require network_name in the next major version \n")
@@ -174,7 +174,7 @@ func resourceVcdDNATRead(d *schema.ResourceData, meta interface{}) error {
 	var found bool
 
 	providedNetworkName := d.Get("network_name")
-	if nil != providedNetworkName && providedNetworkName != "" {
+	if nil != providedNetworkName && providedNetworkName.(string) != "" {
 		for _, r := range e.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule {
 			if r.RuleType == "DNAT" && r.GatewayNatRule.Interface.Name == d.Get("network_name") &&
 				r.GatewayNatRule.OriginalIP == d.Get("external_ip").(string) &&

--- a/vcd/resource_vcd_dnat.go
+++ b/vcd/resource_vcd_dnat.go
@@ -73,7 +73,6 @@ func resourceVcdDNAT() *schema.Resource {
 				Default:  "any",
 			},
 		},
-		DeprecationMessage: "This resource will require network_name in the next major version",
 	}
 }
 

--- a/vcd/resource_vcd_dnat.go
+++ b/vcd/resource_vcd_dnat.go
@@ -34,7 +34,7 @@ func resourceVcdDNAT() *schema.Resource {
 			},
 			"network_name": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"external_ip": &schema.Schema{
@@ -73,6 +73,7 @@ func resourceVcdDNAT() *schema.Resource {
 				Default:  "any",
 			},
 		},
+		DeprecationMessage: "This resource will require network_name in the next major version",
 	}
 }
 

--- a/vcd/resource_vcd_dnat_test.go
+++ b/vcd/resource_vcd_dnat_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 var baseDnatName string = "TestAccVcdDNAT"
+var orgVdcNetworkName = "TestAccVcdDNAT_BasicNetwork"
 
 func TestAccVcdDNAT_Basic(t *testing.T) {
 	if vcdShortTest {
@@ -24,12 +25,17 @@ func TestAccVcdDNAT_Basic(t *testing.T) {
 
 	var dnatName string = baseDnatName + "_Basic"
 	var params = StringMap{
-		"Org":         testConfig.VCD.Org,
-		"Vdc":         testConfig.VCD.Vdc,
-		"EdgeGateway": testConfig.Networking.EdgeGateway,
-		"ExternalIp":  testConfig.Networking.ExternalIp,
-		"DnatName":    dnatName,
+		"Org":               testConfig.VCD.Org,
+		"Vdc":               testConfig.VCD.Vdc,
+		"EdgeGateway":       testConfig.Networking.EdgeGateway,
+		"ExternalIp":        testConfig.Networking.ExternalIp,
+		"DnatName":          dnatName,
+		"OrgVdcNetworkName": orgVdcNetworkName,
+		"Gateway":           "10.10.102.1",
+		"StartIpAddress":    "10.10.102.51",
+		"EndIpAddress":      "10.10.102.100",
 	}
+
 	configText := templateFill(testAccCheckVcdDnat_basic, params)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 	resource.Test(t, resource.TestCase{
@@ -41,6 +47,8 @@ func TestAccVcdDNAT_Basic(t *testing.T) {
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdDNATExists("vcd_dnat."+dnatName, &e),
+					resource.TestCheckResourceAttr(
+						"vcd_dnat."+dnatName, "network_name", orgVdcNetworkName),
 					resource.TestCheckResourceAttr(
 						"vcd_dnat."+dnatName, "external_ip", testConfig.Networking.ExternalIp),
 					resource.TestCheckResourceAttr(
@@ -66,11 +74,15 @@ func TestAccVcdDNAT_tlate(t *testing.T) {
 
 	var dnatName string = baseDnatName + "_tlate"
 	var params = StringMap{
-		"Org":         testConfig.VCD.Org,
-		"Vdc":         testConfig.VCD.Vdc,
-		"EdgeGateway": testConfig.Networking.EdgeGateway,
-		"ExternalIp":  testConfig.Networking.ExternalIp,
-		"DnatName":    dnatName,
+		"Org":               testConfig.VCD.Org,
+		"Vdc":               testConfig.VCD.Vdc,
+		"EdgeGateway":       testConfig.Networking.EdgeGateway,
+		"ExternalIp":        testConfig.Networking.ExternalIp,
+		"DnatName":          dnatName,
+		"OrgVdcNetworkName": "TestAccVcdDNAT_BasicNetwork",
+		"Gateway":           "10.10.102.1",
+		"StartIpAddress":    "10.10.102.51",
+		"EndIpAddress":      "10.10.102.100",
 	}
 
 	configText := templateFill(testAccCheckVcdDnat_tlate, params)
@@ -84,6 +96,8 @@ func TestAccVcdDNAT_tlate(t *testing.T) {
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdDNATtlateExists("vcd_dnat."+dnatName, &e),
+					resource.TestCheckResourceAttr(
+						"vcd_dnat."+dnatName, "network_name", orgVdcNetworkName),
 					resource.TestCheckResourceAttr(
 						"vcd_dnat."+dnatName, "external_ip", testConfig.Networking.ExternalIp),
 					resource.TestCheckResourceAttr(
@@ -212,23 +226,52 @@ func testAccCheckVcdDNATDestroy(s *terraform.State) error {
 }
 
 const testAccCheckVcdDnat_basic = `
+resource "vcd_network_routed" "{{.OrgVdcNetworkName}}" {
+  name         = "{{.OrgVdcNetworkName}}"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  gateway      = "{{.Gateway}}"
+
+  dhcp_pool {
+    start_address = "{{.StartIpAddress}}"
+    end_address   = "{{.EndIpAddress}}"
+  }
+}
 resource "vcd_dnat" "{{.DnatName}}" {
   org          = "{{.Org}}"
   vdc          = "{{.Vdc}}"
+  network_name = "{{.OrgVdcNetworkName}}"
   edge_gateway = "{{.EdgeGateway}}"
   external_ip  = "{{.ExternalIp}}"
   port         = 7777
   internal_ip  = "10.10.102.60"
+  depends_on   = ["vcd_network_routed.{{.OrgVdcNetworkName}}"]
 }
 `
 const testAccCheckVcdDnat_tlate = `
+resource "vcd_network_routed" "{{.OrgVdcNetworkName}}" {
+  name         = "{{.OrgVdcNetworkName}}"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  gateway      = "{{.Gateway}}"
+
+  dhcp_pool {
+    start_address = "{{.StartIpAddress}}"
+    end_address   = "{{.EndIpAddress}}"
+  }
+}
+
 resource "vcd_dnat" "{{.DnatName}}" {
   org             = "{{.Org}}"
   vdc             = "{{.Vdc}}"
+  network_name    = "{{.OrgVdcNetworkName}}"
   edge_gateway    = "{{.EdgeGateway}}"
   external_ip     = "{{.ExternalIp}}"
   port            = 7777
   internal_ip     = "10.10.102.60"
   translated_port = 77
+  depends_on      = ["vcd_network_routed.{{.OrgVdcNetworkName}}"]
 }
 `

--- a/vcd/resource_vcd_dnat_test.go
+++ b/vcd/resource_vcd_dnat_test.go
@@ -249,32 +249,6 @@ resource "vcd_dnat" "{{.DnatName}}" {
   depends_on   = ["vcd_network_routed.{{.OrgVdcNetworkName}}"]
 }
 `
-const testAccCheckVcdDnat_tlate = `
-resource "vcd_network_routed" "{{.OrgVdcNetworkName}}" {
-  name         = "{{.OrgVdcNetworkName}}"
-  org          = "{{.Org}}"
-  vdc          = "{{.Vdc}}"
-  edge_gateway = "{{.EdgeGateway}}"
-  gateway      = "{{.Gateway}}"
-
-  dhcp_pool {
-    start_address = "{{.StartIpAddress}}"
-    end_address   = "{{.EndIpAddress}}"
-  }
-}
-
-resource "vcd_dnat" "{{.DnatName}}" {
-  org             = "{{.Org}}"
-  vdc             = "{{.Vdc}}"
-  network_name    = "{{.OrgVdcNetworkName}}"
-  edge_gateway    = "{{.EdgeGateway}}"
-  external_ip     = "{{.ExternalIp}}"
-  port            = 7777
-  internal_ip     = "10.10.102.60"
-  translated_port = 77
-  depends_on      = ["vcd_network_routed.{{.OrgVdcNetworkName}}"]
-}
-`
 
 func TestAccVcdDNAT_ForBackCompability(t *testing.T) {
 	if vcdShortTest {
@@ -403,5 +377,31 @@ resource "vcd_dnat" "{{.DnatName}}" {
   port            = 7777
   internal_ip     = "10.10.102.60"
   translated_port = 77
+}
+`
+const testAccCheckVcdDnat_tlate = `
+resource "vcd_network_routed" "{{.OrgVdcNetworkName}}" {
+  name         = "{{.OrgVdcNetworkName}}"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  gateway      = "{{.Gateway}}"
+
+  dhcp_pool {
+    start_address = "{{.StartIpAddress}}"
+    end_address   = "{{.EndIpAddress}}"
+  }
+}
+
+resource "vcd_dnat" "{{.DnatName}}" {
+  org             = "{{.Org}}"
+  vdc             = "{{.Vdc}}"
+  network_name    = "{{.OrgVdcNetworkName}}"
+  edge_gateway    = "{{.EdgeGateway}}"
+  external_ip     = "{{.ExternalIp}}"
+  port            = 7777
+  internal_ip     = "10.10.102.60"
+  translated_port = 77
+  depends_on      = ["vcd_network_routed.{{.OrgVdcNetworkName}}"]
 }
 `

--- a/vcd/resource_vcd_network_routed.go
+++ b/vcd/resource_vcd_network_routed.go
@@ -275,6 +275,7 @@ func resourceVcdNetworkDelete(d *schema.ResourceData, meta interface{}) error {
 
 	network, err := vdc.FindVDCNetwork(d.Id())
 	if err != nil {
+		d.SetId("")
 		return fmt.Errorf("error finding network: %#v", err)
 	}
 

--- a/vcd/resource_vcd_snat.go
+++ b/vcd/resource_vcd_snat.go
@@ -32,7 +32,7 @@ func resourceVcdSNAT() *schema.Resource {
 			},
 			"network_name": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"external_ip": &schema.Schema{
@@ -47,6 +47,7 @@ func resourceVcdSNAT() *schema.Resource {
 				ForceNew: true,
 			},
 		},
+		DeprecationMessage: "This resource will require network_name in the next major version",
 	}
 }
 

--- a/vcd/resource_vcd_snat.go
+++ b/vcd/resource_vcd_snat.go
@@ -47,7 +47,6 @@ func resourceVcdSNAT() *schema.Resource {
 				ForceNew: true,
 			},
 		},
-		DeprecationMessage: "This resource will require network_name in the next major version",
 	}
 }
 

--- a/vcd/resource_vcd_snat.go
+++ b/vcd/resource_vcd_snat.go
@@ -71,7 +71,7 @@ func resourceVcdSNATCreate(d *schema.ResourceData, meta interface{}) error {
 
 	var orgVdcnetwork *types.OrgVDCNetwork
 	providedNetworkName := d.Get("network_name")
-	if nil != providedNetworkName && "" != providedNetworkName {
+	if nil != providedNetworkName && "" != providedNetworkName.(string) {
 		orgVdcnetwork, err = getNetwork(d, vcdClient, providedNetworkName.(string))
 	} else {
 		_, _ = fmt.Fprint(GetTerraformStdout(), "WARNING: this resource will require network_name in the next major version \n")
@@ -129,7 +129,7 @@ func resourceVcdSNATRead(d *schema.ResourceData, meta interface{}) error {
 	var found bool
 
 	providedNetworkName := d.Get("network_name")
-	if nil != providedNetworkName && providedNetworkName != "" {
+	if nil != providedNetworkName && providedNetworkName.(string) != "" {
 		for _, r := range e.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule {
 			if r.RuleType == "SNAT" && r.GatewayNatRule.OriginalIP == d.Id() {
 				found = true

--- a/vcd/resource_vcd_snat.go
+++ b/vcd/resource_vcd_snat.go
@@ -83,9 +83,8 @@ func resourceVcdSNATCreate(d *schema.ResourceData, meta interface{}) error {
 	if nil != providedNetworkName && providedNetworkName != "" {
 		err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
 
-			task, err := edgeGateway.AddNATPortMappingWithUplink(orgVdcnetwork, "SNAT",
-				d.Get("external_ip").(string), "any", d.Get("internal_ip").(string),
-				"any", "any", "")
+			task, err := edgeGateway.AddNATRule(orgVdcnetwork, "SNAT",
+				d.Get("external_ip").(string), d.Get("internal_ip").(string))
 			if err != nil {
 				return resource.RetryableError(fmt.Errorf("error setting SNAT rules: %#v", err))
 			}

--- a/vcd/resource_vcd_snat.go
+++ b/vcd/resource_vcd_snat.go
@@ -73,6 +73,8 @@ func resourceVcdSNATCreate(d *schema.ResourceData, meta interface{}) error {
 	providedNetworkName := d.Get("network_name")
 	if nil != providedNetworkName && "" != providedNetworkName {
 		orgVdcnetwork, err = getNetwork(d, vcdClient, providedNetworkName.(string))
+	} else {
+		_, _ = fmt.Fprint(GetTerraformStdout(), "Warning: this resource will require network_name in the next major version \n")
 	}
 	if err != nil {
 		return fmt.Errorf("unable to find orgVdcnetwork: %s, err: %s", providedNetworkName.(string), err)

--- a/vcd/resource_vcd_snat.go
+++ b/vcd/resource_vcd_snat.go
@@ -74,7 +74,7 @@ func resourceVcdSNATCreate(d *schema.ResourceData, meta interface{}) error {
 	if nil != providedNetworkName && "" != providedNetworkName {
 		orgVdcnetwork, err = getNetwork(d, vcdClient, providedNetworkName.(string))
 	} else {
-		_, _ = fmt.Fprint(GetTerraformStdout(), "Warning: this resource will require network_name in the next major version \n")
+		_, _ = fmt.Fprint(GetTerraformStdout(), "WARNING: this resource will require network_name in the next major version \n")
 	}
 	if err != nil {
 		return fmt.Errorf("unable to find orgVdcnetwork: %s, err: %s", providedNetworkName.(string), err)

--- a/vcd/resource_vcd_snat_test.go
+++ b/vcd/resource_vcd_snat_test.go
@@ -159,3 +159,130 @@ resource "vcd_snat" "{{.SnatName}}" {
   depends_on      = ["vcd_network_routed.{{.OrgVdcNetworkName}}"]
 }
 `
+
+func TestAccVcdSNAT_BackCompability(t *testing.T) {
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	if testConfig.Networking.ExternalIp == "" {
+		t.Skip("Variable networking.extarnalIp must be set to run SNAT tests")
+		return
+	}
+
+	var e govcd.EdgeGateway
+
+	snatName := "TestAccVcdSNAT"
+	var params = StringMap{
+		"Org":         testConfig.VCD.Org,
+		"Vdc":         testConfig.VCD.Vdc,
+		"EdgeGateway": testConfig.Networking.EdgeGateway,
+		"ExternalIp":  testConfig.Networking.ExternalIp,
+		"SnatName":    snatName,
+		"LocalIp":     testConfig.Networking.InternalIp,
+	}
+
+	configText := templateFill(testAccCheckVcdSnat_forBackCompability, params)
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVcdSNATDestroyForBackCompability,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config:      configText,
+				ExpectError: regexp.MustCompile(`After applying this step and refreshing, the plan was not empty:`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVcdSNATExistsForBackCompability("vcd_snat."+snatName, &e),
+					resource.TestCheckResourceAttr(
+						"vcd_snat."+snatName, "external_ip", testConfig.Networking.ExternalIp),
+					resource.TestCheckResourceAttr(
+						"vcd_snat."+snatName, "internal_ip", "10.10.102.0/24"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVcdSNATExistsForBackCompability(n string, gateway *govcd.EdgeGateway) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no SNAT ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		gatewayName := rs.Primary.Attributes["edge_gateway"]
+
+		edgeGateway, err := conn.GetEdgeGateway(testConfig.VCD.Org, testConfig.VCD.Vdc, gatewayName)
+
+		if err != nil {
+			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
+		}
+
+		var found bool
+		for _, v := range edgeGateway.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule {
+			if v.RuleType == "SNAT" &&
+				v.GatewayNatRule.OriginalIP == "10.10.102.0/24" &&
+				v.GatewayNatRule.OriginalPort == "" &&
+				v.GatewayNatRule.TranslatedIP == testConfig.Networking.ExternalIp {
+				found = true
+			}
+		}
+		if !found {
+			return fmt.Errorf("SNAT rule was not found")
+		}
+
+		*gateway = edgeGateway
+
+		return nil
+	}
+}
+
+func testAccCheckVcdSNATDestroyForBackCompability(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*VCDClient)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vcd_snat" {
+			continue
+		}
+
+		gatewayName := rs.Primary.Attributes["edge_gateway"]
+
+		edgeGateway, err := conn.GetEdgeGateway(testConfig.VCD.Org, testConfig.VCD.Vdc, gatewayName)
+		if err != nil {
+			return fmt.Errorf(errorUnableToFindEdgeGateway, err)
+		}
+
+		var found bool
+		for _, v := range edgeGateway.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule {
+			if v.RuleType == "SNAT" &&
+				v.GatewayNatRule.OriginalIP == "10.10.102.0/24" &&
+				v.GatewayNatRule.OriginalPort == "" &&
+				v.GatewayNatRule.TranslatedIP == testConfig.Networking.ExternalIp {
+				found = true
+			}
+		}
+
+		if found {
+			return fmt.Errorf("SNAT rule still exists.")
+		}
+	}
+
+	return nil
+}
+
+const testAccCheckVcdSnat_forBackCompability = `
+resource "vcd_snat" "{{.SnatName}}" {
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  external_ip  = "{{.ExternalIp}}"
+  internal_ip  = "10.10.102.0/24"
+}
+`

--- a/vcd/resource_vcd_snat_test.go
+++ b/vcd/resource_vcd_snat_test.go
@@ -134,32 +134,6 @@ func testAccCheckVcdSNATDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccCheckVcdSnat_basic = `
-resource "vcd_network_routed" "{{.OrgVdcNetworkName}}" {
-  name         = "{{.OrgVdcNetworkName}}"
-  org          = "{{.Org}}"
-  vdc          = "{{.Vdc}}"
-  edge_gateway = "{{.EdgeGateway}}"
-  gateway      = "{{.Gateway}}"
-
-  static_ip_pool {
-    start_address = "{{.StartIpAddress}}"
-    end_address   = "{{.EndIpAddress}}"
-  }
-}
-
-
-resource "vcd_snat" "{{.SnatName}}" {
-  org          = "{{.Org}}"
-  vdc          = "{{.Vdc}}"
-  edge_gateway = "{{.EdgeGateway}}"
-  network_name = "{{.OrgVdcNetworkName}}"
-  external_ip  = "{{.ExternalIp}}"
-  internal_ip  = "{{.StartIpAddress}}"
-  depends_on      = ["vcd_network_routed.{{.OrgVdcNetworkName}}"]
-}
-`
-
 func TestAccVcdSNAT_BackCompability(t *testing.T) {
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
@@ -276,6 +250,32 @@ func testAccCheckVcdSNATDestroyForBackCompability(s *terraform.State) error {
 
 	return nil
 }
+
+const testAccCheckVcdSnat_basic = `
+resource "vcd_network_routed" "{{.OrgVdcNetworkName}}" {
+  name         = "{{.OrgVdcNetworkName}}"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  gateway      = "{{.Gateway}}"
+
+  static_ip_pool {
+    start_address = "{{.StartIpAddress}}"
+    end_address   = "{{.EndIpAddress}}"
+  }
+}
+
+
+resource "vcd_snat" "{{.SnatName}}" {
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  network_name = "{{.OrgVdcNetworkName}}"
+  external_ip  = "{{.ExternalIp}}"
+  internal_ip  = "{{.StartIpAddress}}"
+  depends_on      = ["vcd_network_routed.{{.OrgVdcNetworkName}}"]
+}
+`
 
 const testAccCheckVcdSnat_forBackCompability = `
 resource "vcd_snat" "{{.SnatName}}" {

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/edgegateway.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/edgegateway.go
@@ -177,14 +177,21 @@ func (eGW *EdgeGateway) RemoveNATPortMapping(natType, externalIP, externalPort s
 
 }
 
+func (eGW *EdgeGateway) AddNATRule(network *types.OrgVDCNetwork, natType, externalIP, internalIP string) (Task, error) {
+	return eGW.AddNATPortMappingWithUplink(network, natType, externalIP, "any", internalIP, "any", "any", "")
+}
+
+// Deprecated: Use eGW.AddNATRule()
 func (eGW *EdgeGateway) AddNATMapping(natType, externalIP, internalIP string) (Task, error) {
 	return eGW.AddNATPortMapping(natType, externalIP, "any", internalIP, "any", "any", "")
 }
 
+// Deprecated: Use eGW.AddNATPortMappingWithUplink()
 func (eGW *EdgeGateway) AddNATPortMapping(natType, externalIP, externalPort, internalIP, internalPort, protocol, icmpSubType string) (Task, error) {
 	return eGW.AddNATPortMappingWithUplink(nil, natType, externalIP, externalPort, internalIP, internalPort, protocol, icmpSubType)
 }
 
+// Deprecated: creates not good behaviour of functionality
 func (eGW *EdgeGateway) getFirstUplink() types.Reference {
 	var uplink types.Reference
 	for _, gi := range eGW.EdgeGateway.Configuration.GatewayInterfaces.GatewayInterface {
@@ -241,6 +248,7 @@ func (eGW *EdgeGateway) AddNATPortMappingWithUplink(network *types.OrgVDCNetwork
 	if network != nil {
 		uplinkRef = network.HREF
 	} else {
+		// TODO: remove when method used this removed
 		uplinkRef = eGW.getFirstUplink().HREF
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -157,7 +157,7 @@ github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
 github.com/ulikunitz/xz/internal/hash
-# github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.2
+# github.com/vmware/go-vcloud-director/v2 v2.2.0-alpha.3
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util

--- a/website/docs/r/dnat.html.markdown
+++ b/website/docs/r/dnat.html.markdown
@@ -44,7 +44,7 @@ resource "vcd_dnat" "forIcmp" {
 The following arguments are supported:
 
 * `edge_gateway` - (Required) The name of the edge gateway on which to apply the DNAT
-* `network_name` - (Required *v2.2+*) The name of the organization network name on which to apply the DNAT
+* `network_name` - (Optional *v2.2+*) The name of the organization network name on which to apply the DNAT. This will be required field in the next major version.
 * `external_ip` - (Required) One of the external IPs available on your Edge Gateway
 * `port` - (Required) The port number to map. -1 translates to "any"
 * `translated_port` - (Optional) The port number to map

--- a/website/docs/r/dnat.html.markdown
+++ b/website/docs/r/dnat.html.markdown
@@ -44,7 +44,7 @@ resource "vcd_dnat" "forIcmp" {
 The following arguments are supported:
 
 * `edge_gateway` - (Required) The name of the edge gateway on which to apply the DNAT
-* `network_name` - (Optional *v2.2+*) The name of the organization network on which to apply the DNAT. This will be required field in the next major version.
+* `network_name` - (Optional; *v2.2+*) The name of the organization network on which to apply the DNAT. `network_name` will be required field in the next major version.
 * `external_ip` - (Required) One of the external IPs available on your Edge Gateway
 * `port` - (Required) The port number to map. -1 translates to "any"
 * `translated_port` - (Optional) The port number to map

--- a/website/docs/r/dnat.html.markdown
+++ b/website/docs/r/dnat.html.markdown
@@ -30,6 +30,7 @@ resource "vcd_dnat" "forIcmp" {
   vdc = "my-vdc" # Optional
 
   edge_gateway  = "Edge Gateway Name"
+  network_name  = "Org vDC network name"
   external_ip   = "78.101.10.20"
   port          = -1                    # "-1" == "any"
   internal_ip   = "10.10.0.5"
@@ -43,6 +44,7 @@ resource "vcd_dnat" "forIcmp" {
 The following arguments are supported:
 
 * `edge_gateway` - (Required) The name of the edge gateway on which to apply the DNAT
+* `network_name` - (Required *v2.2+*) The name of the organization network name on which to apply the DNAT
 * `external_ip` - (Required) One of the external IPs available on your Edge Gateway
 * `port` - (Required) The port number to map. -1 translates to "any"
 * `translated_port` - (Optional) The port number to map

--- a/website/docs/r/dnat.html.markdown
+++ b/website/docs/r/dnat.html.markdown
@@ -44,7 +44,7 @@ resource "vcd_dnat" "forIcmp" {
 The following arguments are supported:
 
 * `edge_gateway` - (Required) The name of the edge gateway on which to apply the DNAT
-* `network_name` - (Optional *v2.2+*) The name of the organization network name on which to apply the DNAT. This will be required field in the next major version.
+* `network_name` - (Optional *v2.2+*) The name of the organization network on which to apply the DNAT. This will be required field in the next major version.
 * `external_ip` - (Required) One of the external IPs available on your Edge Gateway
 * `port` - (Required) The port number to map. -1 translates to "any"
 * `translated_port` - (Optional) The port number to map

--- a/website/docs/r/dnat.html.markdown
+++ b/website/docs/r/dnat.html.markdown
@@ -44,7 +44,7 @@ resource "vcd_dnat" "forIcmp" {
 The following arguments are supported:
 
 * `edge_gateway` - (Required) The name of the edge gateway on which to apply the DNAT
-* `network_name` - (Optional; *v2.2+*) The name of the organization network on which to apply the DNAT. `network_name` will be required field in the next major version.
+* `network_name` - (Optional; *v2.2+*) The name of the organization network on which to apply the DNAT. *`network_name` will be required field in the next major version.*
 * `external_ip` - (Required) One of the external IPs available on your Edge Gateway
 * `port` - (Required) The port number to map. -1 translates to "any"
 * `translated_port` - (Optional) The port number to map

--- a/website/docs/r/snat.html.markdown
+++ b/website/docs/r/snat.html.markdown
@@ -27,7 +27,7 @@ resource "vcd_snat" "outbound" {
 The following arguments are supported:
 
 * `edge_gateway` - (Required) The name of the edge gateway on which to apply the SNAT
-* `network_name` - (Optional; *v2.2+*) The name of the organization network on which to apply the SNAT. `network_name` will be required field in the next major version.
+* `network_name` - (Optional; *v2.2+*) The name of the organization network on which to apply the SNAT. *`network_name` will be required field in the next major version.*
 * `external_ip` - (Required) One of the external IPs available on your Edge Gateway
 * `internal_ip` - (Required) The IP or IP Range of the VM(s) to map from
 * `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations

--- a/website/docs/r/snat.html.markdown
+++ b/website/docs/r/snat.html.markdown
@@ -27,7 +27,7 @@ resource "vcd_snat" "outbound" {
 The following arguments are supported:
 
 * `edge_gateway` - (Required) The name of the edge gateway on which to apply the SNAT
-* `network_name` - (Optional *v2.2+*) The name of the organization network on which to apply the SNAT. This will be required field in the next major version.
+* `network_name` - (Optional; *v2.2+*) The name of the organization network on which to apply the SNAT. `network_name` will be required field in the next major version.
 * `external_ip` - (Required) One of the external IPs available on your Edge Gateway
 * `internal_ip` - (Required) The IP or IP Range of the VM(s) to map from
 * `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations

--- a/website/docs/r/snat.html.markdown
+++ b/website/docs/r/snat.html.markdown
@@ -16,6 +16,7 @@ and delete source NATs to allow vApps to send external traffic.
 ```hcl
 resource "vcd_snat" "outbound" {
   edge_gateway = "Edge Gateway Name"
+  network_name = "Org vDC network name"
   external_ip  = "78.101.10.20"
   internal_ip  = "10.10.0.0/24"
 }
@@ -26,6 +27,7 @@ resource "vcd_snat" "outbound" {
 The following arguments are supported:
 
 * `edge_gateway` - (Required) The name of the edge gateway on which to apply the SNAT
+* `network_name` - (Required *v2.2+*) The name of the organization network name on which to apply the SNAT
 * `external_ip` - (Required) One of the external IPs available on your Edge Gateway
 * `internal_ip` - (Required) The IP or IP Range of the VM(s) to map from
 * `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations

--- a/website/docs/r/snat.html.markdown
+++ b/website/docs/r/snat.html.markdown
@@ -27,7 +27,7 @@ resource "vcd_snat" "outbound" {
 The following arguments are supported:
 
 * `edge_gateway` - (Required) The name of the edge gateway on which to apply the SNAT
-* `network_name` - (Optional *v2.2+*) The name of the organization network name on which to apply the SNAT. This will be required field in the next major version.
+* `network_name` - (Optional *v2.2+*) The name of the organization network on which to apply the SNAT. This will be required field in the next major version.
 * `external_ip` - (Required) One of the external IPs available on your Edge Gateway
 * `internal_ip` - (Required) The IP or IP Range of the VM(s) to map from
 * `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations

--- a/website/docs/r/snat.html.markdown
+++ b/website/docs/r/snat.html.markdown
@@ -27,7 +27,7 @@ resource "vcd_snat" "outbound" {
 The following arguments are supported:
 
 * `edge_gateway` - (Required) The name of the edge gateway on which to apply the SNAT
-* `network_name` - (Required *v2.2+*) The name of the organization network name on which to apply the SNAT
+* `network_name` - (Optional *v2.2+*) The name of the organization network name on which to apply the SNAT. This will be required field in the next major version.
 * `external_ip` - (Required) One of the external IPs available on your Edge Gateway
 * `internal_ip` - (Required) The IP or IP Range of the VM(s) to map from
 * `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations


### PR DESCRIPTION
This functionality is derived from PR https://github.com/terraform-providers/terraform-provider-vcd/pull/61 which will be closed.

Current NAT resource implementation apply new rules to first network of edge gtw. This change add new required property `network_name` which lets you select org vDC network for which this rule will be applied.