### PR TITLE
Mutex change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 2.4.0 (Unreleased)
+IMPROVEMENTS:
+
+* Change resource handling to use locking mechanism when resource parallel handling is not supported by vDC. [#255] 
+
 ## 2.3.0 (May 29, 2019)
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.4.0 (Unreleased)
 IMPROVEMENTS:
 
-* Change resource handling to use locking mechanism when resource parallel handling is not supported by vDC. [#255] 
+* Change resource handling to use locking mechanism when resource parallel handling is not supported by vCD. [GH-#255] 
 
 ## 2.3.0 (May 29, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ FEATURES:
 * `vcd_vapp_vm` - Ability to add metadata to a VM. For previous behaviour please see `BACKWARDS INCOMPATIBILITIES` ([#158](https://github.com/terraform-providers/terraform-provider-vcd/issues/158))
 * `vcd_vapp_vm` - Ability to enable hardware assisted CPU virtualization for VM. It allows hypervisor nesting. ([#219](https://github.com/terraform-providers/terraform-provider-vcd/issues/219))
 * **New Resource:** external network - `vcd_external_network` - ([#230](https://github.com/terraform-providers/terraform-provider-vcd/issues/230))
-* **New Resource:** VDC resource `vcd_org_vdc` - ([#234](https://github.com/terraform-providers/terraform-provider-vcd/issues/234))
+* **New Resource:** VDC resource `vcd_org_vdc` - ([#236](https://github.com/terraform-providers/terraform-provider-vcd/issues/236))
 * resource/vcd_vapp_vm: Add `network` argument for multiple NIC support and more flexible configuration ([#233](https://github.com/terraform-providers/terraform-provider-vcd/issues/233))
 * resource/vcd_vapp_vm: Add `mac` argument to store MAC address in state file ([#233](https://github.com/terraform-providers/terraform-provider-vcd/issues/233))
 

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.12
 
 require (
 	github.com/hashicorp/terraform v0.12.0
-	github.com/vmware/go-vcloud-director/v2 v2.2.0
+	github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.1
 )

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/hashicorp/terraform v0.12.0
 	github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.1
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,3 @@ require (
 	github.com/hashicorp/terraform v0.12.0
 	github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.1
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.sum
+++ b/go.sum
@@ -301,8 +301,8 @@ github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4A
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/go-vcloud-director/v2 v2.2.0 h1:mfxgMKeErH9lSVyYI7QOcM9OYsSbphcptPa6EG+haMw=
-github.com/vmware/go-vcloud-director/v2 v2.2.0/go.mod h1:HonlGxbjJ1NAibWh99eE4/S2l6ZOZ5KJzKK1rh2a9vc=
+github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.1 h1:zQD5RbcompjwAeACoJjtMgTeUc4lZaLceBv66j5Ayy8=
+github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.1/go.mod h1:HonlGxbjJ1NAibWh99eE4/S2l6ZOZ5KJzKK1rh2a9vc=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=

--- a/vcd/config.go
+++ b/vcd/config.go
@@ -97,7 +97,7 @@ var vcdMutexKV = mutexkv.NewMutexKV()
 func (cli *VCDClient) lockVapp(d *schema.ResourceData) {
 	vappName := d.Get("name").(string)
 	if vappName == "" {
-		panic("vapp name isn't found")
+		panic("vApp name not found")
 	}
 	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", cli.getOrgName(d), cli.getVdcName(d), vappName)
 	vcdMutexKV.Lock(key)
@@ -106,16 +106,18 @@ func (cli *VCDClient) lockVapp(d *schema.ResourceData) {
 func (cli *VCDClient) unLockVapp(d *schema.ResourceData) {
 	vappName := d.Get("name").(string)
 	if vappName == "" {
-		panic("vapp name isn't found")
+		panic("vApp name not found")
 	}
 	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", cli.getOrgName(d), cli.getVdcName(d), vappName)
 	vcdMutexKV.Unlock(key)
 }
 
+// function lockParentVapp locks using vapp_name name existing in resource parameters. Parent means resource needs
+// to lock vApp it depends
 func (cli *VCDClient) lockParentVapp(d *schema.ResourceData) {
 	vappName := d.Get("vapp_name").(string)
 	if vappName == "" {
-		panic("vapp name isn't found")
+		panic("vApp name not found")
 	}
 	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", cli.getOrgName(d), cli.getVdcName(d), vappName)
 	vcdMutexKV.Lock(key)
@@ -124,16 +126,18 @@ func (cli *VCDClient) lockParentVapp(d *schema.ResourceData) {
 func (cli *VCDClient) unLockParentVapp(d *schema.ResourceData) {
 	vappName := d.Get("vapp_name").(string)
 	if vappName == "" {
-		panic("vapp name isn't found")
+		panic("vApp name not found")
 	}
 	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", cli.getOrgName(d), cli.getVdcName(d), vappName)
 	vcdMutexKV.Unlock(key)
 }
 
+// function lockParentEdgeGtw locks using edge_gateway name existing in resource parameters. Parent means resource needs
+// to lock edge gtw it depends
 func (cli *VCDClient) lockParentEdgeGtw(d *schema.ResourceData) {
 	edgeGtwName := d.Get("edge_gateway").(string)
 	if edgeGtwName == "" {
-		panic("edge gtw name isn't found")
+		panic("edge gateway not found")
 	}
 	key := fmt.Sprintf("org:%s|vdc:%s|edge:%s", cli.getOrgName(d), cli.getVdcName(d), edgeGtwName)
 	vcdMutexKV.Lock(key)
@@ -142,7 +146,7 @@ func (cli *VCDClient) lockParentEdgeGtw(d *schema.ResourceData) {
 func (cli *VCDClient) unLockParentEdgeGtw(d *schema.ResourceData) {
 	edgeGtwName := d.Get("edge_gateway").(string)
 	if edgeGtwName == "" {
-		panic("edge gtw name isn't found")
+		panic("edge gateway not found")
 	}
 	key := fmt.Sprintf("org:%s|vdc:%s|edge:%s", cli.getOrgName(d), cli.getVdcName(d), edgeGtwName)
 	vcdMutexKV.Unlock(key)

--- a/vcd/config.go
+++ b/vcd/config.go
@@ -112,8 +112,8 @@ func (cli *VCDClient) unLockVapp(d *schema.ResourceData) {
 	vcdMutexKV.Unlock(key)
 }
 
-// function lockParentVapp locks using vapp_name name existing in resource parameters. Parent means resource needs
-// to lock vApp it depends
+// function lockParentVapp locks using vapp_name name existing in resource parameters.
+// Parent means the resource belongs to the vApp being locked
 func (cli *VCDClient) lockParentVapp(d *schema.ResourceData) {
 	vappName := d.Get("vapp_name").(string)
 	if vappName == "" {
@@ -132,8 +132,8 @@ func (cli *VCDClient) unLockParentVapp(d *schema.ResourceData) {
 	vcdMutexKV.Unlock(key)
 }
 
-// function lockParentEdgeGtw locks using edge_gateway name existing in resource parameters. Parent means resource needs
-// to lock edge gtw it depends
+// function lockParentEdgeGtw locks using edge_gateway name existing in resource parameters.
+// Parent means the resource belongs to the edge gateway being locked
 func (cli *VCDClient) lockParentEdgeGtw(d *schema.ResourceData) {
 	edgeGtwName := d.Get("edge_gateway").(string)
 	if edgeGtwName == "" {

--- a/vcd/config.go
+++ b/vcd/config.go
@@ -95,32 +95,56 @@ func debugPrintf(format string, args ...interface{}) {
 var vcdMutexKV = mutexkv.NewMutexKV()
 
 func (cli *VCDClient) lockVapp(d *schema.ResourceData) {
-	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", cli.getOrgName(d), cli.getVdcName(d), d.Get("name").(string))
+	vappName := d.Get("name").(string)
+	if vappName == "" {
+		panic("vapp name isn't found")
+	}
+	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", cli.getOrgName(d), cli.getVdcName(d), vappName)
 	vcdMutexKV.Lock(key)
 }
 
 func (cli *VCDClient) unLockVapp(d *schema.ResourceData) {
-	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", cli.getOrgName(d), cli.getVdcName(d), d.Get("name").(string))
+	vappName := d.Get("name").(string)
+	if vappName == "" {
+		panic("vapp name isn't found")
+	}
+	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", cli.getOrgName(d), cli.getVdcName(d), vappName)
 	vcdMutexKV.Unlock(key)
 }
 
 func (cli *VCDClient) lockParentVapp(d *schema.ResourceData) {
-	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", cli.getOrgName(d), cli.getVdcName(d), d.Get("vapp_name").(string))
+	vappName := d.Get("vapp_name").(string)
+	if vappName == "" {
+		panic("vapp name isn't found")
+	}
+	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", cli.getOrgName(d), cli.getVdcName(d), vappName)
 	vcdMutexKV.Lock(key)
 }
 
 func (cli *VCDClient) unLockParentVapp(d *schema.ResourceData) {
-	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", cli.getOrgName(d), cli.getVdcName(d), d.Get("vapp_name").(string))
+	vappName := d.Get("vapp_name").(string)
+	if vappName == "" {
+		panic("vapp name isn't found")
+	}
+	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", cli.getOrgName(d), cli.getVdcName(d), vappName)
 	vcdMutexKV.Unlock(key)
 }
 
 func (cli *VCDClient) lockParentEdgeGtw(d *schema.ResourceData) {
-	key := fmt.Sprintf("org:%s|vdc:%s|edge:%s", cli.getOrgName(d), cli.getVdcName(d), d.Get("edge_gateway").(string))
+	edgeGtwName := d.Get("edge_gateway").(string)
+	if edgeGtwName == "" {
+		panic("edge gtw name isn't found")
+	}
+	key := fmt.Sprintf("org:%s|vdc:%s|edge:%s", cli.getOrgName(d), cli.getVdcName(d), edgeGtwName)
 	vcdMutexKV.Lock(key)
 }
 
 func (cli *VCDClient) unLockParentEdgeGtw(d *schema.ResourceData) {
-	key := fmt.Sprintf("org:%s|vdc:%s|edge:%s", cli.getOrgName(d), cli.getVdcName(d), d.Get("edge_gateway").(string))
+	edgeGtwName := d.Get("edge_gateway").(string)
+	if edgeGtwName == "" {
+		panic("edge gtw name isn't found")
+	}
+	key := fmt.Sprintf("org:%s|vdc:%s|edge:%s", cli.getOrgName(d), cli.getVdcName(d), edgeGtwName)
 	vcdMutexKV.Unlock(key)
 }
 

--- a/vcd/config.go
+++ b/vcd/config.go
@@ -94,22 +94,22 @@ func debugPrintf(format string, args ...interface{}) {
 // This is a global MutexKV for all resources
 var vcdMutexKV = mutexkv.NewMutexKV()
 
-func (cli *VCDClient) lockvApp(d *schema.ResourceData) {
+func (cli *VCDClient) lockVapp(d *schema.ResourceData) {
 	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", cli.getOrgName(d), cli.getVdcName(d), d.Get("name").(string))
 	vcdMutexKV.Lock(key)
 }
 
-func (cli *VCDClient) unLockvApp(d *schema.ResourceData) {
+func (cli *VCDClient) unLockVapp(d *schema.ResourceData) {
 	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", cli.getOrgName(d), cli.getVdcName(d), d.Get("name").(string))
 	vcdMutexKV.Unlock(key)
 }
 
-func (cli *VCDClient) lockParentvApp(d *schema.ResourceData) {
+func (cli *VCDClient) lockParentVapp(d *schema.ResourceData) {
 	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", cli.getOrgName(d), cli.getVdcName(d), d.Get("vapp_name").(string))
 	vcdMutexKV.Lock(key)
 }
 
-func (cli *VCDClient) unLockParentvApp(d *schema.ResourceData) {
+func (cli *VCDClient) unLockParentVapp(d *schema.ResourceData) {
 	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", cli.getOrgName(d), cli.getVdcName(d), d.Get("vapp_name").(string))
 	vcdMutexKV.Unlock(key)
 }

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -116,37 +116,37 @@ func Provider() terraform.ResourceProvider {
 var vcdMutexKV = mutexkv.NewMutexKV()
 
 func lockVapp(d *schema.ResourceData) {
-	key := fmt.Sprintf("%s|%s|%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("name").(string))
+	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("name").(string))
 	log.Printf("[TRACE] Locked vapp with key %s.", key)
 	vcdMutexKV.Lock(key)
 }
 
 func unLockVapp(d *schema.ResourceData) {
-	key := fmt.Sprintf("%s|%s|%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("name").(string))
+	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("name").(string))
 	log.Printf("[TRACE] Unlocked vapp with key %s.", key)
 	vcdMutexKV.Unlock(key)
 }
 
 func lockParentVapp(d *schema.ResourceData) {
-	key := fmt.Sprintf("%s|%s|%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("vapp_name").(string))
+	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("vapp_name").(string))
 	log.Printf("[TRACE] Locked parent vapp with key %s.", key)
 	vcdMutexKV.Lock(key)
 }
 
 func unLockParentVapp(d *schema.ResourceData) {
-	key := fmt.Sprintf("%s|%s|%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("vapp_name").(string))
+	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("vapp_name").(string))
 	log.Printf("[TRACE] Unlocked parent vapp with key %s.", key)
 	vcdMutexKV.Unlock(key)
 }
 
 func lockParentEdgeGtw(d *schema.ResourceData) {
-	key := fmt.Sprintf("%s|%s|%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("edge_gateway").(string))
+	key := fmt.Sprintf("org:%s|vdc:%s|edge:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("edge_gateway").(string))
 	log.Printf("[TRACE] Locked parent edge gtw with key %s.", key)
 	vcdMutexKV.Lock(key)
 }
 
 func unLockParentEdgeGtw(d *schema.ResourceData) {
-	key := fmt.Sprintf("%s|%s|%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("edge_gateway").(string))
+	key := fmt.Sprintf("org:%s|vdc:%s|edge:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("edge_gateway").(string))
 	log.Printf("[TRACE] Unlocked parent edge gtw with key %s.", key)
 	vcdMutexKV.Unlock(key)
 }

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -116,37 +116,37 @@ func Provider() terraform.ResourceProvider {
 var vcdMutexKV = mutexkv.NewMutexKV()
 
 func lockVapp(d *schema.ResourceData) {
-	key := fmt.Sprintf("%s|%s|%s", d.Get("vdc").(string), d.Get("org").(string), d.Get("name").(string))
+	key := fmt.Sprintf("%s|%s|%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("name").(string))
 	log.Printf("[TRACE] Locked vapp with key %s.", key)
 	vcdMutexKV.Lock(key)
 }
 
 func unLockVapp(d *schema.ResourceData) {
-	key := fmt.Sprintf("%s|%s|%s", d.Get("vdc").(string), d.Get("org").(string), d.Get("name").(string))
+	key := fmt.Sprintf("%s|%s|%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("name").(string))
 	log.Printf("[TRACE] Unlocked vapp with key %s.", key)
 	vcdMutexKV.Unlock(key)
 }
 
 func lockParentVapp(d *schema.ResourceData) {
-	key := fmt.Sprintf("%s|%s|%s", d.Get("vdc").(string), d.Get("org").(string), d.Get("vapp_name").(string))
+	key := fmt.Sprintf("%s|%s|%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("vapp_name").(string))
 	log.Printf("[TRACE] Locked parent vapp with key %s.", key)
 	vcdMutexKV.Lock(key)
 }
 
 func unLockParentVapp(d *schema.ResourceData) {
-	key := fmt.Sprintf("%s|%s|%s", d.Get("vdc").(string), d.Get("org").(string), d.Get("vapp_name").(string))
+	key := fmt.Sprintf("%s|%s|%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("vapp_name").(string))
 	log.Printf("[TRACE] Unlocked parent vapp with key %s.", key)
 	vcdMutexKV.Unlock(key)
 }
 
 func lockParentEdgeGtw(d *schema.ResourceData) {
-	key := fmt.Sprintf("%s|%s|%s", d.Get("vdc").(string), d.Get("org").(string), d.Get("edge_gateway").(string))
+	key := fmt.Sprintf("%s|%s|%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("edge_gateway").(string))
 	log.Printf("[TRACE] Locked parent edge gtw with key %s.", key)
 	vcdMutexKV.Lock(key)
 }
 
 func unLockParentEdgeGtw(d *schema.ResourceData) {
-	key := fmt.Sprintf("%s|%s|%s", d.Get("vdc").(string), d.Get("org").(string), d.Get("edge_gateway").(string))
+	key := fmt.Sprintf("%s|%s|%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("edge_gateway").(string))
 	log.Printf("[TRACE] Unlocked parent edge gtw with key %s.", key)
 	vcdMutexKV.Lock(key)
 }

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -2,11 +2,12 @@ package vcd
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/vmware/go-vcloud-director/v2/util"
-	"log"
 )
 
 // Provider returns a terraform.ResourceProvider.

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -1,8 +1,6 @@
 package vcd
 
 import (
-	"fmt"
-	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/vmware/go-vcloud-director/v2/util"
@@ -108,39 +106,6 @@ func Provider() terraform.ResourceProvider {
 
 		ConfigureFunc: providerConfigure,
 	}
-}
-
-// This is a global MutexKV for all resources
-var vcdMutexKV = mutexkv.NewMutexKV()
-
-func lockvApp(d *schema.ResourceData) {
-	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("name").(string))
-	vcdMutexKV.Lock(key)
-}
-
-func unLockvApp(d *schema.ResourceData) {
-	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("name").(string))
-	vcdMutexKV.Unlock(key)
-}
-
-func lockParentvApp(d *schema.ResourceData) {
-	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("vapp_name").(string))
-	vcdMutexKV.Lock(key)
-}
-
-func unLockParentvApp(d *schema.ResourceData) {
-	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("vapp_name").(string))
-	vcdMutexKV.Unlock(key)
-}
-
-func lockParentEdgeGtw(d *schema.ResourceData) {
-	key := fmt.Sprintf("org:%s|vdc:%s|edge:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("edge_gateway").(string))
-	vcdMutexKV.Lock(key)
-}
-
-func unLockParentEdgeGtw(d *schema.ResourceData) {
-	key := fmt.Sprintf("org:%s|vdc:%s|edge:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("edge_gateway").(string))
-	vcdMutexKV.Unlock(key)
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -148,7 +148,7 @@ func lockParentEdgeGtw(d *schema.ResourceData) {
 func unLockParentEdgeGtw(d *schema.ResourceData) {
 	key := fmt.Sprintf("%s|%s|%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("edge_gateway").(string))
 	log.Printf("[TRACE] Unlocked parent edge gtw with key %s.", key)
-	vcdMutexKV.Lock(key)
+	vcdMutexKV.Unlock(key)
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -1,10 +1,12 @@
 package vcd
 
 import (
+	"fmt"
 	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/vmware/go-vcloud-director/v2/util"
+	"log"
 )
 
 // Provider returns a terraform.ResourceProvider.
@@ -113,27 +115,39 @@ func Provider() terraform.ResourceProvider {
 var vcdMutexKV = mutexkv.NewMutexKV()
 
 func lockVapp(d *schema.ResourceData) {
-	vcdMutexKV.Lock(d.Get("vdc").(string) + d.Get("name").(string))
+	key := fmt.Sprintf("%s|%s|%s", d.Get("vdc").(string), d.Get("org").(string), d.Get("name").(string))
+	log.Printf("[TRACE] Locked vapp with key %s.", key)
+	vcdMutexKV.Lock(key)
 }
 
 func unLockVapp(d *schema.ResourceData) {
-	vcdMutexKV.Unlock(d.Get("vdc").(string) + d.Get("name").(string))
+	key := fmt.Sprintf("%s|%s|%s", d.Get("vdc").(string), d.Get("org").(string), d.Get("name").(string))
+	log.Printf("[TRACE] Unlocked vapp with key %s.", key)
+	vcdMutexKV.Unlock(key)
 }
 
 func lockParentVapp(d *schema.ResourceData) {
-	vcdMutexKV.Lock(d.Get("vdc").(string) + d.Get("vapp_name").(string))
+	key := fmt.Sprintf("%s|%s|%s", d.Get("vdc").(string), d.Get("org").(string), d.Get("vapp_name").(string))
+	log.Printf("[TRACE] Locked parent vapp with key %s.", key)
+	vcdMutexKV.Lock(key)
 }
 
 func unLockParentVapp(d *schema.ResourceData) {
-	vcdMutexKV.Unlock(d.Get("vdc").(string) + d.Get("vapp_name").(string))
+	key := fmt.Sprintf("%s|%s|%s", d.Get("vdc").(string), d.Get("org").(string), d.Get("vapp_name").(string))
+	log.Printf("[TRACE] Unlocked parent vapp with key %s.", key)
+	vcdMutexKV.Unlock(key)
 }
 
 func lockParentEdgeGtw(d *schema.ResourceData) {
-	vcdMutexKV.Lock(d.Get("vdc").(string) + d.Get("edge_gateway").(string))
+	key := fmt.Sprintf("%s|%s|%s", d.Get("vdc").(string), d.Get("org").(string), d.Get("edge_gateway").(string))
+	log.Printf("[TRACE] Locked parent edge gtw with key %s.", key)
+	vcdMutexKV.Lock(key)
 }
 
 func unLockParentEdgeGtw(d *schema.ResourceData) {
-	vcdMutexKV.Unlock(d.Get("vdc").(string) + d.Get("edge_gateway").(string))
+	key := fmt.Sprintf("%s|%s|%s", d.Get("vdc").(string), d.Get("org").(string), d.Get("edge_gateway").(string))
+	log.Printf("[TRACE] Unlocked parent edge gtw with key %s.", key)
+	vcdMutexKV.Lock(key)
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -1,6 +1,7 @@
 package vcd
 
 import (
+	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/vmware/go-vcloud-director/v2/util"
@@ -106,6 +107,33 @@ func Provider() terraform.ResourceProvider {
 
 		ConfigureFunc: providerConfigure,
 	}
+}
+
+// This is a global MutexKV for all resources
+var vcdMutexKV = mutexkv.NewMutexKV()
+
+func lockVapp(d *schema.ResourceData) {
+	vcdMutexKV.Lock(d.Get("vdc").(string) + d.Get("name").(string))
+}
+
+func unLockVapp(d *schema.ResourceData) {
+	vcdMutexKV.Unlock(d.Get("vdc").(string) + d.Get("name").(string))
+}
+
+func lockParentVapp(d *schema.ResourceData) {
+	vcdMutexKV.Lock(d.Get("vdc").(string) + d.Get("vapp_name").(string))
+}
+
+func unLockParentVapp(d *schema.ResourceData) {
+	vcdMutexKV.Unlock(d.Get("vdc").(string) + d.Get("vapp_name").(string))
+}
+
+func lockParentEdgeGtw(d *schema.ResourceData) {
+	vcdMutexKV.Lock(d.Get("vdc").(string) + d.Get("edge_gateway").(string))
+}
+
+func unLockParentEdgeGtw(d *schema.ResourceData) {
+	vcdMutexKV.Unlock(d.Get("vdc").(string) + d.Get("edge_gateway").(string))
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -2,8 +2,6 @@ package vcd
 
 import (
 	"fmt"
-	"log"
-
 	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
@@ -115,42 +113,33 @@ func Provider() terraform.ResourceProvider {
 // This is a global MutexKV for all resources
 var vcdMutexKV = mutexkv.NewMutexKV()
 
-func lockVapp(d *schema.ResourceData) {
+func lockvApp(d *schema.ResourceData) {
 	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("name").(string))
-	log.Printf("[TRACE] Acquiring lock for vapp with key %s.", key)
 	vcdMutexKV.Lock(key)
-	log.Printf("[TRACE] Locked vapp with key %s.", key)
 }
 
-func unLockVapp(d *schema.ResourceData) {
+func unLockvApp(d *schema.ResourceData) {
 	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("name").(string))
-	log.Printf("[TRACE] Unlocked vapp with key %s.", key)
 	vcdMutexKV.Unlock(key)
 }
 
-func lockParentVapp(d *schema.ResourceData) {
+func lockParentvApp(d *schema.ResourceData) {
 	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("vapp_name").(string))
-	log.Printf("[TRACE] Acquiring lock for parent vapp with key %s.", key)
 	vcdMutexKV.Lock(key)
-	log.Printf("[TRACE] Locked parent vapp with key %s.", key)
 }
 
-func unLockParentVapp(d *schema.ResourceData) {
+func unLockParentvApp(d *schema.ResourceData) {
 	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("vapp_name").(string))
-	log.Printf("[TRACE] Unlocked parent vapp with key %s.", key)
 	vcdMutexKV.Unlock(key)
 }
 
 func lockParentEdgeGtw(d *schema.ResourceData) {
 	key := fmt.Sprintf("org:%s|vdc:%s|edge:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("edge_gateway").(string))
-	log.Printf("[TRACE] Acquiring lock for edge gtw with key %s.", key)
 	vcdMutexKV.Lock(key)
-	log.Printf("[TRACE] Locked parent edge gtw with key %s.", key)
 }
 
 func unLockParentEdgeGtw(d *schema.ResourceData) {
 	key := fmt.Sprintf("org:%s|vdc:%s|edge:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("edge_gateway").(string))
-	log.Printf("[TRACE] Unlocked parent edge gtw with key %s.", key)
 	vcdMutexKV.Unlock(key)
 }
 

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -117,8 +117,9 @@ var vcdMutexKV = mutexkv.NewMutexKV()
 
 func lockVapp(d *schema.ResourceData) {
 	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("name").(string))
-	log.Printf("[TRACE] Locked vapp with key %s.", key)
+	log.Printf("[TRACE] Acquiring lock for vapp with key %s.", key)
 	vcdMutexKV.Lock(key)
+	log.Printf("[TRACE] Locked vapp with key %s.", key)
 }
 
 func unLockVapp(d *schema.ResourceData) {
@@ -129,8 +130,9 @@ func unLockVapp(d *schema.ResourceData) {
 
 func lockParentVapp(d *schema.ResourceData) {
 	key := fmt.Sprintf("org:%s|vdc:%s|vapp:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("vapp_name").(string))
-	log.Printf("[TRACE] Locked parent vapp with key %s.", key)
+	log.Printf("[TRACE] Acquiring lock for parent vapp with key %s.", key)
 	vcdMutexKV.Lock(key)
+	log.Printf("[TRACE] Locked parent vapp with key %s.", key)
 }
 
 func unLockParentVapp(d *schema.ResourceData) {
@@ -141,8 +143,9 @@ func unLockParentVapp(d *schema.ResourceData) {
 
 func lockParentEdgeGtw(d *schema.ResourceData) {
 	key := fmt.Sprintf("org:%s|vdc:%s|edge:%s", d.Get("org").(string), d.Get("vdc").(string), d.Get("edge_gateway").(string))
-	log.Printf("[TRACE] Locked parent edge gtw with key %s.", key)
+	log.Printf("[TRACE] Acquiring lock for edge gtw with key %s.", key)
 	vcdMutexKV.Lock(key)
+	log.Printf("[TRACE] Locked parent edge gtw with key %s.", key)
 }
 
 func unLockParentEdgeGtw(d *schema.ResourceData) {

--- a/vcd/resource_vcd_dnat.go
+++ b/vcd/resource_vcd_dnat.go
@@ -89,8 +89,8 @@ func resourceVcdDNATCreate(d *schema.ResourceData, meta interface{}) error {
 	// Multiple VCD components need to run operations on the Edge Gateway, as
 	// the edge gateway will throw back an error if it is already performing an
 	// operation we must wait until we can acquire a lock on the client
-	lockParentEdgeGtw(d)
-	defer unLockParentEdgeGtw(d)
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
 
 	portString := getPortString(d.Get("port").(int))
 	translatedPortString := portString // default
@@ -210,8 +210,8 @@ func resourceVcdDNATDelete(d *schema.ResourceData, meta interface{}) error {
 	// Multiple VCD components need to run operations on the Edge Gateway, as
 	// the edge gatway will throw back an error if it is already performing an
 	// operation we must wait until we can aquire a lock on the client
-	lockParentEdgeGtw(d)
-	defer unLockParentEdgeGtw(d)
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
 
 	portString := getPortString(d.Get("port").(int))
 	translatedPortString := portString // default

--- a/vcd/resource_vcd_edgegateway_vpn.go
+++ b/vcd/resource_vcd_edgegateway_vpn.go
@@ -141,8 +141,8 @@ func resourceVcdEdgeGatewayVpnCreate(d *schema.ResourceData, meta interface{}) e
 	vcdClient := meta.(*VCDClient)
 	log.Printf("[TRACE] CLIENT: %#v", vcdClient)
 
-	lockParentEdgeGtw(d)
-	defer unLockParentEdgeGtw(d)
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
 
 	edgeGateway, err := vcdClient.GetEdgeGatewayFromResource(d)
 	if err != nil {
@@ -231,8 +231,8 @@ func resourceVcdEdgeGatewayVpnDelete(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[TRACE] CLIENT: %#v", vcdClient)
 
-	lockParentEdgeGtw(d)
-	defer unLockParentEdgeGtw(d)
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
 
 	edgeGateway, err := vcdClient.GetEdgeGatewayFromResource(d)
 	if err != nil {

--- a/vcd/resource_vcd_edgegateway_vpn.go
+++ b/vcd/resource_vcd_edgegateway_vpn.go
@@ -208,7 +208,7 @@ func resourceVcdEdgeGatewayVpnCreate(d *schema.ResourceData, meta interface{}) e
 	err = edgeGateway.Refresh()
 	if err != nil {
 		log.Printf("[INFO] Error refreshing edge gateway: %#v", err)
-		return fmt.Errorf("error error refreshing edge gateway: %#v", err)
+		return fmt.Errorf("error refreshing edge gateway: %#v", err)
 	}
 	task, err := edgeGateway.AddIpsecVPN(ipsecVPNConfig)
 	if err != nil {
@@ -251,7 +251,7 @@ func resourceVcdEdgeGatewayVpnDelete(d *schema.ResourceData, meta interface{}) e
 	err = edgeGateway.Refresh()
 	if err != nil {
 		log.Printf("[INFO] Error refreshing edge gateway: %#v", err)
-		return fmt.Errorf("error error refreshing edge gateway: %#v", err)
+		return fmt.Errorf("error refreshing edge gateway: %#v", err)
 	}
 	task, err := edgeGateway.AddIpsecVPN(ipsecVPNConfig)
 	if err != nil {

--- a/vcd/resource_vcd_edgegateway_vpn.go
+++ b/vcd/resource_vcd_edgegateway_vpn.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
@@ -142,8 +141,8 @@ func resourceVcdEdgeGatewayVpnCreate(d *schema.ResourceData, meta interface{}) e
 	vcdClient := meta.(*VCDClient)
 	log.Printf("[TRACE] CLIENT: %#v", vcdClient)
 
-	vcdClient.Mutex.Lock()
-	defer vcdClient.Mutex.Unlock()
+	lockParentEdgeGtw(d)
+	defer unLockParentEdgeGtw(d)
 
 	edgeGateway, err := vcdClient.GetEdgeGatewayFromResource(d)
 	if err != nil {
@@ -206,22 +205,18 @@ func resourceVcdEdgeGatewayVpnCreate(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[INFO] ipsecVPNConfig: %#v", ipsecVPNConfig)
 
-	err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-		err := edgeGateway.Refresh()
-		if err != nil {
-			log.Printf("[INFO] Error refreshing edge gateway: %#v", err)
-			return resource.RetryableError(
-				fmt.Errorf("error error refreshing edge gateway: %#v", err))
-		}
-		task, err := edgeGateway.AddIpsecVPN(ipsecVPNConfig)
-		if err != nil {
-			log.Printf("[INFO] Error setting ipsecVPNConfig rules: %s", err)
-			return resource.RetryableError(
-				fmt.Errorf("error setting ipsecVPNConfig rules: %#v", err))
-		}
+	err = edgeGateway.Refresh()
+	if err != nil {
+		log.Printf("[INFO] Error refreshing edge gateway: %#v", err)
+		return fmt.Errorf("error error refreshing edge gateway: %#v", err)
+	}
+	task, err := edgeGateway.AddIpsecVPN(ipsecVPNConfig)
+	if err != nil {
+		log.Printf("[INFO] Error setting ipsecVPNConfig rules: %s", err)
+		return fmt.Errorf("error setting ipsecVPNConfig rules: %#v", err)
+	}
 
-		return resource.RetryableError(task.WaitTaskCompletion())
-	})
+	err = task.WaitTaskCompletion()
 	if err != nil {
 		return fmt.Errorf(errorCompletingTask, err)
 	}
@@ -236,8 +231,8 @@ func resourceVcdEdgeGatewayVpnDelete(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[TRACE] CLIENT: %#v", vcdClient)
 
-	vcdClient.Mutex.Lock()
-	defer vcdClient.Mutex.Unlock()
+	lockParentEdgeGtw(d)
+	defer unLockParentEdgeGtw(d)
 
 	edgeGateway, err := vcdClient.GetEdgeGatewayFromResource(d)
 	if err != nil {
@@ -253,22 +248,18 @@ func resourceVcdEdgeGatewayVpnDelete(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[INFO] ipsecVPNConfig: %#v", ipsecVPNConfig)
 
-	err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-		err := edgeGateway.Refresh()
-		if err != nil {
-			log.Printf("[INFO] Error refreshing edge gateway: %#v", err)
-			return resource.RetryableError(
-				fmt.Errorf("error error refreshing edge gateway: %#v", err))
-		}
-		task, err := edgeGateway.AddIpsecVPN(ipsecVPNConfig)
-		if err != nil {
-			log.Printf("[INFO] Error setting ipsecVPNConfig rules: %s", err)
-			return resource.RetryableError(
-				fmt.Errorf("error setting ipsecVPNConfig rules: %#v", err))
-		}
+	err = edgeGateway.Refresh()
+	if err != nil {
+		log.Printf("[INFO] Error refreshing edge gateway: %#v", err)
+		return fmt.Errorf("error error refreshing edge gateway: %#v", err)
+	}
+	task, err := edgeGateway.AddIpsecVPN(ipsecVPNConfig)
+	if err != nil {
+		log.Printf("[INFO] Error setting ipsecVPNConfig rules: %s", err)
+		return fmt.Errorf("error setting ipsecVPNConfig rules: %#v", err)
+	}
 
-		return resource.RetryableError(task.WaitTaskCompletion())
-	})
+	err = task.WaitTaskCompletion()
 	if err != nil {
 		return fmt.Errorf(errorCompletingTask, err)
 	}

--- a/vcd/resource_vcd_firewall_rules.go
+++ b/vcd/resource_vcd_firewall_rules.go
@@ -95,8 +95,8 @@ func resourceVcdFirewallRules() *schema.Resource {
 func resourceVcdFirewallRulesCreate(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
-	lockParentEdgeGtw(d)
-	defer unLockParentEdgeGtw(d)
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
 
 	edgeGatewayName := d.Get("edge_gateway").(string)
 
@@ -130,8 +130,8 @@ func resourceVcdFirewallRulesCreate(d *schema.ResourceData, meta interface{}) er
 func resourceFirewallRulesDelete(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
-	lockParentEdgeGtw(d)
-	defer unLockParentEdgeGtw(d)
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
 
 	edgeGateway, err := vcdClient.GetEdgeGatewayFromResource(d)
 	if err != nil {

--- a/vcd/resource_vcd_firewall_rules.go
+++ b/vcd/resource_vcd_firewall_rules.go
@@ -108,7 +108,7 @@ func resourceVcdFirewallRulesCreate(d *schema.ResourceData, meta interface{}) er
 	err = edgeGateway.Refresh()
 	if err != nil {
 		log.Printf("[INFO] Error refreshing edge gateway: %#v", err)
-		return fmt.Errorf("error error refreshing edge gateway: %#v", err)
+		return fmt.Errorf("error refreshing edge gateway: %#v", err)
 	}
 	firewallRules, _ := expandFirewallRules(d, edgeGateway.EdgeGateway)
 	task, err := edgeGateway.CreateFirewallRules(d.Get("default_action").(string), firewallRules)

--- a/vcd/resource_vcd_inserted_media.go
+++ b/vcd/resource_vcd_inserted_media.go
@@ -67,6 +67,11 @@ func resourceVcdInsertedMedia() *schema.Resource {
 func resourceVcdMediaInsert(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[TRACE] VM media insert initiated")
 
+	vcdClient := meta.(*VCDClient)
+
+	vcdClient.lockParentVapp(d)
+	defer vcdClient.unLockParentVapp(d)
+
 	vm, org, err := getVM(d, meta)
 	if err != nil || org == (govcd.Org{}) {
 		return fmt.Errorf("error: %#v", err)
@@ -113,6 +118,12 @@ func resourceVcdVmInsertedMediaRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceVcdMediaEject(d *schema.ResourceData, meta interface{}) error {
+
+	vcdClient := meta.(*VCDClient)
+
+	vcdClient.lockParentVapp(d)
+	defer vcdClient.unLockParentVapp(d)
+
 	vm, org, err := getVM(d, meta)
 	if err != nil {
 		return fmt.Errorf("error: %#v", err)

--- a/vcd/resource_vcd_network_direct.go
+++ b/vcd/resource_vcd_network_direct.go
@@ -3,7 +3,6 @@ package vcd
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
@@ -57,8 +56,6 @@ func resourceVcdNetworkDirect() *schema.Resource {
 
 func resourceVcdNetworkDirectCreate(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
-	vcdClient.Mutex.Lock()
-	defer vcdClient.Mutex.Unlock()
 
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {
@@ -93,9 +90,7 @@ func resourceVcdNetworkDirectCreate(d *schema.ResourceData, meta interface{}) er
 		IsShared: d.Get("shared").(bool),
 	}
 
-	err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-		return resource.RetryableError(vdc.CreateOrgVDCNetworkWait(orgVDCNetwork))
-	})
+	err = vdc.CreateOrgVDCNetworkWait(orgVDCNetwork)
 	if err != nil {
 		return fmt.Errorf("error: %#v", err)
 	}

--- a/vcd/resource_vcd_network_isolated.go
+++ b/vcd/resource_vcd_network_isolated.go
@@ -3,7 +3,6 @@ package vcd
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
@@ -135,8 +134,6 @@ func resourceVcdNetworkIsolated() *schema.Resource {
 
 func resourceVcdNetworkIsolatedCreate(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
-	vcdClient.Mutex.Lock()
-	defer vcdClient.Mutex.Unlock()
 
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {
@@ -172,9 +169,7 @@ func resourceVcdNetworkIsolatedCreate(d *schema.ResourceData, meta interface{}) 
 		IsShared: d.Get("shared").(bool),
 	}
 
-	err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-		return resource.RetryableError(vdc.CreateOrgVDCNetworkWait(orgVDCNetwork))
-	})
+	err = vdc.CreateOrgVDCNetworkWait(orgVDCNetwork)
 	if err != nil {
 		return fmt.Errorf("error: %#v", err)
 	}

--- a/vcd/resource_vcd_network_routed.go
+++ b/vcd/resource_vcd_network_routed.go
@@ -144,8 +144,8 @@ func resourceVcdNetworkRouted() *schema.Resource {
 func resourceVcdNetworkRoutedCreate(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
-	lockParentEdgeGtw(d)
-	defer unLockParentEdgeGtw(d)
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
 
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {
@@ -259,8 +259,9 @@ func resourceVcdNetworkRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceVcdNetworkDeleteLocked(d *schema.ResourceData, meta interface{}) error {
-	lockParentEdgeGtw(d)
-	defer unLockParentEdgeGtw(d)
+	vcdClient := meta.(*VCDClient)
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
 
 	return resourceVcdNetworkDelete(d, meta)
 }

--- a/vcd/resource_vcd_network_routed.go
+++ b/vcd/resource_vcd_network_routed.go
@@ -285,7 +285,7 @@ func resourceVcdNetworkDelete(d *schema.ResourceData, meta interface{}) error {
 
 	task, err := network.Delete()
 	if err != nil {
-		return fmt.Errorf("error DDeleting Network: %#v", err)
+		return fmt.Errorf("error Deleting Network: %#v", err)
 	}
 	err = task.WaitTaskCompletion()
 	if err != nil {

--- a/vcd/resource_vcd_network_routed.go
+++ b/vcd/resource_vcd_network_routed.go
@@ -282,7 +282,7 @@ func resourceVcdNetworkDelete(d *schema.ResourceData, meta interface{}) error {
 
 	task, err := network.Delete()
 	if err != nil {
-		return fmt.Errorf("error deleting Network: %#v", err)
+		return fmt.Errorf("error deleting network: %#v", err)
 	}
 	err = task.WaitTaskCompletion()
 	if err != nil {

--- a/vcd/resource_vcd_network_routed.go
+++ b/vcd/resource_vcd_network_routed.go
@@ -282,7 +282,7 @@ func resourceVcdNetworkDelete(d *schema.ResourceData, meta interface{}) error {
 
 	task, err := network.Delete()
 	if err != nil {
-		return fmt.Errorf("error Deleting Network: %#v", err)
+		return fmt.Errorf("error deleting Network: %#v", err)
 	}
 	err = task.WaitTaskCompletion()
 	if err != nil {

--- a/vcd/resource_vcd_network_routed.go
+++ b/vcd/resource_vcd_network_routed.go
@@ -3,14 +3,12 @@ package vcd
 import (
 	"bytes"
 	"fmt"
-	"log"
-	"strings"
-	"time"
-
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"log"
+	"strings"
 )
 
 func resourceVcdNetworkRouted() *schema.Resource {
@@ -269,8 +267,6 @@ func resourceVcdNetworkDeleteLocked(d *schema.ResourceData, meta interface{}) er
 
 func resourceVcdNetworkDelete(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
-
-	time.Sleep(10 * time.Second)
 
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {

--- a/vcd/resource_vcd_snat.go
+++ b/vcd/resource_vcd_snat.go
@@ -61,9 +61,9 @@ func resourceVcdSNATCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Multiple VCD components need to run operations on the Edge Gateway, as
 	// the edge gatway will throw back an error if it is already performing an
-	// operation we must wait until we can aquire a lock on the client
-	lockParentEdgeGtw(d)
-	defer unLockParentEdgeGtw(d)
+	// operation we must wait until we can acquire a lock on the client
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
 
 	edgeGateway, err := vcdClient.GetEdgeGatewayFromResource(d)
 	if err != nil {
@@ -156,8 +156,8 @@ func resourceVcdSNATDelete(d *schema.ResourceData, meta interface{}) error {
 	// Multiple VCD components need to run operations on the Edge Gateway, as
 	// the edge gatway will throw back an error if it is already performing an
 	// operation we must wait until we can aquire a lock on the client
-	lockParentEdgeGtw(d)
-	defer unLockParentEdgeGtw(d)
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
 
 	edgeGateway, err := vcdClient.GetEdgeGatewayFromResource(d)
 	if err != nil {

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -111,8 +111,8 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error retrieving Org and VDC: %s", err)
 	}
 
-	vcdClient.lockvApp(d)
-	defer vcdClient.unLockvApp(d)
+	vcdClient.lockVapp(d)
+	defer vcdClient.unLockVapp(d)
 
 	if _, ok := d.GetOk("template_name"); ok {
 		if _, ok := d.GetOk("catalog_name"); ok {
@@ -459,8 +459,8 @@ func getVAppIPAddress(d *schema.ResourceData, meta interface{}, vdc govcd.Vdc, o
 func resourceVcdVAppDelete(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
-	vcdClient.lockvApp(d)
-	defer vcdClient.unLockvApp(d)
+	vcdClient.lockVapp(d)
+	defer vcdClient.unLockVapp(d)
 
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -111,8 +111,8 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error retrieving Org and VDC: %s", err)
 	}
 
-	lockvApp(d)
-	defer unLockvApp(d)
+	vcdClient.lockvApp(d)
+	defer vcdClient.unLockvApp(d)
 
 	if _, ok := d.GetOk("template_name"); ok {
 		if _, ok := d.GetOk("catalog_name"); ok {
@@ -459,8 +459,8 @@ func getVAppIPAddress(d *schema.ResourceData, meta interface{}, vdc govcd.Vdc, o
 func resourceVcdVAppDelete(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
-	lockvApp(d)
-	defer unLockvApp(d)
+	vcdClient.lockvApp(d)
+	defer vcdClient.unLockvApp(d)
 
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -155,16 +155,16 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 			if err != nil {
 				task, err := vdc.ComposeVApp(nets, vapptemplate, storage_profile_reference, d.Get("name").(string), d.Get("description").(string), d.Get("accept_all_eulas").(bool))
 				if err != nil {
-					return fmt.Errorf("error creating vapp: %#v", err)
+					return fmt.Errorf("error creating vApp: %#v", err)
 				}
 
 				err = task.WaitTaskCompletion()
 				if err != nil {
-					return fmt.Errorf("error creating vapp: %#v", err)
+					return fmt.Errorf("error creating vApp: %#v", err)
 				}
 				vapp, err = vdc.FindVAppByName(d.Get("name").(string))
 				if err != nil {
-					return fmt.Errorf("error creating vapp: %#v", err)
+					return fmt.Errorf("error creating vApp: %#v", err)
 				}
 			}
 
@@ -175,7 +175,7 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 
 			task, err := vapp.ChangeVMName(d.Get("name").(string))
 			if err != nil {
-				return fmt.Errorf("error with vm name change: %#v", err)
+				return fmt.Errorf("error with VM name change: %#v", err)
 			}
 
 			err = task.WaitTaskCompletion()
@@ -190,7 +190,7 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 			}}
 			task, err = vapp.ChangeNetworkConfig(networks, d.Get("ip").(string))
 			if err != nil {
-				return fmt.Errorf("error with Networking change: %#v", err)
+				return fmt.Errorf("error with networking change: %#v", err)
 			}
 			err = task.WaitTaskCompletion()
 			if err != nil {
@@ -201,7 +201,7 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 				task, err := vapp.SetOvf(convertToStringMap(ovf.(map[string]interface{})))
 
 				if err != nil {
-					return fmt.Errorf("error set ovf: %#v", err)
+					return fmt.Errorf("error setting the ovf: %#v", err)
 				}
 				err = task.WaitTaskCompletion()
 				if err != nil {
@@ -214,7 +214,7 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 				log.Printf("running customisation script")
 				task, err := vapp.RunCustomizationScript(d.Get("name").(string), initscript.(string))
 				if err != nil {
-					return fmt.Errorf("error with setting init script: %#v", err)
+					return fmt.Errorf("error with init script setting: %#v", err)
 				}
 				err = task.WaitTaskCompletion()
 				if err != nil {
@@ -226,7 +226,7 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 
 				task, err := vapp.PowerOn()
 				if err != nil {
-					return fmt.Errorf("error powerOn machine: %#v", err)
+					return fmt.Errorf("error powering on the machine: %#v", err)
 				}
 				err = task.WaitTaskCompletion()
 
@@ -240,12 +240,12 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 		e := vdc.ComposeRawVApp(d.Get("name").(string))
 
 		if e != nil {
-			return fmt.Errorf("Error: %#v", e)
+			return fmt.Errorf("error: %#v", e)
 		}
 
 		e = vdc.Refresh()
 		if e != nil {
-			return fmt.Errorf("Error: %#v", e)
+			return fmt.Errorf("error: %#v", e)
 		}
 	}
 
@@ -379,7 +379,7 @@ func resourceVcdVAppUpdate(d *schema.ResourceData, meta interface{}) error {
 			task, err := vapp.SetOvf(convertToStringMap(ovf.(map[string]interface{})))
 
 			if err != nil {
-				return fmt.Errorf("error set ovf: %#v", err)
+				return fmt.Errorf("error setting the ovf: %#v", err)
 			}
 			err = task.WaitTaskCompletion()
 			if err != nil {
@@ -402,7 +402,7 @@ func resourceVcdVAppRead(d *schema.ResourceData, meta interface{}) error {
 
 	_, err = vdc.FindVAppByName(d.Id())
 	if err != nil {
-		log.Printf("[DEBUG] Unable to find vapp. Removing from tfstate")
+		log.Printf("[DEBUG] Unable to find vApp. Removing from tfstate")
 		d.SetId("")
 		return nil
 	}
@@ -437,7 +437,7 @@ func getVAppIPAddress(d *schema.ResourceData, meta interface{}, vdc govcd.Vdc, o
 
 	vapp, err := vdc.FindVAppByName(d.Id())
 	if err != nil {
-		return "", fmt.Errorf("unable to find vapp")
+		return "", fmt.Errorf("unable to find vApp")
 	}
 
 	// getting the IP of the specific Vm, rather than index zero.
@@ -445,7 +445,7 @@ func getVAppIPAddress(d *schema.ResourceData, meta interface{}, vdc govcd.Vdc, o
 	// 'first' one, and tests will fail sometimes (annoying huh?)
 	vm, err := vdc.FindVMByName(vapp, d.Get("name").(string))
 	if err != nil {
-		return "", fmt.Errorf("unable to find vm: %s", err)
+		return "", fmt.Errorf("unable to find VM: %s", err)
 	}
 
 	ip = vm.VM.NetworkConnectionSection.NetworkConnection[0].IPAddress
@@ -475,7 +475,7 @@ func resourceVcdVAppDelete(d *schema.ResourceData, meta interface{}) error {
 	// to avoid network destroy issues - detach networks from vApp
 	task, err := vapp.RemoveAllNetworks()
 	if err != nil {
-		return fmt.Errorf("error with Networking change: %#v", err)
+		return fmt.Errorf("error with networking change: %#v", err)
 	}
 	err = task.WaitTaskCompletion()
 	if err != nil {

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -234,7 +234,6 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 					return fmt.Errorf("error completing powerOn tasks: %#v", err)
 				}
 			}
-
 		}
 	} else {
 
@@ -473,7 +472,7 @@ func resourceVcdVAppDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error finding vapp: %s", err)
 	}
 
-	// to avoid network destroy issues - detach networks from VAPP
+	// to avoid network destroy issues - detach networks from vApp
 	task, err := vapp.RemoveAllNetworks()
 	if err != nil {
 		return fmt.Errorf("error with Networking change: %#v", err)
@@ -495,7 +494,7 @@ func resourceVcdVAppDelete(d *schema.ResourceData, meta interface{}) error {
 
 	err = task.WaitTaskCompletion()
 	if err != nil {
-		return fmt.Errorf("error with deleting VAPP task: %#v", err)
+		return fmt.Errorf("error with deleting vApp task: %#v", err)
 	}
 
 	return nil
@@ -511,12 +510,12 @@ func tryUndeploy(vapp govcd.VApp) error {
 		// ignore - can't be undeployed
 		return nil
 	} else if err != nil {
-		return fmt.Errorf("error undeploying VAPP: %#v", err)
+		return fmt.Errorf("error undeploying vApp: %#v", err)
 	}
 
 	err = task.WaitTaskCompletion()
 	if err != nil {
-		return fmt.Errorf("error undeploying VAPP: %#v", err)
+		return fmt.Errorf("error undeploying vApp: %#v", err)
 	}
 	return nil
 }

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -500,11 +500,12 @@ func resourceVcdVAppDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
+// Try to undeploy a vApp, but do not throw an error if the vApp is powered off.
+// Very often the vApp is powered off at this point and Undeploy() would fail with error:
+// "The requested operation could not be executed since vApp vApp_name is not running"
+// So, if the error matches we just ignore it and the caller may fast forward to vapp.Delete()
 func tryUndeploy(vapp govcd.VApp) error {
 	task, err := vapp.Undeploy()
-	// Very often the vApp is powered off at this point and Undeploy() would fail with error:
-	// "The requested operation could not be executed since vApp vApp_name is not running"
-	// So, if the error matches we just ingore and fast forward to vapp.Delete()
 	var reErr = regexp.MustCompile(`.*The requested operation could not be executed since vApp.*is not running.*`)
 	if err != nil && reErr.MatchString(err.Error()) {
 		// ignore - can't be undeployed

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -111,8 +111,8 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error retrieving Org and VDC: %s", err)
 	}
 
-	lockVapp(d)
-	defer unLockVapp(d)
+	lockvApp(d)
+	defer unLockvApp(d)
 
 	if _, ok := d.GetOk("template_name"); ok {
 		if _, ok := d.GetOk("catalog_name"); ok {
@@ -460,8 +460,8 @@ func getVAppIPAddress(d *schema.ResourceData, meta interface{}, vdc govcd.Vdc, o
 func resourceVcdVAppDelete(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
-	lockVapp(d)
-	defer unLockVapp(d)
+	lockvApp(d)
+	defer unLockvApp(d)
 
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {
@@ -485,7 +485,7 @@ func resourceVcdVAppDelete(d *schema.ResourceData, meta interface{}) error {
 
 	err = task.WaitTaskCompletion()
 
-	return err
+	return nil
 }
 
 func tryUndeploy(vapp govcd.VApp) error {

--- a/vcd/resource_vcd_vapp_network.go
+++ b/vcd/resource_vcd_vapp_network.go
@@ -136,8 +136,8 @@ func resourceVcdVappNetwork() *schema.Resource {
 
 func resourceVcdVappNetworkCreate(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
-	vcdClient.Mutex.Lock()
-	defer vcdClient.Mutex.Unlock()
+	vcdClient.lockParentVapp(d)
+	defer vcdClient.unLockParentVapp(d)
 
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {
@@ -249,8 +249,8 @@ func resourceVappNetworkRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceVappNetworkDelete(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
-	vcdClient.Mutex.Lock()
-	defer vcdClient.Mutex.Unlock()
+	vcdClient.lockParentVapp(d)
+	defer vcdClient.unLockParentVapp(d)
 
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {

--- a/vcd/resource_vcd_vapp_network_multi_test.go
+++ b/vcd/resource_vcd_vapp_network_multi_test.go
@@ -1,4 +1,4 @@
-// +build multinetwork
+// +build multinetwork functional
 
 package vcd
 
@@ -151,7 +151,7 @@ func testAccCheckVappNetworkMultiDestroy(s *terraform.State) error {
 
 		_, err := isVappNetworkMultiFound(conn, rs)
 		if err != nil && !strings.Contains(err.Error(), "can't find vApp:") {
-			return fmt.Errorf("vapp %s still exist and error: %#v", itemName, err)
+			return fmt.Errorf("vapp %s still exist and error: %#v", vappNameForNetworkMulti, err)
 		}
 	}
 
@@ -176,7 +176,7 @@ func isVappNetworkMultiFound(conn *VCDClient, rs *terraform.ResourceState) (stri
 
 	var foundNetworks int
 	for _, vappNetworkConfig := range networkConfig.NetworkConfig {
-		if vappNetworkConfig.Configuration.IPScopes.IPScope.DNSSuffix == dnsSuffix {
+		if vappNetworkConfig.Configuration.IPScopes.IPScope[0].DNSSuffix == dnsSuffix {
 			switch vappNetworkConfig.NetworkName {
 			case vappNetworkName1:
 				foundNetworks += 10

--- a/vcd/resource_vcd_vapp_raw_multi_test.go
+++ b/vcd/resource_vcd_vapp_raw_multi_test.go
@@ -61,7 +61,7 @@ func testAccCheckVcdVAppRawMultiExists(n string, vapp *govcd.VApp) resource.Test
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("no VAPP ID is set")
+			return fmt.Errorf("no vApp ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*VCDClient)

--- a/vcd/resource_vcd_vapp_raw_test.go
+++ b/vcd/resource_vcd_vapp_raw_test.go
@@ -118,6 +118,7 @@ resource "vcd_vapp" "{{.VappName}}" {
   org  = "{{.Org}}"
   vdc  = "{{.Vdc}}"
   name = "{{.VappName}}"
+  depends_on   = ["vcd_network_routed.{{.NetworkName}}"]
 }
 
 resource "vcd_vapp_vm" "{{.VmName}}" {

--- a/vcd/resource_vcd_vapp_raw_test.go
+++ b/vcd/resource_vcd_vapp_raw_test.go
@@ -56,7 +56,7 @@ func testAccCheckVcdVAppRawExists(n string, vapp *govcd.VApp) resource.TestCheck
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("no VAPP ID is set")
+			return fmt.Errorf("no vApp ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*VCDClient)

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -13,6 +13,7 @@ import (
 
 var vappName string = "TestAccVcdVAppVapp"
 var vappNameAllocated = "TestAccVcdVAppVappAllocated"
+var vappNamePowerOff = "TestAccVcdVAppVappPowerOff"
 
 func TestAccVcdVApp_PowerOff(t *testing.T) {
 	var vapp govcd.VApp
@@ -28,7 +29,8 @@ func TestAccVcdVApp_PowerOff(t *testing.T) {
 		"CatalogItem":       testSuiteCatalogOVAItem,
 		"VappName":          vappName,
 		"VappNameAllocated": vappNameAllocated,
-		"FuncName":          "TestAccCheckVcdVApp_basic",
+		"VappNamePowerOff":  vappNamePowerOff,
+		"FuncName":          "TestAccCheckVcdVApp_PowerOff",
 		"Tags":              "vapp",
 	}
 	configText := templateFill(testAccCheckVcdVApp_basic, params)
@@ -80,16 +82,16 @@ func TestAccVcdVApp_PowerOff(t *testing.T) {
 			resource.TestStep{
 				Config: configTextPoweroff,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVcdVAppExists("vcd_vapp."+vappName, &vapp),
+					testAccCheckVcdVAppExists("vcd_vapp."+vappNamePowerOff, &vapp),
 					testAccCheckVcdVAppAttributes_off(&vapp),
 					resource.TestCheckResourceAttr(
-						"vcd_vapp."+vappName, "name", vappName),
+						"vcd_vapp."+vappNamePowerOff, "name", vappNamePowerOff),
 					resource.TestCheckResourceAttr(
-						"vcd_vapp."+vappName, "ip", "10.10.103.160"),
+						"vcd_vapp."+vappNamePowerOff, "ip", "10.10.103.160"),
 					resource.TestCheckResourceAttr(
-						"vcd_vapp."+vappName, "power_on", "false"),
+						"vcd_vapp."+vappNamePowerOff, "power_on", "false"),
 					resource.TestCheckResourceAttr(
-						"vcd_vapp."+vappName, "metadata.vapp_metadata", "vApp Metadata."),
+						"vcd_vapp."+vappNamePowerOff, "metadata.vapp_metadata", "vApp Metadata."),
 				),
 			},
 		},
@@ -174,7 +176,7 @@ func testAccCheckVcdVAppAttributes(vapp *govcd.VApp) resource.TestCheckFunc {
 func testAccCheckVcdVAppAttributes_off(vapp *govcd.VApp) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		if vapp.VApp.Name != vappName {
+		if vapp.VApp.Name != vappNamePowerOff {
 			return fmt.Errorf("bad name: %s", vapp.VApp.Name)
 		}
 
@@ -273,10 +275,10 @@ const testAccCheckVcdVApp_powerOff = `resource "vcd_network_routed" "{{.NetworkN
   }
 }
 
-resource "vcd_vapp" "{{.VappName}}" {
+resource "vcd_vapp" "{{.VappNamePowerOff}}" {
   org           = "{{.Org}}"
   vdc           = "{{.Vdc}}"
-  name          = "{{.VappName}}"
+  name          = "{{.VappNamePowerOff}}"
   template_name = "{{.CatalogItem}}"
   catalog_name  = "{{.Catalog}}"
   network_name  = "${vcd_network_routed.{{.NetworkName2}}.name}"

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -255,6 +255,16 @@ resource "vcd_vapp" "{{.VappNameAllocated}}" {
     vapp_metadata = "vApp Metadata."
   }
 }
+
+resource "vcd_snat" "snatTest1" {
+  edge_gateway = "{{.EdgeGateway}}"
+  network_name = "{{.NetworkName}}"
+  network_type    = "org"
+  external_ip  = "10.10.102.144"
+  internal_ip  = "10.10.102.133"
+  depends_on      = ["vcd_network_routed.{{.NetworkName}}"]
+}
+
 `
 
 const testAccCheckVcdVApp_powerOff = `resource "vcd_network_routed" "{{.NetworkName2}}" {

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -106,7 +106,7 @@ func testAccCheckVcdVAppExists(n string, vapp *govcd.VApp) resource.TestCheckFun
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("no VAPP ID is set")
+			return fmt.Errorf("no vApp ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*VCDClient)

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -255,16 +255,6 @@ resource "vcd_vapp" "{{.VappNameAllocated}}" {
     vapp_metadata = "vApp Metadata."
   }
 }
-
-resource "vcd_snat" "snatTest1" {
-  edge_gateway = "{{.EdgeGateway}}"
-  network_name = "{{.NetworkName}}"
-  network_type    = "org"
-  external_ip  = "10.10.102.144"
-  internal_ip  = "10.10.102.133"
-  depends_on      = ["vcd_network_routed.{{.NetworkName}}"]
-}
-
 `
 
 const testAccCheckVcdVApp_powerOff = `resource "vcd_network_routed" "{{.NetworkName2}}" {

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -338,7 +338,7 @@ func resourceVcdVAppVmCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(d.Get("name").(string))
 
 	// TODO do not trigger resourceVcdVAppVmUpdate from create. These must be separate actions.
-	err = resourceVcdVAppVmUpdate(d, meta)
+	err = resourceVcdVAppVmUpdateExecute(d, meta)
 	if err != nil {
 		errAttachedDisk := updateStateOfAttachedDisks(d, vm, vdc)
 		if errAttachedDisk != nil {
@@ -465,6 +465,13 @@ func getVmIndependentDisks(vm govcd.VM) []string {
 }
 
 func resourceVcdVAppVmUpdate(d *schema.ResourceData, meta interface{}) error {
+	lockParentVapp(d)
+	defer unLockParentVapp(d)
+
+	return resourceVcdVAppVmUpdateExecute(d, meta)
+}
+
+func resourceVcdVAppVmUpdateExecute(d *schema.ResourceData, meta interface{}) error {
 
 	vcdClient := meta.(*VCDClient)
 

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -249,8 +249,8 @@ func falseBoolSuppress() schema.SchemaDiffSuppressFunc {
 func resourceVcdVAppVmCreate(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
-	lockParentvApp(d)
-	defer unLockParentvApp(d)
+	vcdClient.lockParentvApp(d)
+	defer vcdClient.unLockParentvApp(d)
 
 	org, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {
@@ -465,8 +465,9 @@ func getVmIndependentDisks(vm govcd.VM) []string {
 }
 
 func resourceVcdVAppVmUpdate(d *schema.ResourceData, meta interface{}) error {
-	lockParentvApp(d)
-	defer unLockParentvApp(d)
+	vcdClient := meta.(*VCDClient)
+	vcdClient.lockParentvApp(d)
+	defer vcdClient.unLockParentvApp(d)
 
 	return resourceVcdVAppVmUpdateExecute(d, meta)
 }
@@ -802,8 +803,8 @@ func updateStateOfAttachedDisks(d *schema.ResourceData, vm govcd.VM, vdc govcd.V
 func resourceVcdVAppVmDelete(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
-	lockParentvApp(d)
-	defer unLockParentvApp(d)
+	vcdClient.lockParentvApp(d)
+	defer vcdClient.unLockParentvApp(d)
 
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
@@ -250,6 +249,9 @@ func falseBoolSuppress() schema.SchemaDiffSuppressFunc {
 func resourceVcdVAppVmCreate(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
+	lockParentVapp(d)
+	defer unLockParentVapp(d)
+
 	org, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {
 		return fmt.Errorf(errorRetrievingOrgAndVdc, err)
@@ -290,15 +292,12 @@ func resourceVcdVAppVmCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("unable to process network configuration: %s", err)
 	}
 
-	err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-		log.Printf("[TRACE] Creating VM: %s", d.Get("name").(string))
-		task, err := vapp.AddNewVM(d.Get("name").(string), vappTemplate, &networkConnectionSection, acceptEulas)
-		if err != nil {
-			return resource.RetryableError(fmt.Errorf("error adding VM: %#v", err))
-		}
-		return resource.RetryableError(task.WaitTaskCompletion())
-	})
-
+	log.Printf("[TRACE] Creating VM: %s", d.Get("name").(string))
+	task, err := vapp.AddNewVM(d.Get("name").(string), vappTemplate, &networkConnectionSection, acceptEulas)
+	if err != nil {
+		return fmt.Errorf("error adding VM: %#v", err)
+	}
+	err = task.WaitTaskCompletion()
 	if err != nil {
 		return fmt.Errorf(errorCompletingTask, err)
 	}
@@ -313,26 +312,24 @@ func resourceVcdVAppVmCreate(d *schema.ResourceData, meta interface{}) error {
 	// The below operation assumes VM is powered off and does not check for it because VM is being
 	// powered on in the last stage of create/update cycle
 	if d.Get("expose_hardware_virtualization").(bool) {
-		err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-			task, err := vm.ToggleHardwareVirtualization(true)
-			if err != nil {
-				return resource.RetryableError(fmt.Errorf("error enabling hardware assisted virtualization: %#v", err))
-			}
-			return resource.RetryableError(task.WaitTaskCompletion())
-		})
+
+		task, err := vm.ToggleHardwareVirtualization(true)
+		if err != nil {
+			return fmt.Errorf("error enabling hardware assisted virtualization: %#v", err)
+		}
+		err = task.WaitTaskCompletion()
+
 		if err != nil {
 			return fmt.Errorf(errorCompletingTask, err)
 		}
 	}
 
 	if initScript, ok := d.GetOk("initscript"); ok {
-		err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-			task, err := vm.RunCustomizationScript(d.Get("name").(string), initScript.(string))
-			if err != nil {
-				return resource.RetryableError(fmt.Errorf("error with setting init script: %#v", err))
-			}
-			return resource.RetryableError(task.WaitTaskCompletion())
-		})
+		task, err := vm.RunCustomizationScript(d.Get("name").(string), initScript.(string))
+		if err != nil {
+			return fmt.Errorf("error with setting init script: %#v", err)
+		}
+		err = task.WaitTaskCompletion()
 		if err != nil {
 			return fmt.Errorf(errorCompletingTask, err)
 		}
@@ -380,14 +377,11 @@ func addVdcNetwork(networkNameToAdd string, vdc govcd.Vdc, vapp govcd.VApp, vcdC
 	}
 
 	if !isAlreadyVappNetwork {
-		err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-			task, err := vapp.AddRAWNetworkConfig([]*types.OrgVDCNetwork{vdcNetwork})
-			if err != nil {
-				return resource.RetryableError(fmt.Errorf("error assigning network to vApp: %#v", err))
-			}
-			return resource.RetryableError(task.WaitTaskCompletion())
-		})
-
+		task, err := vapp.AddRAWNetworkConfig([]*types.OrgVDCNetwork{vdcNetwork})
+		if err != nil {
+			return &types.OrgVDCNetwork{}, fmt.Errorf("error assigning network to vApp: %#v", err)
+		}
+		err = task.WaitTaskCompletion()
 		if err != nil {
 			return &types.OrgVDCNetwork{}, fmt.Errorf("error assigning network to vApp:: %#v", err)
 		}
@@ -563,63 +557,58 @@ func resourceVcdVAppVmUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if d.HasChange("memory") {
-			err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-				task, err := vm.ChangeMemorySize(d.Get("memory").(int))
-				if err != nil {
-					return resource.RetryableError(fmt.Errorf("error changing memory size: %#v", err))
-				}
 
-				return resource.RetryableError(task.WaitTaskCompletion())
-			})
+			task, err := vm.ChangeMemorySize(d.Get("memory").(int))
+			if err != nil {
+				return fmt.Errorf("error changing memory size: %#v", err)
+			}
+
+			err = task.WaitTaskCompletion()
 			if err != nil {
 				return err
 			}
 		}
 
 		if d.HasChange("cpus") || d.HasChange("cpu_cores") {
-			err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-				var task govcd.Task
-				var err error
-				if d.Get("cpu_cores") != nil {
-					coreCounts := d.Get("cpu_cores").(int)
-					task, err = vm.ChangeCPUCountWithCore(d.Get("cpus").(int), &coreCounts)
-				} else {
-					task, err = vm.ChangeCPUCount(d.Get("cpus").(int))
-				}
-				if err != nil {
-					return resource.RetryableError(fmt.Errorf("error changing cpu count: %#v", err))
-				}
+			var task govcd.Task
+			var err error
+			if d.Get("cpu_cores") != nil {
+				coreCounts := d.Get("cpu_cores").(int)
+				task, err = vm.ChangeCPUCountWithCore(d.Get("cpus").(int), &coreCounts)
+			} else {
+				task, err = vm.ChangeCPUCount(d.Get("cpus").(int))
+			}
+			if err != nil {
+				return fmt.Errorf("error changing cpu count: %#v", err)
+			}
 
-				return resource.RetryableError(task.WaitTaskCompletion())
-			})
+			err = task.WaitTaskCompletion()
 			if err != nil {
 				return fmt.Errorf(errorCompletingTask, err)
 			}
 		}
 
 		if d.HasChange("expose_hardware_virtualization") {
-			err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-				task, err := vm.ToggleHardwareVirtualization(d.Get("expose_hardware_virtualization").(bool))
-				if err != nil {
-					return resource.RetryableError(fmt.Errorf("error changing hardware assisted virtualization: %#v", err))
-				}
 
-				return resource.RetryableError(task.WaitTaskCompletion())
-			})
+			task, err := vm.ToggleHardwareVirtualization(d.Get("expose_hardware_virtualization").(bool))
+			if err != nil {
+				return fmt.Errorf("error changing hardware assisted virtualization: %#v", err)
+			}
+
+			err = task.WaitTaskCompletion()
 			if err != nil {
 				return err
 			}
 		}
 
 		if d.Get("power_on").(bool) {
-			err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-				task, err := vm.PowerOn()
-				if err != nil {
-					return resource.RetryableError(fmt.Errorf("error Powering Up: %#v", err))
-				}
 
-				return resource.RetryableError(task.WaitTaskCompletion())
-			})
+			task, err := vm.PowerOn()
+			if err != nil {
+				fmt.Errorf("error Powering Up: %#v", err)
+			}
+
+			err = task.WaitTaskCompletion()
 			if err != nil {
 				return fmt.Errorf(errorCompletingTask, err)
 			}
@@ -806,6 +795,9 @@ func updateStateOfAttachedDisks(d *schema.ResourceData, vm govcd.VM, vdc govcd.V
 func resourceVcdVAppVmDelete(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
+	lockParentVapp(d)
+	defer unLockParentVapp(d)
+
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {
 		return fmt.Errorf(errorRetrievingOrgAndVdc, err)
@@ -831,28 +823,22 @@ func resourceVcdVAppVmDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[TRACE] vApp Status:: %s", status)
 	if status != "POWERED_OFF" {
 		log.Printf("[TRACE] Undeploying vApp: %s", vapp.VApp.Name)
-		err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-			task, err := vapp.Undeploy()
-			if err != nil {
-				return resource.RetryableError(fmt.Errorf("error Undeploying: %#v", err))
-			}
+		task, err := vapp.Undeploy()
+		if err != nil {
+			return fmt.Errorf("error Undeploying: %#v", err)
+		}
 
-			return resource.RetryableError(task.WaitTaskCompletion())
-		})
+		err = task.WaitTaskCompletion()
 		if err != nil {
 			return fmt.Errorf("error Undeploying vApp: %#v", err)
 		}
 	}
 
-	err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-		log.Printf("[TRACE] Removing VM: %s", vm.VM.Name)
-		err := vapp.RemoveVM(vm)
-		if err != nil {
-			return resource.RetryableError(fmt.Errorf("error deleting: %#v", err))
-		}
-
-		return nil
-	})
+	log.Printf("[TRACE] Removing VM: %s", vm.VM.Name)
+	err = vapp.RemoveVM(vm)
+	if err != nil {
+		return fmt.Errorf("error deleting: %#v", err)
+	}
 
 	if status != "POWERED_OFF" {
 		log.Printf("[TRACE] Redeploying vApp: %s", vapp.VApp.Name)
@@ -866,14 +852,12 @@ func resourceVcdVAppVmDelete(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		log.Printf("[TRACE] Powering on vApp: %s", vapp.VApp.Name)
-		err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-			task, err = vapp.PowerOn()
-			if err != nil {
-				return resource.RetryableError(fmt.Errorf("error Powering Up vApp: %#v", err))
-			}
+		task, err = vapp.PowerOn()
+		if err != nil {
+			return fmt.Errorf("error Powering Up vApp: %#v", err)
+		}
 
-			return resource.RetryableError(task.WaitTaskCompletion())
-		})
+		err = task.WaitTaskCompletion()
 		if err != nil {
 			return fmt.Errorf("error Powering Up vApp: %#v", err)
 		}

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -249,8 +249,8 @@ func falseBoolSuppress() schema.SchemaDiffSuppressFunc {
 func resourceVcdVAppVmCreate(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
-	lockParentVapp(d)
-	defer unLockParentVapp(d)
+	lockParentvApp(d)
+	defer unLockParentvApp(d)
 
 	org, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {
@@ -465,8 +465,8 @@ func getVmIndependentDisks(vm govcd.VM) []string {
 }
 
 func resourceVcdVAppVmUpdate(d *schema.ResourceData, meta interface{}) error {
-	lockParentVapp(d)
-	defer unLockParentVapp(d)
+	lockParentvApp(d)
+	defer unLockParentvApp(d)
 
 	return resourceVcdVAppVmUpdateExecute(d, meta)
 }
@@ -802,8 +802,8 @@ func updateStateOfAttachedDisks(d *schema.ResourceData, vm govcd.VM, vdc govcd.V
 func resourceVcdVAppVmDelete(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
-	lockParentVapp(d)
-	defer unLockParentVapp(d)
+	lockParentvApp(d)
+	defer unLockParentvApp(d)
 
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -605,7 +605,7 @@ func resourceVcdVAppVmUpdate(d *schema.ResourceData, meta interface{}) error {
 
 			task, err := vm.PowerOn()
 			if err != nil {
-				fmt.Errorf("error Powering Up: %#v", err)
+				return fmt.Errorf("error Powering Up: %#v", err)
 			}
 
 			err = task.WaitTaskCompletion()
@@ -863,7 +863,7 @@ func resourceVcdVAppVmDelete(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	return err
+	return nil
 }
 
 func resourceVcdVmIndependentDiskHash(v interface{}) int {

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -249,8 +249,8 @@ func falseBoolSuppress() schema.SchemaDiffSuppressFunc {
 func resourceVcdVAppVmCreate(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
-	vcdClient.lockParentvApp(d)
-	defer vcdClient.unLockParentvApp(d)
+	vcdClient.lockParentVapp(d)
+	defer vcdClient.unLockParentVapp(d)
 
 	org, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {
@@ -466,8 +466,8 @@ func getVmIndependentDisks(vm govcd.VM) []string {
 
 func resourceVcdVAppVmUpdate(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
-	vcdClient.lockParentvApp(d)
-	defer vcdClient.unLockParentvApp(d)
+	vcdClient.lockParentVapp(d)
+	defer vcdClient.unLockParentVapp(d)
 
 	return resourceVcdVAppVmUpdateExecute(d, meta)
 }
@@ -803,8 +803,8 @@ func updateStateOfAttachedDisks(d *schema.ResourceData, vm govcd.VM, vdc govcd.V
 func resourceVcdVAppVmDelete(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
-	vcdClient.lockParentvApp(d)
-	defer vcdClient.unLockParentvApp(d)
+	vcdClient.lockParentVapp(d)
+	defer vcdClient.unLockParentVapp(d)
 
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -327,7 +327,7 @@ func resourceVcdVAppVmCreate(d *schema.ResourceData, meta interface{}) error {
 	if initScript, ok := d.GetOk("initscript"); ok {
 		task, err := vm.RunCustomizationScript(d.Get("name").(string), initScript.(string))
 		if err != nil {
-			return fmt.Errorf("error with setting init script: %#v", err)
+			return fmt.Errorf("error with init script setting: %#v", err)
 		}
 		err = task.WaitTaskCompletion()
 		if err != nil {

--- a/vcd/resource_vcd_vapp_vm_checks_test.go
+++ b/vcd/resource_vcd_vapp_vm_checks_test.go
@@ -18,7 +18,7 @@ func testAccCheckVcdVAppVmExists(vappName, vmName, node string, vapp *govcd.VApp
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("no VAPP ID is set")
+			return fmt.Errorf("no vApp ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*VCDClient)

--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -1,4 +1,4 @@
-// +build multivm
+// +build multivm functional
 
 package vcd
 
@@ -60,20 +60,20 @@ func TestAccVcdVAppVmMulti(t *testing.T) {
 			resource.TestStep{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVcdVAppVmMultiExists("vcd_vapp_vm."+vmName, &vapp, &vm),
+					testAccCheckVcdVAppVmMultiExists("vcd_vapp_vm."+vmName1, &vapp, &vm, vappName2, vmName1),
 					resource.TestCheckResourceAttr(
-						"vcd_vapp_vm."+vmName, "name", vmName),
+						"vcd_vapp_vm."+vmName1, "name", vmName1),
 					resource.TestCheckResourceAttr(
-						"vcd_vapp_vm."+vmName, "ip", "10.10.102.161"),
+						"vcd_vapp_vm."+vmName1, "ip", "10.10.102.161"),
 					resource.TestCheckResourceAttr(
-						"vcd_vapp_vm."+vmName, "power_on", "true"),
+						"vcd_vapp_vm."+vmName1, "power_on", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckVcdVAppVmMultiExists(n string, vapp *govcd.VApp, vm *govcd.VM) resource.TestCheckFunc {
+func testAccCheckVcdVAppVmMultiExists(n string, vapp *govcd.VApp, vm *govcd.VM, vappName, vmName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -90,10 +90,12 @@ func testAccCheckVcdVAppVmMultiExists(n string, vapp *govcd.VApp, vm *govcd.VM) 
 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
 		}
 
-		vapp, err := vdc.FindVAppByName(vappName2)
+		vapp, err := vdc.FindVAppByName(vappName)
+		if err != nil {
+			return err
+		}
 
 		resp, err := vdc.FindVMByName(vapp, vmName)
-
 		if err != nil {
 			return err
 		}

--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -81,7 +81,7 @@ func testAccCheckVcdVAppVmMultiExists(n string, vapp *govcd.VApp, vm *govcd.VM, 
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("no VAPP ID is set")
+			return fmt.Errorf("no vApp ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*VCDClient)

--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -158,6 +158,7 @@ resource "vcd_vapp" "{{.VappName}}" {
   name = "{{.VappName}}"
   org  = "{{.Org}}"
   vdc  = "{{.Vdc}}"
+  depends_on = ["vcd_network_routed.{{.NetworkName}}"]
 }
 
 resource "vcd_vapp_vm" "{{.VmName1}}" {

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -93,7 +93,6 @@ resource "vcd_independent_disk" "{{.diskResourceName}}" {
   bus_sub_type    = "{{.busSubType}}"
   storage_profile = "{{.storageProfileName}}"
 
-  depends_on = ["vcd_vapp_vm.{{.VmName}}"]
 }
 
 resource "vcd_vapp" "{{.VappName}}" {

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -93,7 +93,7 @@ resource "vcd_independent_disk" "{{.diskResourceName}}" {
   bus_sub_type    = "{{.busSubType}}"
   storage_profile = "{{.storageProfileName}}"
 
-  depends_on = ["vcd_vapp_vm.{{.VmName}}"
+  depends_on = ["vcd_vapp_vm.{{.VmName}}"]
 }
 
 resource "vcd_vapp" "{{.VappName}}" {

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -98,6 +98,7 @@ resource "vcd_vapp" "{{.VappName}}" {
   name = "{{.VappName}}"
   org  = "{{.Org}}"
   vdc  = "{{.Vdc}}"
+  depends_on = ["vcd_network_routed.{{.NetworkName}}"]
 }
 
 resource "vcd_vapp_vm" "{{.VmName}}" {

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -92,6 +92,8 @@ resource "vcd_independent_disk" "{{.diskResourceName}}" {
   bus_type        = "{{.busType}}"
   bus_sub_type    = "{{.busSubType}}"
   storage_profile = "{{.storageProfileName}}"
+
+  depends_on = ["vcd_vapp_vm.{{.VmName}}"
 }
 
 resource "vcd_vapp" "{{.VappName}}" {

--- a/vendor/github.com/hashicorp/terraform/helper/mutexkv/mutexkv.go
+++ b/vendor/github.com/hashicorp/terraform/helper/mutexkv/mutexkv.go
@@ -1,0 +1,51 @@
+package mutexkv
+
+import (
+	"log"
+	"sync"
+)
+
+// MutexKV is a simple key/value store for arbitrary mutexes. It can be used to
+// serialize changes across arbitrary collaborators that share knowledge of the
+// keys they must serialize on.
+//
+// The initial use case is to let aws_security_group_rule resources serialize
+// their access to individual security groups based on SG ID.
+type MutexKV struct {
+	lock  sync.Mutex
+	store map[string]*sync.Mutex
+}
+
+// Locks the mutex for the given key. Caller is responsible for calling Unlock
+// for the same key
+func (m *MutexKV) Lock(key string) {
+	log.Printf("[DEBUG] Locking %q", key)
+	m.get(key).Lock()
+	log.Printf("[DEBUG] Locked %q", key)
+}
+
+// Unlock the mutex for the given key. Caller must have called Lock for the same key first
+func (m *MutexKV) Unlock(key string) {
+	log.Printf("[DEBUG] Unlocking %q", key)
+	m.get(key).Unlock()
+	log.Printf("[DEBUG] Unlocked %q", key)
+}
+
+// Returns a mutex for the given key, no guarantee of its lock status
+func (m *MutexKV) get(key string) *sync.Mutex {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	mutex, ok := m.store[key]
+	if !ok {
+		mutex = &sync.Mutex{}
+		m.store[key] = mutex
+	}
+	return mutex
+}
+
+// Returns a properly initalized MutexKV
+func NewMutexKV() *MutexKV {
+	return &MutexKV{
+		store: make(map[string]*sync.Mutex),
+	}
+}

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vapp.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/vapp.go
@@ -887,3 +887,8 @@ func updateNetworkConfigurations(vapp *VApp, networkConfigurations []types.VAppN
 	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
 		types.MimeNetworkConfigSection, "error updating vApp Network: %s", networkConfig)
 }
+
+// Function RemoveAllNetworks unattach all networks from VAPP
+func (vapp *VApp) RemoveAllNetworks() (Task, error) {
+	return updateNetworkConfigurations(vapp, []types.VAppNetworkConfiguration{})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -124,6 +124,7 @@ github.com/hashicorp/logutils
 # github.com/hashicorp/terraform v0.12.0
 github.com/hashicorp/terraform/plugin
 github.com/hashicorp/terraform/helper/hashcode
+github.com/hashicorp/terraform/helper/mutexkv
 github.com/hashicorp/terraform/helper/resource
 github.com/hashicorp/terraform/helper/schema
 github.com/hashicorp/terraform/helper/validation

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -216,7 +216,7 @@ github.com/ulikunitz/xz/internal/hash
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/vmware/go-vcloud-director/v2 v2.2.0
+# github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.1
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util


### PR DESCRIPTION
This initial change which allows us come from retrycall approach to mutex one.

Notes:
* Remove rectrycall's
* Add k,v mutex
* Add locking/unlocking helper functions
* remove locking where isn't needed - now isolated/direct networks works faster

Spotted issues:
* for a moment vm.changeName fails without rectrycall - looks like function initiated to soon, though vm creation task completed
* Test TestAccVcdVApp_PowerOff failing on my env. Seems that in test's terraform dependencies isn't working - if HCL runned with binary - everything is fine. Still looking for solution