### PR TITLE
Replace usage of deprecated functions

### DIFF
--- a/vcd/resource_vcd_inserted_media.go
+++ b/vcd/resource_vcd_inserted_media.go
@@ -145,25 +145,25 @@ func resourceVcdMediaEject(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func getVM(d *schema.ResourceData, meta interface{}) (govcd.VM, *govcd.Org, error) {
+func getVM(d *schema.ResourceData, meta interface{}) (*govcd.VM, *govcd.Org, error) {
 	vcdClient := meta.(*VCDClient)
 
 	org, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil || org == nil || vdc == nil {
-		return govcd.VM{}, nil, fmt.Errorf(errorRetrievingOrgAndVdc, err)
+		return nil, nil, fmt.Errorf(errorRetrievingOrgAndVdc, err)
 	}
 
 	vmRecord, err := vdc.QueryVM(d.Get("vapp_name").(string), d.Get("vm_name").(string))
 	if err != nil {
 		log.Printf("[DEBUG] Unable to find VM. Removing from tfstate")
 		d.SetId("")
-		return govcd.VM{}, nil, fmt.Errorf("unable to find VM. Removing from tfstate. Err: #%v", err)
+		return nil, nil, fmt.Errorf("unable to find VM. Removing from tfstate. Err: #%v", err)
 	}
 
-	vm, err := vcdClient.Client.FindVMByHREF(vmRecord.VM.HREF)
-	if err != nil || vm == (govcd.VM{}) {
+	vm, err := vcdClient.Client.GetVMByHref(vmRecord.VM.HREF)
+	if err != nil {
 		log.Printf("[DEBUG] Unable to get VM data")
-		return govcd.VM{}, nil, fmt.Errorf("error getting VM data: %s", err)
+		return nil, nil, fmt.Errorf("error getting VM data: %s", err)
 	}
 	return vm, org, nil
 }

--- a/vcd/resource_vcd_inserted_media_test.go
+++ b/vcd/resource_vcd_inserted_media_test.go
@@ -4,7 +4,6 @@ package vcd
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -80,12 +79,12 @@ func testAccCheckMediaInserted(itemName string) resource.TestCheckFunc {
 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
 		}
 
-		vapp, err := vdc.FindVAppByName(vappNameForInsert)
+		vapp, err := vdc.GetVAppByName(vappNameForInsert, false)
 		if err != nil {
 			return err
 		}
 
-		vm, err := vdc.FindVMByName(vapp, vmNameForInsert)
+		vm, err := vapp.GetVMByName(vmNameForInsert, false)
 
 		if err != nil {
 			return err
@@ -118,12 +117,12 @@ func testAccCheckMediaEjected(itemName string) resource.TestCheckFunc {
 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
 		}
 
-		vapp, err := vdc.FindVAppByName(vappNameForInsert)
+		vapp, err := vdc.GetVAppByName(vappNameForInsert, false)
 		if err != nil {
 			return err
 		}
 
-		vm, err := vdc.FindVMByName(vapp, vmNameForInsert)
+		vm, err := vapp.GetVMByName(vmNameForInsert, false)
 
 		if err != nil {
 			return err
@@ -151,9 +150,9 @@ func testAccResourcesDestroyed(s *terraform.State) error {
 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
 		}
 
-		_, err = vdc.FindVAppByName(vappNameForInsert)
-		if err != nil && !strings.Contains(err.Error(), "can't find vApp:") {
-			return fmt.Errorf("vapp %s still exist and error: %#v", itemName, err)
+		_, err = vdc.GetVAppByName(vappNameForInsert, false)
+		if err == nil {
+			return fmt.Errorf("vapp %s still exist", itemName)
 		}
 
 		_, err = vdc.GetOrgVdcNetworkByName(TestAccVcdVAppVmNetForInsert, false)

--- a/vcd/resource_vcd_vapp_network.go
+++ b/vcd/resource_vcd_vapp_network.go
@@ -147,7 +147,7 @@ func resourceVcdVappNetworkCreate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf(errorRetrievingOrgAndVdc, err)
 	}
 
-	vapp, err := vdc.FindVAppByName(d.Get("vapp_name").(string))
+	vapp, err := vdc.GetVAppByName(d.Get("vapp_name").(string), false)
 	if err != nil {
 		return fmt.Errorf("error finding vApp. %#v", err)
 	}
@@ -205,7 +205,7 @@ func resourceVappNetworkRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf(errorRetrievingOrgAndVdc, err)
 	}
 
-	vapp, err := vdc.FindVAppByName(d.Get("vapp_name").(string))
+	vapp, err := vdc.GetVAppByName(d.Get("vapp_name").(string), false)
 	if err != nil {
 		return fmt.Errorf("error finding Vapp: %#v", err)
 	}
@@ -260,7 +260,7 @@ func resourceVappNetworkDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf(errorRetrievingOrgAndVdc, err)
 	}
 
-	vapp, err := vdc.FindVAppByName(d.Get("vapp_name").(string))
+	vapp, err := vdc.GetVAppByName(d.Get("vapp_name").(string), false)
 	if err != nil {
 		return fmt.Errorf("error finding vApp: %#v", err)
 	}

--- a/vcd/resource_vcd_vapp_network_multi_test.go
+++ b/vcd/resource_vcd_vapp_network_multi_test.go
@@ -4,7 +4,6 @@ package vcd
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -150,8 +149,8 @@ func testAccCheckVappNetworkMultiDestroy(s *terraform.State) error {
 		}
 
 		_, err := isVappNetworkMultiFound(conn, rs)
-		if err != nil && !strings.Contains(err.Error(), "can't find vApp:") {
-			return fmt.Errorf("vapp %s still exist and error: %#v", vappNameForNetworkMulti, err)
+		if err == nil {
+			return fmt.Errorf("vapp %s still exists", vappNameForNetworkMulti)
 		}
 	}
 
@@ -164,7 +163,7 @@ func isVappNetworkMultiFound(conn *VCDClient, rs *terraform.ResourceState) (stri
 		return "uninstalled", fmt.Errorf(errorRetrievingOrgAndVdc, err)
 	}
 
-	vapp, err := vdc.FindVAppByName(vappNameForNetworkMulti)
+	vapp, err := vdc.GetVAppByName(vappNameForNetworkMulti, false)
 	if err != nil {
 		return "uninstalled", fmt.Errorf("error retrieving vApp: %s, %#v", rs.Primary.ID, err)
 	}

--- a/vcd/resource_vcd_vapp_network_test.go
+++ b/vcd/resource_vcd_vapp_network_test.go
@@ -4,7 +4,6 @@ package vcd
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -115,8 +114,8 @@ func testAccCheckVappNetworkDestroy(s *terraform.State) error {
 		}
 
 		_, err := isVappNetworkFound(conn, rs)
-		if err != nil && !strings.Contains(err.Error(), "can't find vApp:") {
-			return fmt.Errorf("vapp %s still exist and error: %#v", vappNameForNetworkTest, err)
+		if err == nil {
+			return fmt.Errorf("vapp %s still exists", vappNameForNetworkTest)
 		}
 	}
 
@@ -129,7 +128,7 @@ func isVappNetworkFound(conn *VCDClient, rs *terraform.ResourceState) (bool, err
 		return false, fmt.Errorf(errorRetrievingOrgAndVdc, err)
 	}
 
-	vapp, err := vdc.FindVAppByName(vappNameForNetworkTest)
+	vapp, err := vdc.GetVAppByName(vappNameForNetworkTest, false)
 	if err != nil {
 		return false, fmt.Errorf("error retrieving vApp: %s, %#v", rs.Primary.ID, err)
 	}

--- a/vcd/resource_vcd_vapp_raw_multi_test.go
+++ b/vcd/resource_vcd_vapp_raw_multi_test.go
@@ -70,12 +70,12 @@ func testAccCheckVcdVAppRawMultiExists(n string, vapp *govcd.VApp) resource.Test
 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
 		}
 
-		resp, err := vdc.FindVAppByName(rs.Primary.ID)
+		newVapp, err := vdc.GetVAppByNameOrId(rs.Primary.ID, false)
 		if err != nil {
 			return err
 		}
 
-		*vapp = resp
+		*vapp = *newVapp
 
 		return nil
 	}
@@ -93,7 +93,7 @@ func testAccCheckVcdVAppRawMultiDestroy(s *terraform.State) error {
 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
 		}
 
-		_, err = vdc.FindVAppByName(rs.Primary.ID)
+		_, err = vdc.GetVAppByNameOrId(rs.Primary.ID, false)
 
 		if err == nil {
 			return fmt.Errorf("VPCs still exist")

--- a/vcd/resource_vcd_vapp_raw_test.go
+++ b/vcd/resource_vcd_vapp_raw_test.go
@@ -65,12 +65,12 @@ func testAccCheckVcdVAppRawExists(n string, vapp *govcd.VApp) resource.TestCheck
 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
 		}
 
-		resp, err := vdc.FindVAppByName(rs.Primary.ID)
+		newVapp, err := vdc.GetVAppByNameOrId(rs.Primary.ID, false)
 		if err != nil {
 			return err
 		}
 
-		*vapp = resp
+		*vapp = *newVapp
 
 		return nil
 	}
