### PR TITLE
Add tags to all test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ BUG FIXES:
 BACKWARDS INCOMPATIBILITIES / NOTES:
 
 * `vcd_vapp` - Metadata is no longer added to first VM in vApp it will be added to vApp directly instead. [GH-158]
+* Tests files are now all tagged. Running them through Makefile works as before, but manual execution requires specific tags. Run `go test -v .` for tags list.
 
 ## 2.1.0 (March 27, 2019)
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -24,6 +24,20 @@ testacc: fmtcheck
 testmulti: fmtcheck
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' multiple"
 
+testcatalog: fmtcheck
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' catalog"
+
+testvapp: fmtcheck
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' vapp"
+
+testvm: fmtcheck
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' vm"
+
+testgateway: fmtcheck
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' gateway"
+
+testnetwork: fmtcheck
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' network"
 
 vet:
 	@echo "go vet ."
@@ -54,7 +68,7 @@ test-compile:
 		echo "  make test-compile TEST=./$(PKG_NAME)"; \
 		exit 1; \
 	fi
-	go test -c $(TEST) $(TESTARGS)
+	go test -tags ALL -c $(TEST) $(TESTARGS)
 
 website:
 ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -63,12 +63,7 @@ vendor-check:
 	git diff --exit-code
 
 test-compile:
-	@if [ "$(TEST)" = "./..." ]; then \
-		echo "ERROR: Set TEST to a specific package. For example,"; \
-		echo "  make test-compile TEST=./$(PKG_NAME)"; \
-		exit 1; \
-	fi
-	go test -tags ALL -c $(TEST) $(TESTARGS)
+	cd vcd && go test -tags ALL -c .
 
 website:
 ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))

--- a/TESTING.md
+++ b/TESTING.md
@@ -25,6 +25,54 @@ template (`catalogItem`) are defined in the configuration file, new ones will be
 the test. You can choose to preserve catalog and vApp template across runs (use the `preserve` field in the
 configuration file).
 
+The tests can run with several tags that define which components are tested.
+Using the Makefile, you can run one of the following:
+
+```bash
+make testcatalog
+make testnetwork
+make testgateway
+make testvapp
+make testvm
+```
+
+For more options, you can run manually in `./vcd`
+When running `go test` without tags, we'll get a list of tags that are available.
+
+```bash
+$ go test -v .
+=== RUN   TestTags
+--- FAIL: TestTags (0.00s)
+    api_test.go:66: # No tags were defined
+    api_test.go:41:
+        # -----------------------------------------------------
+        # Tags are required to run the tests
+        # -----------------------------------------------------
+
+        At least one of the following tags should be defined:
+
+           * ALL :       Runs all the tests
+           * functional: Runs all the acceptance tests
+           * unit:       Runs unit tests that don't need a live vCD (currently unused, but we plan to)
+
+           * catalog:    Runs catalog related tests (also catalog_item, media)
+           * disk:       Runs disk related tests
+           * network:    Runs network related tests
+           * gateway:    Runs edge gateway related tests
+           * org:        Runs org related tests
+           * vapp:       Runs vapp related tests
+           * vdc:        Runs vdc related tests
+           * vm:         Runs vm related tests
+
+        Examples:
+
+        go test -tags functional -v -timeout=45m .
+        go test -tags catalog -v -timeout=15m .
+        go test -tags "org vdc" -v -timeout=5m .
+FAIL
+FAIL	github.com/terraform-providers/terraform-provider-vcd/v2/vcd	0.019s
+```
+
 There are several environment variables that can affect the tests:
 
 * `TF_ACC=1` enables the acceptance tests. It is also set when you run `make testacc`.

--- a/TESTING.md
+++ b/TESTING.md
@@ -51,7 +51,8 @@ $ go test -v .
 
         At least one of the following tags should be defined:
 
