### PR TITLE
fix typo that undeploys vapp instead of vm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-## 2.4.0 (Unreleased)
 ## 2.3.0 (May 29, 2019)
 
 IMPROVEMENTS:

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -823,16 +823,16 @@ func resourceVcdVAppVmDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error getting VM4 : %#v", err)
 	}
 
-	status, err := vapp.GetStatus()
+	status, err := vm.GetStatus()
 	if err != nil {
 		return fmt.Errorf("error getting vApp status: %#v", err)
 	}
 
-	log.Printf("[TRACE] vApp Status:: %s", status)
+	log.Printf("[TRACE] VM Status:: %s", status)
 	if status != "POWERED_OFF" {
-		log.Printf("[TRACE] Undeploying vApp: %s", vapp.VApp.Name)
+		log.Printf("[TRACE] Undeploying VM: %s", vapp.VApp.Name)
 		err = retryCall(vcdClient.MaxRetryTimeout, func() *resource.RetryError {
-			task, err := vapp.Undeploy()
+			task, err := vm.Undeploy()
 			if err != nil {
 				return resource.RetryableError(fmt.Errorf("error Undeploying: %#v", err))
 			}


### PR DESCRIPTION
Found the information in #69 So made the change and tested locally.