@@ -88,7 +88,7 @@ func testAccCheckVcdVAppRawDestroy(s *terraform.State) error {
 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
 		}
 
-		_, err = vdc.FindVAppByName(rs.Primary.ID)
+		_, err = vdc.GetVAppByNameOrId(rs.Primary.ID, false)
 
 		if err == nil {
 			return fmt.Errorf("VPCs still exist")

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -121,7 +121,6 @@ func testAccCheckVcdVAppExists(n string, vapp *govcd.VApp) resource.TestCheckFun
 			return err
 		}
 
-		govcd.ShowVapp(*newVapp.VApp)
 		*vapp = *newVapp
 
 		return nil

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -116,12 +116,13 @@ func testAccCheckVcdVAppExists(n string, vapp *govcd.VApp) resource.TestCheckFun
 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
 		}
 
-		resp, err := vdc.FindVAppByName(rs.Primary.ID)
+		newVapp, err := vdc.GetVAppByNameOrId(rs.Primary.ID, false)
 		if err != nil {
 			return err
 		}
 
-		*vapp = resp
+		govcd.ShowVapp(*newVapp.VApp)
+		*vapp = *newVapp
 
 		return nil
 	}
@@ -140,7 +141,7 @@ func testAccCheckVcdVAppDestroy(s *terraform.State) error {
 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
 		}
 