-           * ALL :       Runs all the tests
+           * ALL :       Runs all the tests (= functional + unit == all feature tests)
+
            * functional: Runs all the acceptance tests
            * unit:       Runs unit tests that don't need a live vCD (currently unused, but we plan to)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -73,6 +73,11 @@ FAIL
 FAIL	github.com/terraform-providers/terraform-provider-vcd/v2/vcd	0.019s
 ```
 
+When adding new features, we should create a new tag, and add it to the test file, to allow running the new test in isolation. The tag must also be added to `provider_test.go` and `config_test.go`.
+It would be useful to add the new tag to the `tagsHelp` function in `api_test.go`. Notice that this file must NOT have tags, or else the help won't appear.
+
+We must also make sure that the "functional" tag includes the new feature (i.e. the new test has both the new feature tag and `functional`).
+
 There are several environment variables that can affect the tests:
 
 * `TF_ACC=1` enables the acceptance tests. It is also set when you run `make testacc`.

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -55,26 +55,31 @@ function short_test {
     if [ -n "$VERBOSE" ] 
     then
         echo " go test -i ${TEST} || exit 1"
-	    echo "VCD_SHORT_TEST=1 go test -v -timeout 3m ."
+	    echo "VCD_SHORT_TEST=1 go test -tags functional -v -timeout 3m ."
     fi
     if [ -z "$DRY_RUN" ]
     then
 	    go test -i ${TEST} || exit 1
-	    VCD_SHORT_TEST=1 go test -v -timeout 3m .
+	    VCD_SHORT_TEST=1 go test -tags functional -v -timeout 3m .
     fi
 }
 
 function acceptance_test {
+    tags="$1"
+    if [ -z "$tags" ]
+    then
+        tags=functional
+    fi
     if [ -n "$VERBOSE" ] 
     then
         echo "# check for config file"
-	    echo "TF_ACC=1 go test -v -timeout 60m ."
+	    echo "TF_ACC=1 go test -tags '$tags' -v -timeout 60m ."
     fi
 
     if [ -z "$DRY_RUN" ]
     then
         check_for_config_file
-	    TF_ACC=1 go test -v -timeout 60m .
+	    TF_ACC=1 go test -tags "$tags" -v -timeout 60m .
     fi
 }
 
@@ -87,13 +92,13 @@ function multiple_test {
     if [ -n "$VERBOSE" ] 
     then
         echo "# check for config file"
-	    echo "TF_ACC=1 go test -v -timeout 60m -tags 'multivm multinetwork' -run '$filter' ."
+	    echo "TF_ACC=1 go test -v -timeout 60m -tags 'api multivm multinetwork' -run '$filter' ."
     fi
 
     if [ -z "$DRY_RUN" ]
     then
         check_for_config_file
-	    TF_ACC=1 go test -v -timeout 60m -tags 'multivm multinetwork' -run "$filter" .
+	    TF_ACC=1 go test -v -timeout 60m -tags 'api multivm multinetwork' -run "$filter" .
     fi
 }
 
@@ -102,13 +107,28 @@ case $wanted in
         short_test
         ;;
     acceptance)
-        acceptance_test
+        acceptance_test functional
         ;;
     multinetwork)
         multiple_test TestAccVcdVappNetworkMulti
         ;;
     multiple)
         multiple_test
+        ;;
+    catalog)
+        acceptance_test catalog
+        ;;
+    vapp)
+        acceptance_test vapp
+        ;;
+    vm)
+        acceptance_test vm
+        ;;
+    network)
+        acceptance_test network
+        ;;
+    gateway)
+        acceptance_test gateway
         ;;
     *)
         echo "Unhandled testing method $wanted"

--- a/vcd/api_test.go
+++ b/vcd/api_test.go
@@ -1,0 +1,74 @@
+// IMPORTANT: DO NOT ADD build tags to this file
+
+package vcd
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+var testingTags = make(map[string]string)
+
+func tagsHelp(t *testing.T) {
+
+	var helpText string = `
+# -----------------------------------------------------
+# Tags are required to run the tests
+# -----------------------------------------------------
+
+At least one of the following tags should be defined:
+
+   * ALL :       Runs all the tests
+   * functional: Runs all the acceptance tests
+   * unit:       Runs unit tests that don't need a live vCD (currently unused, but we plan to)
+
+   * catalog:    Runs catalog related tests (also catalog_item, media)
+   * disk:       Runs disk related tests
+   * network:    Runs network related tests
+   * gateway:    Runs edge gateway related tests
+   * org:        Runs org related tests
+   * vapp:       Runs vapp related tests
+   * vdc:        Runs vdc related tests
+   * vm:         Runs vm related tests
+
+Examples:
+
+go test -tags functional -v -timeout=45m .
+go test -tags catalog -v -timeout=15m .
+go test -tags "org vdc" -v -timeout=5m .
+`
+	t.Logf(helpText)
+}
+
+// Tells indirectly if a tag has been set
+// For every tag there is an `init` function that
+// fills an item in `testingTags`
+func isTagSet(tagName string) bool {
+	_, ok := testingTags[tagName]
+	return ok
+}
+
+// For troubleshooting:
+// Shows which tags were set, and in which file.
+func showTags() {
+	if len(testingTags) > 0 {
+		fmt.Println("# Defined tags:")
+	}
+	for k, v := range testingTags {
+		fmt.Printf("# %s (%s)", k, v)
+	}
+}
+
+// Checks whether any tags were defined, and raises an error if not
+func TestTags(t *testing.T) {
+	if len(testingTags) == 0 {
+		t.Logf("# No tags were defined")
+		tagsHelp(t)
+		t.Fail()
+		return
+	}
+	if os.Getenv("SHOW_TAGS") != "" {
+		showTags()
+	}
+}

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -1,3 +1,5 @@
+// +build api functional catalog vapp network org query vm vdc gateway disk ALL
+
 package vcd
 
 // This module provides initialization routines for the whole suite

--- a/vcd/provider_test.go
+++ b/vcd/provider_test.go
@@ -1,3 +1,5 @@
+// +build api functional catalog vapp network org query vm vdc gateway disk ALL
+
 package vcd
 
 import (
@@ -9,16 +11,6 @@ import (
 
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
-
-/*
-// Initialization moved to config_test.TestMain
-func init() {
-	testAccProvider = Provider().(*schema.Provider)
-	testAccProviders = map[string]terraform.ResourceProvider{
-		"vcd": testAccProvider,
-	}
-}
-*/
 
 func TestProvider(t *testing.T) {
 	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
@@ -54,4 +46,8 @@ func testAccPreCheck(t *testing.T) {
 	if testConfig.VCD.Vdc == "" {
 		t.Fatal("vcd.vdc must be set for acceptance tests")
 	}
+}
+
+func init() {
+	testingTags["api"] = "provider_test.go"
 }

--- a/vcd/resource_vcd_catalog_item_test.go
+++ b/vcd/resource_vcd_catalog_item_test.go
@@ -1,3 +1,5 @@
+// +build catalog ALL functional
+
 package vcd
 
 import (

--- a/vcd/resource_vcd_catalog_media_test.go
+++ b/vcd/resource_vcd_catalog_media_test.go
@@ -1,3 +1,5 @@
+// +build catalog ALL functional
+
 package vcd
 
 import (

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -1,3 +1,5 @@
+// +build catalog ALL functional
+
 package vcd
 
 import (
@@ -99,6 +101,10 @@ func testAccCheckCatalogDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func init() {
+	testingTags["catalog"] = "resource_vcd_catalog_test.go"
 }
 
 const testAccCheckVcdCatalogBasic = `

