### PR TITLE
Update independent disk size type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.12
 
 require (
 	github.com/hashicorp/terraform v0.12.0
-	github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.3
+	github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.4
 )

--- a/go.sum
+++ b/go.sum
@@ -301,8 +301,6 @@ github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4A
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.3 h1:cgQGF5SmFtHPbwUESzlKu6C8mXBoCei/Wqkji8aScBM=
-github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.3/go.mod h1:+Hq7ryFfgZqsO6mXH29RQFnpIMSujCOMI57otHoXHhQ=
 github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.4 h1:rCB0qPtEgOchapyTKbcPUUFcJMoYDaRSP4RAC/dDT6A=
 github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.4/go.mod h1:+Hq7ryFfgZqsO6mXH29RQFnpIMSujCOMI57otHoXHhQ=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,8 @@ github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElyw
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.3 h1:cgQGF5SmFtHPbwUESzlKu6C8mXBoCei/Wqkji8aScBM=
 github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.3/go.mod h1:+Hq7ryFfgZqsO6mXH29RQFnpIMSujCOMI57otHoXHhQ=
+github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.4 h1:rCB0qPtEgOchapyTKbcPUUFcJMoYDaRSP4RAC/dDT6A=
+github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.4/go.mod h1:+Hq7ryFfgZqsO6mXH29RQFnpIMSujCOMI57otHoXHhQ=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=

--- a/vcd/resource_vcd_independent_disk.go
+++ b/vcd/resource_vcd_independent_disk.go
@@ -91,7 +91,7 @@ func resourceVcdIndependentDiskCreate(d *schema.ResourceData, meta interface{}) 
 
 	diskCreateParams := &types.DiskCreateParams{Disk: &types.Disk{
 		Name: diskName,
-		Size: int(d.Get("size").(float64) * 1024 * 1024),
+		Size: int64(d.Get("size").(float64) * 1024 * 1024),
 	}}
 
 	var storageReference types.Reference

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/disk.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/disk.go
@@ -44,7 +44,7 @@ func NewDiskRecord(cli *Client) *DiskRecord {
 
 // While theoretically we can use smaller amounts, there is an issue when updating
 // disks with size < 1MB
-const MinimumDiskSize int = 1048576 // = 1Mb
+const MinimumDiskSize int64 = 1048576 // = 1Mb
 
 // Create an independent disk in VDC
 // Reference: vCloud API Programming Guide for Service Providers vCloud API 30.0 PDF Page 102 - 103,

--- a/vendor/github.com/vmware/go-vcloud-director/v2/types/v56/types.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/types/v56/types.go
@@ -367,7 +367,7 @@ type Vdc struct {
 	ID           string `xml:"id,attr,omitempty"`
 	OperationKey string `xml:"operationKey,attr,omitempty"`
 	Name         string `xml:"name,attr"`
-	Status       string `xml:"status,attr,omitempty"`
+	Status       int    `xml:"status,attr,omitempty"`
 
 	AllocationModel    string                `xml:"AllocationModel"`
 	AvailableNetworks  []*AvailableNetworks  `xml:"AvailableNetworks,omitempty"`
@@ -2303,7 +2303,7 @@ type Disk struct {
 	OperationKey    string           `xml:"operationKey,attr,omitempty"`
 	Name            string           `xml:"name,attr"`
 	Status          int              `xml:"status,attr,omitempty"`
-	Size            int              `xml:"size,attr"`
+	Size            int64            `xml:"size,attr"`
 	Iops            *int             `xml:"iops,attr,omitempty"`
 	BusType         string           `xml:"busType,attr,omitempty"`
 	BusSubType      string           `xml:"busSubType,attr,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -216,7 +216,7 @@ github.com/ulikunitz/xz/internal/hash
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.3
+# github.com/vmware/go-vcloud-director/v2 v2.3.0-alpha.4
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util


### PR DESCRIPTION
Using int64, as required in the API, instead of int, which was
   mistakenly used in go-vcloud-director