### PR TITLE
Implement Issue #250 Terraform binary tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,6 +15,14 @@ dist:
 install: build
 	@$(CURDIR)/scripts/install-plugin.sh
 
+test-binary-prepare: install
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' short-provider"
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' binary-prepare"
+
+test-binary: install
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' short-provider"
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' binary"
+
 testunit: fmtcheck
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' unit"
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -175,7 +175,7 @@ make test-binary
 
 All the tests run unattended, stopping only if there is an error.
 
-It is possible to run the tests with manual control, by preparing them and then running the test script from the `tests-artifacts` directory:
+It is possible to customise running of the binary tests, by preparing them and then running the test script from the `tests-artifacts` directory:
 
 ```bash
 make test-binary-prepare
@@ -193,7 +193,7 @@ cd ./vcd/test-artifacts
 
 The "pause" option will stop the test after every call to the terraform tool, waiting for user input.
 
-When the test runs unattended, it is possible to stop it gracefully by creating a file named `pause.txt` inside the
+When the test runs unattended, it is possible to stop it gracefully by creating a file named `pause` inside the
 `test-artifacts` directory. When such file exists, the test execution stops at the next `terraform` command, waiting
 for user input.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -175,7 +175,7 @@ make test-binary
 
 All the tests run unattended, stopping only if there is an error.
 
-It is possible to customise running of the binary tests, by preparing them and then running the test script from the `tests-artifacts` directory:
+It is possible to customise running of the binary tests by preparing them and then running the test script from the `tests-artifacts` directory:
 
 ```bash
 make test-binary-prepare

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+scripts_dir=$(dirname $0)
+cd $scripts_dir
+scripts_dir=$PWD
+cd -
 
 if [ ! -d ./vcd ]
 then
@@ -35,6 +39,8 @@ fi
 echo "==> Run test $wanted"
 
 cd vcd
+
+source_dir=$PWD
 
 function check_for_config_file {
     config_file=vcd_test_config.json
@@ -115,11 +121,47 @@ function multiple_test {
     fi
 }
 
+function binary_test {
+    cd $source_dir
+    if [ ! -d test-artifacts ]
+    then
+        echo "test-artifacts not found"
+        exit 1
+    fi
+    cp $scripts_dir/test-binary.sh test-artifacts/test-binary.sh
+    chmod +x test-artifacts/test-binary.sh
+    cd test-artifacts
+    if [ -f already_run.txt ]
+    then
+        rm -f already_run.txt
+    fi
+    if [ -n "$NORUN" ]
+    then
+        pwd
+        ls -l
+        exit
+    fi
+    ./test-binary.sh
+}
+
 case $wanted in
+    binary-prepare)
+        export NORUN=1
+        binary_test
+        ;;
+    binary)
+        binary_test
+        ;;
     unit)
         unit_test
         ;;
     short)
+        export VCD_SKIP_TEMPLATE_WRITING=1
+        short_test
+        ;;
+    short-provider)
+        unset VCD_SKIP_TEMPLATE_WRITING
+        export VCD_ADD_PROVIDER=1
         short_test
         ;;
     acceptance)

