### PR TITLE
Add check for version in docs header

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,10 +15,13 @@ dist:
 install: build
 	@$(CURDIR)/scripts/install-plugin.sh
 
-test: fmtcheck
+testunit: fmtcheck
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' unit"
+
+test: testunit
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' short"
 
-testacc: fmtcheck
+testacc: testunit
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' acceptance"
 
 testmulti: fmtcheck

--- a/TESTING.md
+++ b/TESTING.md
@@ -35,6 +35,15 @@ the test. You can choose to preserve catalog and vApp template across runs (use 
 configuration file).
 
 
+Both the (short) test and the acceptance test include a run of the `unit` tests, i.e. tests that check the correctness
+of the code without need for a live vCD.
+
+You can run the unit tests directly with
+
+```sh
+make testunit
+```
+
 ## Tests split by feature set
 
 The tests can run with several tags that define which components are tested.
@@ -55,37 +64,41 @@ When running `go test` without tags, you'll get a list of tags that are availabl
 ```
 $ go test -v .
 === RUN   TestTags
---- FAIL: TestTags (0.00s)
-    api_test.go:66: # No tags were defined
-    api_test.go:41:
-        # -----------------------------------------------------
-        # Tags are required to run the tests
-        # -----------------------------------------------------
-
-        At least one of the following tags should be defined:
-
-           * ALL :       Runs all the tests (= functional + unit == all feature tests)
-
-           * functional: Runs all the acceptance tests
-           * unit:       Runs unit tests that don't need a live vCD (currently unused, but we plan to)
-
-           * catalog:    Runs catalog related tests (also catalog_item, media)
-           * disk:       Runs disk related tests
-           * network:    Runs network related tests
-           * extnetwork: Runs external network related tests
-           * gateway:    Runs edge gateway related tests
-           * org:        Runs org related tests
-           * vapp:       Runs vapp related tests
-           * vdc:        Runs vdc related tests
-           * vm:         Runs vm related tests
-
-        Examples:
-
-        go test -tags functional -v -timeout=45m .
-        go test -tags catalog -v -timeout=15m .
-        go test -tags "org vdc" -v -timeout=5m .
-FAIL
-FAIL	github.com/terraform-providers/terraform-provider-vcd/v2/vcd	0.019s
+ --- FAIL: TestTags (0.00s)
+     api_test.go:87: # No tags were defined
+     api_test.go:62:
+         # -----------------------------------------------------
+         # Tags are required to run the tests
+         # -----------------------------------------------------
+ 
+         At least one of the following tags should be defined:
+ 
+            * ALL :       Runs all the tests
+            * functional: Runs all the acceptance tests
+            * unit:       Runs unit tests that don't need a live vCD
+ 
+            * catalog:    Runs catalog related tests (also catalog_item, media)
+            * disk:       Runs disk related tests
+            * network:    Runs network related tests
+            * gateway:    Runs edge gateway related tests
+            * org:        Runs org related tests
+            * vapp:       Runs vapp related tests
+            * vdc:        Runs vdc related tests
+            * vm:         Runs vm related tests
+ 
+         Examples:
+ 
+           go test -tags unit -v -timeout=45m .
+           go test -tags functional -v -timeout=45m .
+           go test -tags catalog -v -timeout=15m .
+           go test -tags "org vdc" -v -timeout=5m .
+ 
+         Tagged tests can also run using make
+           make testunit
+           make testacc
+           make testcatalog
+ FAIL
+ FAIL	github.com/terraform-providers/terraform-provider-vcd/v2/vcd	0.017s
 ```
 
 ## Adding new tests