-		_, err = vdc.FindVAppByName(rs.Primary.ID)
+		_, err = vdc.GetVAppByNameOrId(rs.Primary.ID, false)
 
 		if err == nil {
 			return fmt.Errorf("VPCs still exist")

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -265,7 +265,7 @@ func resourceVcdVAppVmCreate(d *schema.ResourceData, meta interface{}) error {
 
 	acceptEulas := d.Get("accept_all_eulas").(bool)
 
-	vapp, err := vdc.FindVAppByName(d.Get("vapp_name").(string))
+	vapp, err := vdc.GetVAppByName(d.Get("vapp_name").(string), false)
 	if err != nil {
 		return fmt.Errorf("error finding vApp: %#v", err)
 	}
@@ -274,10 +274,10 @@ func resourceVcdVAppVmCreate(d *schema.ResourceData, meta interface{}) error {
 	// TODO v3.0 remove else branch once 'network_name', 'vapp_network_name', 'ip' are deprecated
 	networkConnectionSection := types.NetworkConnectionSection{}
 	if len(d.Get("network").([]interface{})) > 0 {
-		networkConnectionSection, err = networksToConfig(d.Get("network").([]interface{}), vdc, vapp, vcdClient)
+		networkConnectionSection, err = networksToConfig(d.Get("network").([]interface{}), vdc, *vapp, vcdClient)
 	} else {
 		networkConnectionSection, err = deprecatedNetworksToConfig(d.Get("network_name").(string),
-			d.Get("vapp_network_name").(string), d.Get("ip").(string), vdc, vapp, vcdClient)
+			d.Get("vapp_network_name").(string), d.Get("ip").(string), vdc, *vapp, vcdClient)
 	}
 	if err != nil {
 		return fmt.Errorf("unable to process network configuration: %s", err)
@@ -293,7 +293,7 @@ func resourceVcdVAppVmCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf(errorCompletingTask, err)
 	}
 
-	vm, err := vdc.FindVMByName(vapp, d.Get("name").(string))
+	vm, err := vapp.GetVMByName(d.Get("name").(string), true)
 
 	if err != nil {
 		d.SetId("")
@@ -365,7 +365,7 @@ func resourceVcdVAppVmCreate(d *schema.ResourceData, meta interface{}) error {
 	// TODO do not trigger resourceVcdVAppVmUpdate from create. These must be separate actions.
 	err = resourceVcdVAppVmUpdateExecute(d, meta)
 	if err != nil {
-		errAttachedDisk := updateStateOfAttachedDisks(d, vm, vdc)
+		errAttachedDisk := updateStateOfAttachedDisks(d, *vm, vdc)
 		if errAttachedDisk != nil {
 			d.Set("disk", nil)
 			return fmt.Errorf("error reading attached disks : %#v and internal error : %#v", errAttachedDisk, err)
@@ -512,13 +512,13 @@ func resourceVcdVAppVmUpdateExecute(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf(errorRetrievingOrgAndVdc, err)
 	}
 
-	vapp, err := vdc.FindVAppByName(d.Get("vapp_name").(string))
+	vapp, err := vdc.GetVAppByName(d.Get("vapp_name").(string), false)
 
 	if err != nil {
 		return fmt.Errorf("error finding vApp: %s", err)
 	}
 
-	vm, err := vdc.FindVMByName(vapp, d.Get("name").(string))
+	vm, err := vapp.GetVMByName(d.Get("name").(string), false)
 
 	if err != nil {
 		d.SetId("")
@@ -617,9 +617,9 @@ func resourceVcdVAppVmUpdateExecute(d *schema.ResourceData, meta interface{}) er
 
 		// detaching independent disks - only possible when VM power off
 		if d.HasChange("disk") {
-			err = attachDetachDisks(d, vm, vdc)
+			err = attachDetachDisks(d, *vm, vdc)
 			if err != nil {
-				errAttachedDisk := updateStateOfAttachedDisks(d, vm, vdc)
+				errAttachedDisk := updateStateOfAttachedDisks(d, *vm, vdc)
 				if errAttachedDisk != nil {
 					d.Set("disk", nil)
 					return fmt.Errorf("error reading attached disks : %#v and internal error : %#v", errAttachedDisk, err)
@@ -674,7 +674,7 @@ func resourceVcdVAppVmUpdateExecute(d *schema.ResourceData, meta interface{}) er
 		}
 
 		if d.HasChange("network") {
-			networkConnectionSection, err := networksToConfig(d.Get("network").([]interface{}), vdc, vapp, vcdClient)
+			networkConnectionSection, err := networksToConfig(d.Get("network").([]interface{}), vdc, *vapp, vcdClient)
 			if err != nil {
 				return fmt.Errorf("unable to setup network configuration for update: %s", err)
 			}
@@ -829,13 +829,13 @@ func resourceVcdVAppVmRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf(errorRetrievingOrgAndVdc, err)
 	}
 
-	vapp, err := vdc.FindVAppByName(d.Get("vapp_name").(string))
+	vapp, err := vdc.GetVAppByName(d.Get("vapp_name").(string), false)
 
 	if err != nil {
 		return fmt.Errorf("error finding vApp: %s", err)
 	}
 
-	vm, err := vdc.FindVMByName(vapp, d.Get("name").(string))
+	vm, err := vapp.GetVMByName(d.Get("name").(string), false)
 
 	if err != nil {
 		d.SetId("")
@@ -848,7 +848,7 @@ func resourceVcdVAppVmRead(d *schema.ResourceData, meta interface{}) error {
 	switch {
 	// TODO v3.0 remove this case block when we cleanup deprecated 'ip' and 'network_name' attributes
 	case d.Get("network_name").(string) != "" || d.Get("vapp_network_name").(string) != "":
-		ip, mac, err := deprecatedReadNetworks(d.Get("network_name").(string), d.Get("vapp_network_name").(string), vm)
+		ip, mac, err := deprecatedReadNetworks(d.Get("network_name").(string), d.Get("vapp_network_name").(string), *vm)
 		if err != nil {
 			return fmt.Errorf("failed reading network details: %s", err)
 		}
@@ -856,7 +856,7 @@ func resourceVcdVAppVmRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("mac", mac)
 		// TODO v3.0 EO remove this case block when we cleanup deprecated 'ip' and 'network_name' attributes
 	case len(d.Get("network").([]interface{})) > 0:
-		networks, err := readNetworks(vm, vapp)
+		networks, err := readNetworks(*vm, *vapp)
 		if err != nil {
 			return fmt.Errorf("failed reading network details: %s", err)
 		}
@@ -877,7 +877,7 @@ func resourceVcdVAppVmRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("unable to set guest properties in state: %s", err)
 	}
 
-	err = updateStateOfAttachedDisks(d, vm, vdc)
+	err = updateStateOfAttachedDisks(d, *vm, vdc)
 	if err != nil {
 		d.Set("disk", nil)
 		return fmt.Errorf("error reading attached disks : %#v", err)
@@ -947,13 +947,13 @@ func resourceVcdVAppVmDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf(errorRetrievingOrgAndVdc, err)
 	}
 
-	vapp, err := vdc.FindVAppByName(d.Get("vapp_name").(string))
+	vapp, err := vdc.GetVAppByName(d.Get("vapp_name").(string), false)
 
 	if err != nil {
 		return fmt.Errorf("error finding vApp: %s", err)
 	}
 
-	vm, err := vdc.FindVMByName(vapp, d.Get("name").(string))
+	vm, err := vapp.GetVMByName(d.Get("name").(string), false)
 
 	if err != nil {
 		return fmt.Errorf("error getting VM4 : %#v", err)
@@ -979,7 +979,7 @@ func resourceVcdVAppVmDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// to avoid race condition for independent disks is attached or not - detach before removing vm
-	existingDisks := getVmIndependentDisks(vm)
+	existingDisks := getVmIndependentDisks(*vm)
 
 	for _, existingDiskHref := range existingDisks {
 		disk, err := vdc.FindDiskByHREF(existingDiskHref)
@@ -1000,7 +1000,7 @@ func resourceVcdVAppVmDelete(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[TRACE] Removing VM: %s", vm.VM.Name)
 
-	err = vapp.RemoveVM(vm)
+	err = vapp.RemoveVM(*vm)
 	if err != nil {
 		return fmt.Errorf("error deleting: %#v", err)
 	}

--- a/vcd/resource_vcd_vapp_vm_checks_test.go
+++ b/vcd/resource_vcd_vapp_vm_checks_test.go
@@ -27,18 +27,18 @@ func testAccCheckVcdVAppVmExists(vappName, vmName, node string, vapp *govcd.VApp
 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
 		}
 
-		vapp, err := vdc.FindVAppByName(vappName)
+		vapp, err := vdc.GetVAppByName(vappName, false)
 		if err != nil {
 			return err
 		}
 
-		resp, err := vdc.FindVMByName(vapp, vmName)
+		newVm, err := vapp.GetVMByName(vmName, false)
 
 		if err != nil {
 			return err
 		}
 
-		*vm = resp
+		*vm = *newVm
 
 		return nil
 	}
@@ -57,7 +57,7 @@ func testAccCheckVcdVAppVmDestroy(vappName string) resource.TestCheckFunc {
 				return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
 			}
 
-			_, err = vdc.FindVAppByName(vappName)
+			_, err = vdc.GetVAppByName(vappName, false)
 
 			if err == nil {
 				return fmt.Errorf("VPCs still exist")

--- a/vcd/resource_vcd_vapp_vm_customization_test.go
+++ b/vcd/resource_vcd_vapp_vm_customization_test.go
@@ -157,12 +157,12 @@ func testAccCheckVcdVMCustomization(node string, customizationPending bool) reso
 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
 		}
 
-		vapp, err := vdc.FindVAppByName(rs.Primary.Attributes["vapp_name"])
+		vapp, err := vdc.GetVAppByName(rs.Primary.Attributes["vapp_name"], false)
 		if err != nil {
 			return err
 		}
 
-		vm, err := vdc.FindVMByName(vapp, rs.Primary.Attributes["name"])
+		vm, err := vapp.GetVMByName(rs.Primary.Attributes["name"], false)
 
 		if err != nil {
 			return err

--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/vmware/go-vcloud-director/v2/govcd"
 )
 
 // To execute this test, run
@@ -16,8 +15,6 @@ import (
 // Extends TestAccVcdVappVM with multiple VMs
 func TestAccVcdVAppVmMulti(t *testing.T) {
 	var (
-		vapp              govcd.VApp
-		vm                govcd.VM
 		diskResourceNameM string = "TestAccVcdVAppVmMulti"
 		vappName2         string = "TestAccVcdVAppVmVappM"
 		diskName          string = "TestAccVcdIndependentDiskMulti"
@@ -60,7 +57,7 @@ func TestAccVcdVAppVmMulti(t *testing.T) {
 			resource.TestStep{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVcdVAppVmMultiExists("vcd_vapp_vm."+vmName1, &vapp, &vm, vappName2, vmName1),
+					testAccCheckVcdVAppVmMultiExists("vcd_vapp_vm."+vmName1, vappName2, vmName1),
 					resource.TestCheckResourceAttr(
 						"vcd_vapp_vm."+vmName1, "name", vmName1),
 					resource.TestCheckResourceAttr(
@@ -73,7 +70,7 @@ func TestAccVcdVAppVmMulti(t *testing.T) {
 	})
 }
 
-func testAccCheckVcdVAppVmMultiExists(n string, vapp *govcd.VApp, vm *govcd.VM, vappName, vmName string) resource.TestCheckFunc {
+func testAccCheckVcdVAppVmMultiExists(n string, vappName, vmName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -95,12 +92,10 @@ func testAccCheckVcdVAppVmMultiExists(n string, vapp *govcd.VApp, vm *govcd.VM, 
 			return err
 		}
 
-		newVm, err := vapp.GetVMByName(vmName, false)
+		_, err = vapp.GetVMByName(vmName, false)
 		if err != nil {
 			return err
 		}
-
-		*vm = *newVm
 
 		return nil
 	}

--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -90,17 +90,17 @@ func testAccCheckVcdVAppVmMultiExists(n string, vapp *govcd.VApp, vm *govcd.VM, 
 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
 		}
 
-		vapp, err := vdc.FindVAppByName(vappName)
+		vapp, err := vdc.GetVAppByName(vappName, false)
 		if err != nil {
 			return err
 		}
 
-		resp, err := vdc.FindVMByName(vapp, vmName)
+		newVm, err := vapp.GetVMByName(vmName, false)
 		if err != nil {
 			return err
 		}
 
-		*vm = resp
+		*vm = *newVm
 
 		return nil
 	}
@@ -118,7 +118,7 @@ func testAccCheckVcdVAppVmMultiDestroy(s *terraform.State) error {
 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
 		}
 
-		_, err = vdc.FindVAppByName(vappName2)
+		_, err = vdc.GetVAppByName(vappName2, false)
 
 		if err == nil {
 			return fmt.Errorf("VPCs still exist")


### PR DESCRIPTION
* Replace FindVAppByName with GetVAppByName or GetVAppByNameOrId as needed.
* Replace vdc.FindVMByName with vapp.GetVMByName
* Replace FindVMByHREF with GetVMByHref