--- a/scripts/test-binary.sh
+++ b/scripts/test-binary.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+
+runtime_dir=$(dirname $0)
+cd $runtime_dir
+runtime_dir=$PWD
+cd -
+pause_file=$runtime_dir/pause.txt
+dash_line="# ---------------------------------------------------------"
+
+function get_help {
+    echo "Syntax: $(basename $0) [options]"
+    echo "Where options are one or more of the following:"
+    echo "  h | help               Show this help and exit"
+    echo "  t | tags 'tags list'   Sets the tags to use"
+    echo "  c | clear              Clears list of run files"
+    echo "  p | pause              Pause after each stage"
+    echo "  d | dry                Dry-run: show commands without executing them"
+    echo "  v | verbose            Gives more info"
+    echo ""
+    echo "Examples"
+    echo "test-binary.sh tags 'catalog gateway' clear pause"
+    echo "test-binary.sh t 'catalog gateway' c p"
+    echo "test-binary.sh tags vapp dry"
+    echo ""
+    echo "## During the execution, if you create a file named 'pause.txt',"
+    echo "## the program will pause at the next 'terraform' command"
+    exit 0
+}
+
+function echo_verbose {
+    if [ -n "$VERBOSE" ]
+    then
+        echo "$@"
+    fi
+}
+
+while [ "$1" != "" ]
+do
+  opt=$1
+  case $opt in
+    h|help)
+        get_help
+        ;;
+    p|pause)
+        will_pause=1
+        echo "will pause"
+        ;;
+    c|clear)
+        if [ -f already_run.txt ]
+        then
+            rm -f already_run.txt
+            echo "already_run.txt removed"
+        fi
+        ;;
+    d|dry)
+        DRY_RUN=1
+        ;;
+    t|tags)
+        shift
+        opt=$1
+        if [ -z "$opt" ]
+        then
+            echo "option 'tags' requires an argument"
+            exit 1
+        fi
+        tags="$opt"
+        echo "tags: $tags"
+        ;;
+    v|verbose)
+        export VERBOSE=1
+        ;;
+    *)
+        get_help 
+        ;;
+  esac
+  shift
+done
+
+exit_code=0
+start_time=$(date +%s)
+start_timestamp=$(date)
+
+test_names='*.tf'
+
+function summary {
+    end_time=$(date +%s)
+    end_timestamp=$(date)
+    elapsed=$(($end_time-$start_time))
+    echo "# Started:   $start_timestamp"
+    echo "# Ended:     $end_timestamp"
+    echo "# Elapsed:   $elapsed"
+    echo "# exit code: $exit_code"
+    exit $exit_code
+}
+
+function run {
+    cmd="$@"
+    echo "# $cmd"
+    if [ -n "$DRY_RUN" ]
+    then
+        return
+    fi
+    $cmd
+    exit_code=$?
+    if [ "$exit_code" != "0" ]
+    then
+        echo "EXECUTION ERROR"
+        summary
+    fi
+    if [ -f $pause_file ]
+    then
+        rm -f $pause_file
+        export will_pause=1
+    fi
+    if [ -n "$will_pause" ]
+    then
+        echo "Paused at user request - Press ENTER when ready"
+        echo "(Enter 'q' to exit with 0, 'x' to exit with 1, 'c' to continue without further pause)"
+        read answer
+        case $answer in
+            q)
+                echo "Exit at user request"
+                exit 0
+                ;;
+            x)
+                echo "Exit with non-zero code at user request"
+                exit 1
+                ;;
+            c)
+                unset will_pause
+                echo "Execution will not pause any more"
+                ;;
+        esac
+    fi
+}
+
+if [ ! -f already_run.txt ]
+then
+    touch already_run.txt
+fi
+
+for CF in $test_names
+do
+    is_provider=$(grep ^provider $CF)
+    is_resource=$(grep ^resource $CF)
+    if [ -z "$is_resource" ]
+    then
+        echo_verbose "$CF not a resource"
+        continue
+    fi
+    if [ -z "$is_provider" ]
+    then
+        echo_verbose "$CF does not contain a provider"
+        continue
+    fi
+    using_tags=$(grep '^# tags' $CF | sed -e 's/# tags //')
+    already_run=$(grep $CF already_run.txt)
+    if [ -n "$already_run" ]
+    then
+        echo "$CF already run"
+        continue
+    fi
+    unset will_run
+    # No tags were requested: we will run every file
+    if [ "$tags" == "" ]
+    then
+        will_run=1
+    else
+        for utag in $using_tags
+        do
+            for wtag in $tags
+            do
+                if [ "$utag" == "$wtag" -o "$utag" == "ALL" ]
+                then
+                    echo_verbose "Using tag $utag"
+                    will_run=1
+                fi
+            done
+        done
+    fi
+    if [ -z "$will_run" ]
+    then
+        echo_verbose "$CF skipped for non-matching tag"
+        continue
+    fi
+    echo $dash_line
+    echo "# $CF"
+    echo $dash_line
+    if [ -d ./tmp ]
+    then
+        rm -rf tmp
+    fi
+    mkdir tmp
+    cp $CF tmp/config.tf
+    if [ -z "$DRY_RUN" ]
+    then
+        echo $CF >> already_run.txt
+    fi
+    cd tmp
+
+    run terraform init
+    run terraform plan
+    run terraform apply -auto-approve
+    run terraform destroy -auto-approve
+    cd ..
+done
+
+summary
+

--- a/scripts/test-binary.sh
+++ b/scripts/test-binary.sh
@@ -4,7 +4,7 @@ runtime_dir=$(dirname $0)
 cd $runtime_dir
 runtime_dir=$PWD
 cd -