@@ -134,15 +147,14 @@ func init() {
 to add such test to GNUMakefile under `make test` and `make testacc`. **The general principle is that `make test` and `make testacc` run all tests**. If this can't be
 achieved by adding the new test to the `functional` tag (perhaps because we foresee framework conflicts), we need to add the
 new test as a separate command.
-For example:
+For example, the unit test run as a command before the acceptance test:
 
 ```
-testacc: fmtcheck
+testacc: testunit
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' acceptance"
-	@sh -c "'$(CURDIR)/scripts/runtest.sh' something_new"
 ``` 
 
-## Environmant variables
+## Environment variables
 
 There are several environment variables that can affect the tests:
 
@@ -157,3 +169,5 @@ When `REMOVE_ORG_VDC_FROM_TEMPLATE` is set, the terraform
 templates will be changed on-the-fly, to comment out the definitions of org and vdc. This will force the test to
 borrow org and vcd from the provider.
 * `VCD_TEST_SUITE_CLEANUP=1` will clean up testing resources that were created in previous test runs. 
+* `TEST_VERBOSE=1` enables verbose output in some tests, such as the list of used tags, or the version
+used in the documentation index.

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -43,24 +43,37 @@ function check_for_config_file {
         echo "Using configuration file from variable \$VCD_CONFIG"
         config_file=$VCD_CONFIG
     fi
-	if [ ! -f $config_file ]
+    if [ ! -f $config_file ]
     then
-		echo "ERROR: test configuration file $config_file is missing"; \
-		exit 1
-	fi
+        echo "ERROR: test configuration file $config_file is missing"; \
+        exit 1
+    fi
 
 }
 
-function short_test {
-    if [ -n "$VERBOSE" ] 
+function unit_test {
+    if [ -n "$VERBOSE" ]
     then
         echo " go test -i ${TEST} || exit 1"
-	    echo "VCD_SHORT_TEST=1 go test -tags functional -v -timeout 3m ."
+        echo "VCD_SHORT_TEST=1 go test -tags unit -v -timeout 3m ."
     fi
     if [ -z "$DRY_RUN" ]
     then
-	    go test -i ${TEST} || exit 1
-	    VCD_SHORT_TEST=1 go test -tags functional -v -timeout 3m .
+        go test -i ${TEST} || exit 1
+        go test -tags unit -v -timeout 3m .
+    fi
+}
+
+function short_test {
+    if [ -n "$VERBOSE" ]
+    then
+        echo " go test  -i ${TEST} || exit 1"
+        echo "VCD_SHORT_TEST=1 go test -tags functional -v -timeout 3m ."
+    fi
+    if [ -z "$DRY_RUN" ]
+    then
+        go test -i ${TEST} || exit 1
+        VCD_SHORT_TEST=1 go test -tags functional -v -timeout 3m .
     fi
 }
 
@@ -70,16 +83,16 @@ function acceptance_test {
     then
         tags=functional
     fi
-    if [ -n "$VERBOSE" ] 
+    if [ -n "$VERBOSE" ]
     then
         echo "# check for config file"
-	    echo "TF_ACC=1 go test -tags '$tags' -v -timeout 60m ."
+        echo "TF_ACC=1 go test -tags '$tags' -v -timeout 60m ."
     fi
 
     if [ -z "$DRY_RUN" ]
     then
         check_for_config_file
-	    TF_ACC=1 go test -tags "$tags" -v -timeout 60m .
+        TF_ACC=1 go test -tags "$tags" -v -timeout 60m .
     fi
 }
 
@@ -89,20 +102,23 @@ function multiple_test {
     then
         filter='TestAccVcdV.pp.*Multi'
     fi
-    if [ -n "$VERBOSE" ] 
+    if [ -n "$VERBOSE" ]
     then
         echo "# check for config file"
-	    echo "TF_ACC=1 go test -v -timeout 60m -tags 'api multivm multinetwork' -run '$filter' ."
+        echo "TF_ACC=1 go test -v -timeout 60m -tags 'api multivm multinetwork' -run '$filter' ."
     fi
 
     if [ -z "$DRY_RUN" ]
     then
         check_for_config_file
-	    TF_ACC=1 go test -v -timeout 60m -tags 'api multivm multinetwork' -run "$filter" .
+        TF_ACC=1 go test -v -timeout 60m -tags 'api multivm multinetwork' -run "$filter" .
     fi
 }
 
-case $wanted in 
+case $wanted in
+    unit)
+        unit_test
+        ;;
     short)
         short_test
         ;;

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -18,7 +18,6 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -120,8 +119,7 @@ provider "vcd" {
 )
 
 var (
-	// This library major version
-	currentProviderVersion string = getMajorVersion()
+
 	// This is a global variable shared across all tests. It contains
 	// the information from the configuration file.
 	testConfig TestConfig
@@ -325,12 +323,6 @@ func getConfigStruct() TestConfig {
 		util.InitLogging()
 	}
 	return configStruct
-}
-
-// Finds the current directory, through the path of this running test
-func getCurrentDir() string {
-	_, currentFilename, _, _ := runtime.Caller(0)
-	return filepath.Dir(currentFilename)
 }
 
 // This function is called before any other test
@@ -582,37 +574,4 @@ func destroySuiteCatalogAndItem(config TestConfig) {
 		fmt.Printf("Catalog item deletion skipped as user defined resource is used or removed with catalog\n")
 	}
 
