### PR TITLE
Expanded EdgeGateway resource and data source to include network info of the uplink interface(s).

### DIFF
--- a/vcd/datasource_vcd_edgegateway.go
+++ b/vcd/datasource_vcd_edgegateway.go
@@ -46,6 +46,30 @@ func datasourceVcdEdgeGateway() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"external_networks_ip": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "A list of IP addresses for each external network interface.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"external_networks_netmask": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "A list of netmasks for each external network interface.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"external_networks_gateway": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "A list of gateways for each external network interface.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"default_gateway_network": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/vcd/resource_vcd_edgegateway.go
+++ b/vcd/resource_vcd_edgegateway.go
@@ -72,6 +72,30 @@ func resourceVcdEdgeGateway() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"external_networks_ip": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:	 true,
+				Description: "A list of IP addresses for each external network interface.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"external_networks_netmask": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:	 true,
+				Description: "A list of netmasks for each external network interface.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"external_networks_gateway": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:	 true,
+				Description: "A list of gateways for each external network interface.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"default_gateway_network": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -322,13 +346,31 @@ func setEdgeGatewayValues(d *schema.ResourceData, egw govcd.EdgeGateway) error {
 	}
 	var gateways = make(map[string]string)
 	var networks []string
+	var networks_ips []string
+	var networks_netmasks []string
+	var networks_gateways []string
 	for _, net := range egw.EdgeGateway.Configuration.GatewayInterfaces.GatewayInterface {
 		if net.InterfaceType == "uplink" {
 			networks = append(networks, net.Network.Name)
+			networks_ips = append(networks_ips, net.SubnetParticipation.IPAddress)
+			networks_netmasks = append(networks_netmasks, net.SubnetParticipation.Netmask)
+			networks_gateways = append(networks_gateways, net.SubnetParticipation.Gateway)
 			gateways[net.SubnetParticipation.Gateway] = net.Network.Name
 		}
 	}
 	err = d.Set("external_networks", networks)
+	if err != nil {
+		return err
+	}
+	err = d.Set("external_networks_ip", networks_ips)
+	if err != nil {
+		return err
+	}
+	err = d.Set("external_networks_netmask", networks_netmasks)
+	if err != nil {
+		return err
+	}
+	err = d.Set("external_networks_gateway", networks_gateways)
 	if err != nil {
 		return err
 	}

--- a/website/docs/d/edgegateway.html.markdown
+++ b/website/docs/d/edgegateway.html.markdown
@@ -21,20 +21,21 @@ data "vcd_edgegateway" "mygw" {
     org  = "myorg"
     vdc  = "myvdc"
 }
+
+# Get the index of our network from the external_networks list of the data source
 locals {
     network_index = index(data.vcd_edgegateway.mygw.external_networks, "My External Network Name")
 }
+
+# Use the index to find the corresponding element from external_networks_ip, external_networks_netmask, external_networks_gateway.
 output "ip_address" {
   value = element(data.vcd_edgegateway.mygw.external_networks_ip, local.network_index)
-  depends_on = [data.vcd_edgegateway.mygw]
 }
 output "netmask" {
   value = element(data.vcd_edgegateway.mygw.external_networks_netmask, local.network_index)
-  depends_on = [data.vcd_edgegateway.mygw]
 }
 output "gateway" {
   value = element(data.vcd_edgegateway.mygw.external_networks_gateway, local.network_index)
-  depends_on = [data.vcd_edgegateway.mygw]
 }
 ```
 

--- a/website/docs/d/edgegateway.html.markdown
+++ b/website/docs/d/edgegateway.html.markdown
@@ -13,37 +13,28 @@ edge gateways for Org VDC networks to connect.
 
 Supported in provider *v2.5+*
 
-## Example Usage
+## Example Usages
 
 ```hcl
 data "vcd_edgegateway" "mygw" {
-  name = "mygw"
-  org  = "myorg"
-  vdc  = "myvdc"
+    name = "mygw"
+    org  = "myorg"
+    vdc  = "myvdc"
 }
-
-output "external_network" {
-  value = data.vcd_edgegateway.mygw.default_gateway_network
+locals {
+    network_index = index(data.vcd_edgegateway.mygw.external_networks, "My External Network Name")
 }
-
-# Get the name of the default gateway from the data source
-# and use it to establish a second data source
-data "vcd_external_network" "external_network1" {
-  name = "${data.vcd_edgegateway.mygw.default_gateway_network}"
-}
-
-# From the second data source we extract the basic networking info
-output "gateway" {
-  value = data.vcd_external_network.external_network1.ip_scope.0.gateway
+output "ip_address" {
+  value = element(data.vcd_edgegateway.mygw.external_networks_ip, local.network_index)
+  depends_on = [data.vcd_edgegateway.mygw]
 }
 output "netmask" {
-  value = data.vcd_external_network.external_network1.ip_scope.0.netmask
+  value = element(data.vcd_edgegateway.mygw.external_networks_netmask, local.network_index)
+  depends_on = [data.vcd_edgegateway.mygw]
 }
-output "DNS" {
-  value = data.vcd_external_network.external_network1.ip_scope.0.dns1
-}
-output "external_ip" {
-  value = data.vcd_external_network.external_network1.ip_scope.0.static_ip_pool.0.start_address
+output "gateway" {
+  value = element(data.vcd_edgegateway.mygw.external_networks_gateway, local.network_index)
+  depends_on = [data.vcd_edgegateway.mygw]
 }
 ```
 

--- a/website/docs/d/edgegateway.html.markdown
+++ b/website/docs/d/edgegateway.html.markdown
@@ -13,7 +13,7 @@ edge gateways for Org VDC networks to connect.
 
 Supported in provider *v2.5+*
 
-## Example Usages
+## Example Usage
 
 ```hcl
 data "vcd_edgegateway" "mygw" {

--- a/website/docs/d/edgegateway.html.markdown
+++ b/website/docs/d/edgegateway.html.markdown
@@ -17,9 +17,9 @@ Supported in provider *v2.5+*
 
 ```hcl
 data "vcd_edgegateway" "mygw" {
-    name = "mygw"
-    org  = "myorg"
-    vdc  = "myvdc"
+  name = "mygw"
+  org  = "myorg"
+  vdc  = "myvdc"
 }
 
 # Get the index of our network from the external_networks list of the data source


### PR DESCRIPTION
- Added extra XML elements to Edge Gateway to provide ip, netmask and gateway for external_network interfaces. These list elements are named external_networks_ip, external_networks_netmask, external_networks_gateway.
- Replaced data source example usage to reflect changes.

Fixes #351 