### PR TITLE
Improve tests

### DIFF
--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -11,7 +11,7 @@ then
 fi
 
 wanted=$1
-timeout=90m
+timeout=120m
 if [ -n "$VCD_TIMEOUT" ]
 then
     timeout=$VCD_TIMEOUT

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -11,6 +11,11 @@ then
 fi
 
 wanted=$1
+timeout=90m
+if [ -n "$VCD_TIMEOUT" ]
+then
+    timeout=$VCD_TIMEOUT
+fi
 
 if [ -n "$DRY_RUN" ]
 then
@@ -92,13 +97,13 @@ function acceptance_test {
     if [ -n "$VERBOSE" ]
     then
         echo "# check for config file"
-        echo "TF_ACC=1 go test -tags '$tags' -v -timeout 120m ."
+        echo "TF_ACC=1 go test -tags '$tags' -v -timeout $timeout ."
     fi
 
     if [ -z "$DRY_RUN" ]
     then
         check_for_config_file
-        TF_ACC=1 go test -tags "$tags" -v -timeout 120m .
+        TF_ACC=1 go test -tags "$tags" -v -timeout $timeout .
     fi
 }
 
@@ -111,13 +116,13 @@ function multiple_test {
     if [ -n "$VERBOSE" ]
     then
         echo "# check for config file"
-        echo "TF_ACC=1 go test -v -timeout 120m -tags 'api multivm multinetwork' -run '$filter' ."
+        echo "TF_ACC=1 go test -v -timeout $timeout -tags 'api multivm multinetwork' -run '$filter' ."
     fi
 
     if [ -z "$DRY_RUN" ]
     then
         check_for_config_file
-        TF_ACC=1 go test -v -timeout 120m -tags 'api multivm multinetwork' -run "$filter" .
+        TF_ACC=1 go test -v -timeout $timeout -tags 'api multivm multinetwork' -run "$filter" .
     fi
 }
 

--- a/scripts/test-binary.sh
+++ b/scripts/test-binary.sh
@@ -13,6 +13,14 @@ unset in_building
 operations=(init plan apply destroy)
 skipping_items=($build_script)
 
+if [ -f skip-files.txt ]
+then
+    for f in $(cat skip-files.txt)
+    do
+        skipping_items+=($f)
+    done
+fi
+
 function remove_item_from_skipping {
     item=$1
     new_array=()

--- a/vcd/resource_vcd_dnat_test.go
+++ b/vcd/resource_vcd_dnat_test.go
@@ -394,6 +394,7 @@ resource "vcd_dnat" "{{.DnatName}}" {
 }
 `
 const testAccCheckVcdDnatWithExtNetwUpdate = `
+# skip-binary-test: only for updates
 resource "vcd_dnat" "{{.DnatName}}" {
   org             = "{{.Org}}"
   vdc             = "{{.Vdc}}"

--- a/vcd/resource_vcd_org_vdc_test.go
+++ b/vcd/resource_vcd_org_vdc_test.go
@@ -315,6 +315,7 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
 `
 
 const testAccCheckVcdVdc_update = `
+# skip-binary-test: only for updates
 resource "vcd_org_vdc" "{{.VdcName}}" {
   name = "{{.VdcName}}"
   org  = "{{.OrgName}}"

--- a/vcd/resource_vcd_snat_test.go
+++ b/vcd/resource_vcd_snat_test.go
@@ -293,6 +293,7 @@ resource "vcd_snat" "{{.SnatName}}" {
 `
 
 const testAccCheckVcdSnat_update = `
+# skip-binary-test: only for updates
 resource "vcd_network_routed" "{{.OrgVdcNetworkName}}" {
   name         = "{{.OrgVdcNetworkName}}"
   org          = "{{.Org}}"


### PR DESCRIPTION
Add variable to change testacc timeout on-the-fly
Add personalized file to skip tests locally
Add a skipping notice to some update tests
   (binary tests can only run init-apply-destroy, while
   these tests are part of a multi-script combo)