-}
-
-// Reads the version from the VERSION file in the root directory
-func getMajorVersion() string {
-
-	versionFile := path.Join(getCurrentDir(), "..", "VERSION")
-
-	// Checks whether the VERSION file exists
-	_, err := os.Stat(versionFile)
-	if os.IsNotExist(err) {
-		panic("Could not find VERSION file")
-	}
-
-	// Reads the version from the file
-	versionText, err := ioutil.ReadFile(versionFile)
-	if err != nil {
-		panic(fmt.Errorf("could not read VERSION file %s: %v", versionFile, err))
-	}
-
-	// The version is expected to be in the format v#.#.#
-	// We only need the first two numbers
-	reVersion := regexp.MustCompile(`v(\d+\.\d+)\.\d+`)
-	versionList := reVersion.FindAllStringSubmatch(string(versionText), -1)
-	if versionList == nil || len(versionList) == 0 {
-		panic("empty or non-formatted version found in VERSION file")
-	}
-	if versionList[0] == nil || len(versionList[0]) < 2 {
-		panic("unable to extract major version from VERSION file")
-	}
-	// A successful match will look like
-	// [][]string{[]string{"v2.0.0", "2.0"}}
-	// Where the first element is the full text matched, and the second one is the first captured text
-	return versionList[0][1]
 }

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -112,7 +112,9 @@ provider "vcd" {
   sysorg               = "{{.SysOrg}}"
   org                  = "{{.Org}}"
   allow_unverified_ssl = "{{.AllowInsecure}}"
+  max_retry_timeout    = {{.MaxRetryTimeout}}
   version              = "~> {{.VersionRequired}}"
+  logging              = {{.Logging}}
 }
 
 `
@@ -175,7 +177,9 @@ func templateFill(tmpl string, data StringMap) string {
 		data["SysOrg"] = testConfig.Provider.SysOrg
 		data["Org"] = testConfig.VCD.Org
 		data["AllowInsecure"] = testConfig.Provider.AllowInsecure
+		data["MaxRetryTimeout"] = testConfig.Provider.MaxRetryTimeout
 		data["VersionRequired"] = currentProviderVersion
+		data["Logging"] = testConfig.Logging.Enabled
 	}
 
 	// Creates a template. The template gets the same name of the calling function, to generate a better

--- a/vcd/provider_unit_test.go
+++ b/vcd/provider_unit_test.go
@@ -1,0 +1,53 @@
+// +build unit ALL
+
+package vcd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"regexp"
+	"testing"
+)
+
+// Checks that the provider header in index.html.markdown
+// has the version defined in the VERSION file
+func TestProviderVersion(t *testing.T) {
+	indexFile := path.Join(getCurrentDir(), "..", "website", "docs", "index.html.markdown")
+	_, err := os.Stat(indexFile)
+	if os.IsNotExist(err) {
+		fmt.Printf("%s\n", indexFile)
+		panic("Could not find index.html.markdown file")
+	}
+
+	indexText, err := ioutil.ReadFile(indexFile)
+	if err != nil {
+		panic(fmt.Errorf("could not read index file %s: %v", indexFile, err))
+	}
+
+	vcdHeader := `# VMware vCloud Director Provider`
+	expectedText := vcdHeader + ` ` + currentProviderVersion
+	reExpectedVersion := regexp.MustCompile(`(?m)^` + expectedText)
+	reFoundVersion := regexp.MustCompile(`(?m)^` + vcdHeader + ` \d+\.\d+`)
+	if reExpectedVersion.MatchString(string(indexText)) {
+		if os.Getenv(testVerbose) != "" {
+			t.Logf("Found expected version <%s> in index.html.markdown", currentProviderVersion)
+		}
+	} else {
+		foundList := reFoundVersion.FindAllStringSubmatch(string(indexText), -1)
+		foundText := ""
+		if foundList != nil && len(foundList) > 0 && len(foundList[0]) > 0 {
+			foundText = foundList[0][0]
+			t.Logf("Expected text: <%s>", expectedText)
+			t.Logf("Found text   : <%s> in index.html.markdown", foundText)
+		} else {
+			t.Logf("No version found in index.html.markdown")
+		}
+		t.Fail()
+	}
+}
+
+func init() {
+	testingTags["unit"] = "provider_unit_test.go"
+}


### PR DESCRIPTION
Add check for version in index.html.markdown
Move general purpose functions to api_test.go

The main reason for moving functions is that the version check will then run always, regardless of any tags being defined.

Signed-off-by: Giuseppe Maxia <gmaxia@vmware.com>