-pause_file=$runtime_dir/pause.txt
+pause_file=$runtime_dir/pause
 dash_line="# ---------------------------------------------------------"
 
 function get_help {
@@ -24,7 +24,7 @@ function get_help {
     echo "test-binary.sh t 'catalog gateway' c p"
     echo "test-binary.sh tags vapp dry"
     echo ""
-    echo "## During the execution, if you create a file named 'pause.txt',"
+    echo "## During the execution, if you create a file named 'pause',"
     echo "## the program will pause at the next 'terraform' command"
     exit 0
 }

--- a/scripts/test-binary.sh
+++ b/scripts/test-binary.sh
@@ -17,6 +17,8 @@ function get_help {
     echo "  d | dry                Dry-run: show commands without executing them"
     echo "  v | verbose            Gives more info"
     echo ""
+    echo "If no options are given, it runs all the tests in test-artifacts"
+    echo ""
     echo "Examples"
     echo "test-binary.sh tags 'catalog gateway' clear pause"
     echo "test-binary.sh t 'catalog gateway' c p"
@@ -162,7 +164,7 @@ do
     fi
     unset will_run
     # No tags were requested: we will run every file
-    if [ "$tags" == "" ]
+    if [ "$tags" == ""  -o "$tags" == "ALL" ]
     then
         will_run=1
     else
@@ -170,7 +172,7 @@ do
         do
             for wtag in $tags
             do
-                if [ "$utag" == "$wtag" -o "$utag" == "ALL" ]
+                if [ "$utag" == "$wtag" ]
                 then
                     echo_verbose "Using tag $utag"
                     will_run=1

--- a/vcd/api_test.go
+++ b/vcd/api_test.go
@@ -94,6 +94,26 @@ func TestTags(t *testing.T) {
 	}
 }
 
+// Checks if a file exists
+func fileExists(filename string) bool {
+	f, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	fileMode := f.Mode()
+	return fileMode.IsRegular()
+}
+
+// Checks if a directory exists
+func dirExists(filename string) bool {
+	f, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	fileMode := f.Mode()
+	return fileMode.IsDir()
+}
+
 // Finds the current directory, through the path of this running test
 func getCurrentDir() string {
 	_, currentFilename, _, _ := runtime.Caller(0)

--- a/vcd/resource_vcd_catalog_item_test.go
+++ b/vcd/resource_vcd_catalog_item_test.go
@@ -26,13 +26,14 @@ func TestAccVcdCatalogItemBasic(t *testing.T) {
 		"OvaPath":         testConfig.Ova.OvaPath,
 		"UploadPieceSize": testConfig.Ova.UploadPieceSize,
 		"UploadProgress":  testConfig.Ova.UploadProgress,
+		"Tags":            "catalog",
 	}
 
+	configText := templateFill(testAccCheckVcdCatalogItemBasic, params)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
 	}
-	configText := templateFill(testAccCheckVcdCatalogItemBasic, params)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	resource.Test(t, resource.TestCase{

--- a/vcd/resource_vcd_catalog_media_test.go
+++ b/vcd/resource_vcd_catalog_media_test.go
@@ -25,13 +25,14 @@ func TestAccVcdCatalogMediaBasic(t *testing.T) {
 		"MediaPath":        testConfig.Media.MediaPath,
 		"UploadPieceSize":  testConfig.Media.UploadPieceSize,
 		"UploadProgress":   testConfig.Media.UploadProgress,
+		"Tags":             "catalog",
 	}
 
+	configText := templateFill(testAccCheckVcdCatalogMediaBasic, params)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
 	}
-	configText := templateFill(testAccCheckVcdCatalogMediaBasic, params)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	resource.Test(t, resource.TestCase{

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -21,13 +21,14 @@ func TestAccVcdCatalogBasic(t *testing.T) {
 		"Org":         testConfig.VCD.Org,
 		"CatalogName": TestAccVcdCatalog,
 		"Description": TestAccVcdCatalogDescription,
+		"Tags":        "catalog",
 	}
 
+	configText := templateFill(testAccCheckVcdCatalogBasic, params)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
 	}
-	configText := templateFill(testAccCheckVcdCatalogBasic, params)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	resource.Test(t, resource.TestCase{

--- a/vcd/resource_vcd_dnat_test.go
+++ b/vcd/resource_vcd_dnat_test.go
@@ -268,6 +268,7 @@ func TestAccVcdDNAT_ForBackCompability(t *testing.T) {
 		"EdgeGateway": testConfig.Networking.EdgeGateway,
 		"ExternalIp":  testConfig.Networking.ExternalIp,
 		"DnatName":    dnatName,
+		"Tags":        "gateway",
 	}
 
 	configText := templateFill(testAccCheckVcdDnat_ForBackCompability, params)

--- a/vcd/resource_vcd_dnat_test.go
+++ b/vcd/resource_vcd_dnat_test.go
@@ -15,10 +15,6 @@ var baseDnatName string = "TestAccVcdDNAT"
 var orgVdcNetworkName = "TestAccVcdDNAT_BasicNetwork"
 
 func TestAccVcdDNAT_Basic(t *testing.T) {
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	if testConfig.Networking.ExternalIp == "" {
 		t.Skip("Variable networking.externalIp must be set to run DNAT tests")
 		return
@@ -36,9 +32,14 @@ func TestAccVcdDNAT_Basic(t *testing.T) {
 		"Gateway":           "10.10.102.1",
 		"StartIpAddress":    "10.10.102.51",
 		"EndIpAddress":      "10.10.102.100",
+		"Tags":              "gateway",
 	}
 
 	configText := templateFill(testAccCheckVcdDnat_basic, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -64,10 +65,6 @@ func TestAccVcdDNAT_Basic(t *testing.T) {
 }
 
 func TestAccVcdDNAT_tlate(t *testing.T) {
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	if testConfig.Networking.ExternalIp == "" {
 		t.Skip("Variable networking.externalIp must be set to run DNAT tests")
 		return
@@ -85,9 +82,14 @@ func TestAccVcdDNAT_tlate(t *testing.T) {
 		"Gateway":           "10.10.102.1",
 		"StartIpAddress":    "10.10.102.51",
 		"EndIpAddress":      "10.10.102.100",
+		"Tags":              "gateway",
 	}
 
 	configText := templateFill(testAccCheckVcdDnat_tlate, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -253,10 +255,6 @@ resource "vcd_dnat" "{{.DnatName}}" {
 `
 
 func TestAccVcdDNAT_ForBackCompability(t *testing.T) {
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	if testConfig.Networking.ExternalIp == "" {
 		t.Skip("Variable networking.externalIp must be set to run DNAT tests")
 		return
@@ -273,6 +271,10 @@ func TestAccVcdDNAT_ForBackCompability(t *testing.T) {
 	}
 
 	configText := templateFill(testAccCheckVcdDnat_ForBackCompability, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/vcd/resource_vcd_edgegateway_vpn_test.go
+++ b/vcd/resource_vcd_edgegateway_vpn_test.go
@@ -13,10 +13,6 @@ import (
 func TestAccVcdVpn_Basic(t *testing.T) {
 	var vpnName string = "TestAccVcdVpnVpn"
 
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	// String map to fill the template
 	var params = StringMap{
 		"Org":           testConfig.VCD.Org,
@@ -31,8 +27,13 @@ func TestAccVcdVpn_Basic(t *testing.T) {
 		"LocalSubnetGW": testConfig.Networking.Local.LocalSubnetGateway,
 		"SiteName":      "TestAccVcdVpnSite",
 		"VpnName":       vpnName,
+		"Tags":          "gateway",
 	}
 	configText := templateFill(testAccCheckVcdVpn_basic, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/vcd/resource_vcd_external_network_test.go
+++ b/vcd/resource_vcd_external_network_test.go
@@ -27,11 +27,7 @@ func TestAccVcdExternalNetworkBasic(t *testing.T) {
 		"Type":                testConfig.Networking.ExternalNetworkPortGroupType,
 		"PortGroup":           testConfig.Networking.ExternalNetworkPortGroup,
 		"Vcenter":             testConfig.Networking.Vcenter,
-	}
-
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
+		"Tags":                "network extnetwork",
 	}
 
 	if !usingSysAdmin() {
@@ -40,6 +36,10 @@ func TestAccVcdExternalNetworkBasic(t *testing.T) {
 	}
 
 	configText := templateFill(testAccCheckVcdExternalNetwork_basic, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	resource.Test(t, resource.TestCase{

--- a/vcd/resource_vcd_independent_disk_test.go
+++ b/vcd/resource_vcd_independent_disk_test.go
@@ -25,13 +25,14 @@ func TestAccVcdIndependentDiskBasic(t *testing.T) {
 		"busSubType":         "lsilogicsas",
 		"storageProfileName": "*",
 		"ResourceName":       resourceName,
+		"Tags":               "disk",
 	}
 
+	configText := templateFill(testAccCheckVcdIndependentDiskBasic, params)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
 	}
-	configText := templateFill(testAccCheckVcdIndependentDiskBasic, params)
 
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 

--- a/vcd/resource_vcd_inserted_media_test.go
+++ b/vcd/resource_vcd_inserted_media_test.go
@@ -36,13 +36,14 @@ func TestAccVcdMediaInsertBasic(t *testing.T) {
 		"InsertMediaName":  TestAccVcdMediaInsert,
 		"NetworkName":      TestAccVcdVAppVmNetForInsert,
 		"EjectForce":       true,
+		"Tags":             "catalog",
 	}
 
+	configText := templateFill(testAccCheckVcdInsertEjectBasic, params)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
 	}
-	configText := templateFill(testAccCheckVcdInsertEjectBasic, params)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	resource.Test(t, resource.TestCase{

--- a/vcd/resource_vcd_network_test.go
+++ b/vcd/resource_vcd_network_test.go
@@ -35,11 +35,6 @@ const (
 )
 
 func TestAccVcdNetworkIsolatedStatic(t *testing.T) {
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
-
 	var def = networkDef{
 		name:           isolatedStaticNetwork,
 		gateway:        "192.168.2.1",
@@ -53,10 +48,6 @@ func TestAccVcdNetworkIsolatedStatic(t *testing.T) {
 }
 
 func TestAccVcdNetworkIsolatedDhcp(t *testing.T) {
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	var def = networkDef{
 		name:           isolatedDhcpNetwork,
 		gateway:        "192.168.2.1",
@@ -69,10 +60,6 @@ func TestAccVcdNetworkIsolatedDhcp(t *testing.T) {
 }
 
 func TestAccVcdNetworkIsolatedMixed(t *testing.T) {
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	var def = networkDef{
 		name:            isolatedMixedNetwork,
 		gateway:         "192.168.2.1",
@@ -87,11 +74,6 @@ func TestAccVcdNetworkIsolatedMixed(t *testing.T) {
 }
 
 func TestAccVcdNetworkRoutedStatic(t *testing.T) {
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
-
 	var def = networkDef{
 		name:           routedNetworkStatic,
 		gateway:        "10.10.102.1",
@@ -104,11 +86,6 @@ func TestAccVcdNetworkRoutedStatic(t *testing.T) {
 }
 
 func TestAccVcdNetworkRoutedDhcp(t *testing.T) {
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
-
 	var def = networkDef{
 		name:           routedNetworkDhcp,
 		gateway:        "10.10.102.1",
@@ -121,10 +98,6 @@ func TestAccVcdNetworkRoutedDhcp(t *testing.T) {
 }
 
 func TestAccVcdNetworkRoutedMixed(t *testing.T) {
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 
 	var def = networkDef{
 		name:            routedNetworkMixed,
@@ -140,10 +113,6 @@ func TestAccVcdNetworkRoutedMixed(t *testing.T) {
 }
 
 func TestAccVcdNetworkDirect(t *testing.T) {
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	if !usingSysAdmin() {
 		t.Skip("TestAccVcdNetworkDirect requires system admin privileges")
 		return
@@ -175,9 +144,15 @@ func runTest(def networkDef, t *testing.T) {
 		"EndIpAddress2":   def.endIpAddress2,
 		"ExternalNetwork": def.externalNetwork,
 		"FuncName":        networkName,
+		"Tags":            "network",
 	}
 	var network govcd.OrgVDCNetwork
 	configText := templateFill(def.configText, params)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	// steps for external network

--- a/vcd/resource_vcd_org_test.go
+++ b/vcd/resource_vcd_org_test.go
@@ -19,11 +19,7 @@ func TestAccVcdOrgBasic(t *testing.T) {
 	var e govcd.Org
 	var params = StringMap{
 		"OrgName": orgNameTestAccVcdOrgBasic,
-	}
-
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
+		"Tags":    "org",
 	}
 
 	if !usingSysAdmin() {
@@ -32,6 +28,10 @@ func TestAccVcdOrgBasic(t *testing.T) {
 	}
 
 	configText := templateFill(testAccCheckVcdOrg_basic, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	resource.Test(t, resource.TestCase{

--- a/vcd/resource_vcd_org_vdc_test.go
+++ b/vcd/resource_vcd_org_vdc_test.go
@@ -26,6 +26,8 @@ func TestAccVcdOrgVdcReservationPool(t *testing.T) {
 		"ProviderVdc":               testConfig.VCD.ProviderVdc.Name,
 		"NetworkPool":               testConfig.VCD.ProviderVdc.NetworkPool,
 		"ProviderVdcStorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
+		"Tags":                      "vdc",
+		"FuncName":                  "TestAccVcdOrgVdcReservationPool",
 	}
 	runOrgVdcTest(t, params, allocationModel)
 }
@@ -42,6 +44,8 @@ func TestAccVcdOrgVdcAllocationPool(t *testing.T) {
 		"ProviderVdc":               testConfig.VCD.ProviderVdc.Name,
 		"NetworkPool":               testConfig.VCD.ProviderVdc.NetworkPool,
 		"ProviderVdcStorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
+		"Tags":                      "vdc",
+		"FuncName":                  "TestAccVcdOrgVdcAllocationPool",
 	}
 	runOrgVdcTest(t, params, allocationModel)
 }
@@ -59,6 +63,8 @@ func TestAccVcdOrgVdcAllocationVApp(t *testing.T) {
 		"ProviderVdc":               testConfig.VCD.ProviderVdc.Name,
 		"NetworkPool":               testConfig.VCD.ProviderVdc.NetworkPool,
 		"ProviderVdcStorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
+		"Tags":                      "vdc",
+		"FuncName":                  "TestAccVcdOrgVdcAllocationVapp",
 	}
 	runOrgVdcTest(t, params, allocationModel)
 }
@@ -86,17 +92,16 @@ func runOrgVdcTest(t *testing.T, params StringMap, allocationModel string) {
 
 	var vdc govcd.Vdc
 
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
-
 	if !usingSysAdmin() {
 		t.Skip("TestAccVcdVdcBasic requires system admin privileges")
 		return
 	}
 
 	configText := templateFill(testAccCheckVcdVdc_basic, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	resource.Test(t, resource.TestCase{

--- a/vcd/resource_vcd_snat_test.go
+++ b/vcd/resource_vcd_snat_test.go
@@ -15,10 +15,6 @@ var orgVdcNetworkNameForSnat = "TestAccVcdDNAT_BasicNetworkForSnat"
 var startIpAddress = "10.10.102.51"
 
 func TestAccVcdSNAT_Basic(t *testing.T) {
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	if testConfig.Networking.ExternalIp == "" {
 		t.Skip("Variable networking.extarnalIp must be set to run SNAT tests")
 		return
@@ -38,9 +34,14 @@ func TestAccVcdSNAT_Basic(t *testing.T) {
 		"Gateway":           "10.10.102.1",
 		"StartIpAddress":    startIpAddress,
 		"EndIpAddress":      "10.10.102.100",
+		"Tags":              "gateway",
 	}
 
 	configText := templateFill(testAccCheckVcdSnat_basic, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	resource.Test(t, resource.TestCase{
@@ -156,6 +157,7 @@ func TestAccVcdSNAT_BackCompability(t *testing.T) {
 		"ExternalIp":  testConfig.Networking.ExternalIp,
 		"SnatName":    snatName,
 		"LocalIp":     testConfig.Networking.InternalIp,
+		"Tags":        "gateway",
 	}
 
 	configText := templateFill(testAccCheckVcdSnat_forBackCompability, params)

--- a/vcd/resource_vcd_vapp_network_multi_test.go
+++ b/vcd/resource_vcd_vapp_network_multi_test.go
@@ -23,10 +23,6 @@ const (
 // go test -v -timeout 0 -tags multinetwork -run TestAccVcdVappNetworkMulti .
 //
 func TestAccVcdVappNetworkMulti(t *testing.T) {
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 
 	const (
 		networkBaseIp1     = "192.168.11"
@@ -77,9 +73,14 @@ func TestAccVcdVappNetworkMulti(t *testing.T) {
 		"dhcpStartAddress3": networkBaseIp3 + startDhcpAddress,
 		"dhcpEndAddress3":   networkBaseIp3 + endDhcpAddress,
 		"dhcpEnabled":       "true",
+		"Tags":              "multinetwork",
 	}
 
 	configText := templateFill(testAccCheckVappNetworkMulti, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	resource.Test(t, resource.TestCase{

--- a/vcd/resource_vcd_vapp_raw_multi_test.go
+++ b/vcd/resource_vcd_vapp_raw_multi_test.go
@@ -17,11 +17,6 @@ import (
 func TestAccVcdVAppRawMulti(t *testing.T) {
 	var vapp govcd.VApp
 
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
-
 	var params = StringMap{
 		"Org":         testConfig.VCD.Org,
 		"Vdc":         testConfig.VCD.Vdc,
@@ -33,8 +28,13 @@ func TestAccVcdVAppRawMulti(t *testing.T) {
 		"VmName1":     "TestAccVcdVAppRawVm1",
 		"VmName2":     "TestAccVcdVAppRawVm2",
 		"VmName3":     "TestAccVcdVAppRawVm3",
+		"Tags":        "multivm",
 	}
 	configText := templateFill(testAccCheckVcdVAppRawMulti, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/vcd/resource_vcd_vapp_raw_test.go
+++ b/vcd/resource_vcd_vapp_raw_test.go
@@ -14,10 +14,6 @@ import (
 func TestAccVcdVAppRaw_Basic(t *testing.T) {
 	var vapp govcd.VApp
 
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	var params = StringMap{
 		"Org":         testConfig.VCD.Org,
 		"Vdc":         testConfig.VCD.Vdc,
@@ -27,8 +23,13 @@ func TestAccVcdVAppRaw_Basic(t *testing.T) {
 		"CatalogItem": testSuiteCatalogOVAItem,
 		"VappName":    "TestAccVcdVAppRawVapp",
 		"VmName":      "TestAccVcdVAppRawVm",
+		"Tags":        "vapp",
 	}
 	configText := templateFill(testAccCheckVcdVAppRaw_basic, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -17,10 +17,6 @@ var vappNameAllocated = "TestAccVcdVAppVappAllocated"
 func TestAccVcdVApp_PowerOff(t *testing.T) {
 	var vapp govcd.VApp
 
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	var params = StringMap{
 		"Org":               testConfig.VCD.Org,
 		"Vdc":               testConfig.VCD.Vdc,
@@ -33,12 +29,17 @@ func TestAccVcdVApp_PowerOff(t *testing.T) {
 		"VappName":          vappName,
 		"VappNameAllocated": vappNameAllocated,
 		"FuncName":          "TestAccCheckVcdVApp_basic",
+		"Tags":              "vapp",
 	}
 	configText := templateFill(testAccCheckVcdVApp_basic, params)
 
 	params["FuncName"] = "TestAccCheckVcdVApp_powerOff"
 
 	configTextPoweroff := templateFill(testAccCheckVcdVApp_powerOff, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	debugPrintf("#[DEBUG] CONFIGURATION basic: %s\n", configText)
 	debugPrintf("#[DEBUG] CONFIGURATION poweroff: %s\n", configTextPoweroff)
 	resource.Test(t, resource.TestCase{

--- a/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
+++ b/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
@@ -15,10 +15,6 @@ func TestAccVcdVAppVm_HardwareVirtualization(t *testing.T) {
 	var vapp govcd.VApp
 	var vm govcd.VM
 
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	var params = StringMap{
 		"Org":         testConfig.VCD.Org,
 		"Vdc":         testConfig.VCD.Vdc,
@@ -28,6 +24,7 @@ func TestAccVcdVAppVm_HardwareVirtualization(t *testing.T) {
 		"CatalogItem": testSuiteCatalogOVAItem,
 		"VappName":    vappNameHwVirt,
 		"VmName":      vmNameHwVirt,
+		"Tags":        "vapp vm",
 	}
 
 	configTextStep0 := templateFill(testAccCheckVcdVAppVm_hardwareVirtualization, params)
@@ -36,6 +33,10 @@ func TestAccVcdVAppVm_HardwareVirtualization(t *testing.T) {
 	params["FuncName"] = t.Name() + "-step1"
 	configTextStep1 := templateFill(testAccCheckVcdVAppVm_hardwareVirtualization, params)
 
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configTextStep0)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -26,10 +26,6 @@ func TestAccVcdVAppVmMulti(t *testing.T) {
 		vmName3           string = "TestAccVcdVAppVmVm3"
 	)
 
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	var params = StringMap{
 		"Org":                testConfig.VCD.Org,
 		"Vdc":                testConfig.VCD.Vdc,
@@ -47,9 +43,14 @@ func TestAccVcdVAppVmMulti(t *testing.T) {
 		"busSubType":         "lsilogicsas",
 		"storageProfileName": "*",
 		"diskResourceName":   diskResourceNameM,
+		"Tags":               "multivm",
 	}
 
 	configText := templateFill(testAccCheckVcdVAppVmMulti, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/vcd/resource_vcd_vapp_vm_multinetwork_test.go
+++ b/vcd/resource_vcd_vapp_vm_multinetwork_test.go
@@ -17,10 +17,6 @@ func TestAccVcdVAppVmMultiNIC(t *testing.T) {
 		netVmName1  string = t.Name() + "VM"
 	)
 
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	var params = StringMap{
 		"Org":         testConfig.VCD.Org,
 		"Vdc":         testConfig.VCD.Vdc,
@@ -29,9 +25,14 @@ func TestAccVcdVAppVmMultiNIC(t *testing.T) {
 		"CatalogItem": testSuiteCatalogOVAItem,
 		"VAppName":    netVappName,
 		"VMName":      netVmName1,
+		"Tags":        "vapp vm",
 	}
 
 	configTextVM := templateFill(testAccCheckVcdVAppVmNetworkVM, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 
 	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configTextVM)
 	resource.Test(t, resource.TestCase{

--- a/vcd/resource_vcd_vapp_vm_singlenetwork_test.go
+++ b/vcd/resource_vcd_vapp_vm_singlenetwork_test.go
@@ -22,10 +22,6 @@ func TestAccVcdVAppVmSingleNIC(t *testing.T) {
 		netVmName1  string = t.Name()
 	)
 
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	var params = StringMap{
 		"Org":           testConfig.VCD.Org,
 		"Vdc":           testConfig.VCD.Vdc,
@@ -35,6 +31,7 @@ func TestAccVcdVAppVmSingleNIC(t *testing.T) {
 		"VMNetworkName": "singlenic-net",
 		"VAppName":      netVappName,
 		"IP":            "allocated",
+		"Tags":          "vapp vm",
 	}
 
 	params["FuncName"] = t.Name() + "-NetOnly"
@@ -44,6 +41,7 @@ func TestAccVcdVAppVmSingleNIC(t *testing.T) {
 	configTextNetworkVapp := templateFill(testAccCheckVcdVAppVmSingleNICNetworkVapp, params)
 
 	// allocated
+	params["FuncName"] = t.Name() + "-allocated"
 	netVmNameAllocated := netVmName1 + "allocated"
 	params["VMName"] = netVmNameAllocated
 	configTextStep0 := templateFill(testAccCheckVcdVAppVmSingleNICNetwork, params)
@@ -87,6 +85,10 @@ func TestAccVcdVAppVmSingleNIC(t *testing.T) {
 	params["VMName"] = netVmNameBothNetworks
 	params["FuncName"] = t.Name() + "-step10"
 	configTextStep10 := templateFill(testAccCheckVcdVAppVmSingleNICvAppAndVdc, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 
 	debugPrintf("#[DEBUG] CONFIGURATION (allocated): %s\n", configTextStep0)
 	debugPrintf("#[DEBUG] CONFIGURATION (dhcp): %s\n", configTextStep2)

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -18,10 +18,6 @@ func TestAccVcdVAppVm_Basic(t *testing.T) {
 	var vapp govcd.VApp
 	var vm govcd.VM
 
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	var params = StringMap{
 		"Org":                testConfig.VCD.Org,
 		"Vdc":                testConfig.VCD.Vdc,
@@ -37,9 +33,14 @@ func TestAccVcdVAppVm_Basic(t *testing.T) {
 		"busSubType":         "lsilogicsas",
 		"storageProfileName": "*",
 		"diskResourceName":   diskResourceName,
+		"Tags":               "vapp vm",
 	}
 
 	configText := templateFill(testAccCheckVcdVAppVm_basic, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 
 	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
This is the first part of the test suite enhancement to allow running tests using a Terraform executable tool. (Issue #250)

Add commands make test-binary and make test-binary-prepare
Add subcommands for binary testing in runtest.sh
Add script test-binary.sh with possible interactive tests
Improve production of test-artifacts scripts
Add check on test-artifacts for duplicate script names
Add tags and other metadata to test-artifacts scripts
Update TESTING.md

TODO: The second part will include the production of binary tests from custom templates.

Signed-off-by: Giuseppe Maxia <gmaxia@vmware.com>