--- a/vcd/resource_vcd_dnat_test.go
+++ b/vcd/resource_vcd_dnat_test.go
@@ -1,3 +1,5 @@
+// +build functional gateway ALL
+
 package vcd
 
 import (

--- a/vcd/resource_vcd_edgegateway_vpn_test.go
+++ b/vcd/resource_vcd_edgegateway_vpn_test.go
@@ -1,3 +1,5 @@
+// +build gateway ALL functional
+
 package vcd
 
 import (

--- a/vcd/resource_vcd_firewall_rules_test.go
+++ b/vcd/resource_vcd_firewall_rules_test.go
@@ -1,3 +1,5 @@
+// +build functional gateway ALL
+
 package vcd
 
 import (
@@ -116,6 +118,10 @@ func createFirewallRulesConfigs(existingRules *govcd.EdgeGateway) string {
 	configText := templateFill(testAccCheckVcdFirewallRules_add, params)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 	return configText
+}
+
+func init() {
+	testingTags["gateway"] = "resource_firewall_rules_test.go"
 }
 
 const testAccCheckVcdFirewallRules_add = `

--- a/vcd/resource_vcd_independent_disk_test.go
+++ b/vcd/resource_vcd_independent_disk_test.go
@@ -1,3 +1,5 @@
+// +build disk ALL functional
+
 package vcd
 
 import (
@@ -94,6 +96,10 @@ func testDiskResourcesDestroyed(s *terraform.State) error {
 		}
 	}
 	return nil
+}
+
+func init() {
+	testingTags["disk"] = "resource_vcd_independent_disk_test.go"
 }
 
 const testAccCheckVcdIndependentDiskBasic = `

--- a/vcd/resource_vcd_inserted_media_test.go
+++ b/vcd/resource_vcd_inserted_media_test.go
@@ -1,3 +1,5 @@
+// +build catalog ALL functional
+
 package vcd
 
 import (

--- a/vcd/resource_vcd_network_test.go
+++ b/vcd/resource_vcd_network_test.go
@@ -1,3 +1,5 @@
+// +build network ALL functional
+
 package vcd
 
 import (
@@ -306,6 +308,10 @@ func testAccCheckVcdNetworkAttributes(name string, network *govcd.OrgVDCNetwork)
 
 		return nil
 	}
+}
+
+func init() {
+	testingTags["network"] = "resource_vcd_network_test.go"
 }
 
 const testAccCheckVcdNetworkIsolatedStatic = `

--- a/vcd/resource_vcd_org_test.go
+++ b/vcd/resource_vcd_org_test.go
@@ -1,3 +1,5 @@
+// +build org ALL functional
+
 package vcd
 
 import (
@@ -105,6 +107,10 @@ func testAccCheckOrgDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func init() {
+	testingTags["org"] = "resource_vcd_org_test.go"
 }
 
 const testAccCheckVcdOrg_basic = `

--- a/vcd/resource_vcd_snat_test.go
+++ b/vcd/resource_vcd_snat_test.go
@@ -1,3 +1,5 @@
+// +build functional gateway ALL
+
 package vcd
 
 import (

--- a/vcd/resource_vcd_vapp_network_test.go
+++ b/vcd/resource_vcd_vapp_network_test.go
@@ -1,3 +1,5 @@
+// +build network vapp ALL functional
+
 package vcd
 
 import (

--- a/vcd/resource_vcd_vapp_raw_test.go
+++ b/vcd/resource_vcd_vapp_raw_test.go
@@ -1,3 +1,5 @@
+// +build vapp ALL functional
+
 package vcd
 
 import (

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -1,3 +1,5 @@
+// +build vapp ALL functional
+
 package vcd
 
 import (
@@ -187,6 +189,10 @@ func testAccCheckVcdVAppAttributes_off(vapp *govcd.VApp) resource.TestCheckFunc 
 
 		return nil
 	}
+}
+
+func init() {
+	testingTags["vapp"] = "resource_vcd_vapp_test.go"
 }
 
 const testAccCheckVcdVApp_basic = `

--- a/vcd/resource_vcd_vapp_vm_checks_test.go
+++ b/vcd/resource_vcd_vapp_vm_checks_test.go
@@ -1,3 +1,5 @@
+// +build vapp vm ALL functional
+
 package vcd
 
 import (

--- a/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
+++ b/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
@@ -1,3 +1,5 @@
+// +build vapp vm ALL functional
+
 package vcd
 
 import (

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -1,3 +1,5 @@
+// +build vapp vm ALL functional
+
 package vcd
 
 import (
@@ -61,6 +63,10 @@ func TestAccVcdVAppVm_Basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func init() {
+	testingTags["vm"] = "resource_vcd_vapp_vm_test.go"
 }
 
 const testAccCheckVcdVAppVm_basic = `


### PR DESCRIPTION
Test files are now all built conditionally using tags.
Running the tests without tags will trigger an error message
with a list of available tags (`cd vcd && go test -v .`).
The tags allow users to run only a subset of the tests, or all of them.
The `Makefile` uses the tags to run the same tests as before (tag
`functional`), and a few tags to run tests related to several features
(`make testcatalog`, `make testvapp`, `make testnetwork`, `make testgateway`).

The split by tags allows also running several sets of tests, such as one
using a live vCD (our current default) and one using mocks.
