### PR TITLE
Add dynamic separator for terraform import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ IMPROVEMENTS:
 * `vcd_org_vdc` Add import capability and full read support [#218]
 * Upgrade Terraform SDK dependency to 0.12.8 [#320]
 * `resource/vcd_vapp_vm` has new field `computer_name` [#334]
+* Import functions can now use custom separators instead of "." [#343]
 
 BUG FIXES:
 * Change default value for `vcd_org.deployed_vm_quota` and `vcd_org.stored_vm_quota`. It was incorrectly set at `-1` instead of `0`.

--- a/vcd/config.go
+++ b/vcd/config.go
@@ -78,8 +78,9 @@ var (
 	// Invalidates the cache after a given time (connection tokens usually expire after 20 to 30 minutes)
 	maxConnectionValidity time.Duration = 20 * time.Minute
 
-	enableDebug bool = os.Getenv("GOVCD_DEBUG") != ""
-	enableTrace bool = os.Getenv("GOVCD_TRACE") != ""
+	enableDebug           bool = os.Getenv("GOVCD_DEBUG") != ""
+	enableTrace           bool = os.Getenv("GOVCD_TRACE") != ""
+	ImportSeparationToken      = "."
 )
 
 // Displays conditional messages
@@ -359,4 +360,11 @@ func callFuncName() string {
 		}
 	}
 	return ""
+}
+
+func init() {
+	separator := os.Getenv("VCD_IMPORT_SEPARATOR")
+	if separator != "" {
+		ImportSeparationToken = separator
+	}
 }

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -725,7 +725,9 @@ func importStateIdOrgObject(vcd TestConfig, objectName string) resource.ImportSt
 		if testConfig.VCD.Org == "" || objectName == "" {
 			return "", fmt.Errorf("missing information to generate import path")
 		}
-		return testConfig.VCD.Org + "." + objectName, nil
+		return testConfig.VCD.Org +
+			ImportSeparationToken +
+			objectName, nil
 	}
 }
 
@@ -735,6 +737,56 @@ func importStateIdOrgVdcObject(vcd TestConfig, objectName string) resource.Impor
 		if testConfig.VCD.Org == "" || testConfig.VCD.Vdc == "" || objectName == "" {
 			return "", fmt.Errorf("missing information to generate import path")
 		}
-		return testConfig.VCD.Org + "." + testConfig.VCD.Vdc + "." + objectName, nil
+		return testConfig.VCD.Org +
+			ImportSeparationToken +
+			testConfig.VCD.Vdc +
+			ImportSeparationToken +
+			objectName, nil
+	}
+}
+
+// Used by all entities that depend on Org + Catalog (such as catalog item, media item)
+func importStateIdOrgCatalogObject(vcd TestConfig, objectName string) resource.ImportStateIdFunc {
+	return func(*terraform.State) (string, error) {
+		if testConfig.VCD.Org == "" || testConfig.VCD.Catalog.Name == "" || objectName == "" {
+			return "", fmt.Errorf("missing information to generate import path")
+		}
+		return testConfig.VCD.Org +
+			ImportSeparationToken +
+			testConfig.VCD.Catalog.Name +
+			ImportSeparationToken +
+			objectName, nil
+	}
+}
+
+// Used by all entities that depend on Org + VDC + vApp (such as VM, vapp networks)
+func importStateIdVappObject(vcd TestConfig, vappName, objectName string) resource.ImportStateIdFunc {
+	return func(*terraform.State) (string, error) {
+		if testConfig.VCD.Org == "" || testConfig.VCD.Vdc == "" || vappName == "" || objectName == "" {
+			return "", fmt.Errorf("missing information to generate import path")
+		}
+		return testConfig.VCD.Org +
+			ImportSeparationToken +
+			testConfig.VCD.Vdc +
+			ImportSeparationToken +
+			vappName +
+			ImportSeparationToken +
+			objectName, nil
+	}
+}
+
+// Used by all entities that depend on Org + VDC + edge gateway (such as FW, LB, NAT)
+func importStateIdEdgeGatewayObject(vcd TestConfig, edgeGatewayName, objectName string) resource.ImportStateIdFunc {
+	return func(*terraform.State) (string, error) {
+		if testConfig.VCD.Org == "" || testConfig.VCD.Vdc == "" || edgeGatewayName == "" || objectName == "" {
+			return "", fmt.Errorf("missing information to generate import path")
+		}
+		return testConfig.VCD.Org +
+			ImportSeparationToken +
+			testConfig.VCD.Vdc +
+			ImportSeparationToken +
+			edgeGatewayName +
+			ImportSeparationToken +
+			objectName, nil
 	}
 }

--- a/vcd/datasource_vcd_catalog_item_test.go
+++ b/vcd/datasource_vcd_catalog_item_test.go
@@ -67,7 +67,7 @@ func TestAccVcdCatalogAndItemDatasource(t *testing.T) {
 				ResourceName:      "vcd_catalog_item." + TestCatalogItemDS + "-import",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: importStateIdByCatalogItem(TestCatalogItemDS),
+				ImportStateIdFunc: importStateIdOrgCatalogObject(testConfig, TestCatalogItemDS),
 				// These fields can't be retrieved from catalog item data
 				ImportStateVerifyIgnore: []string{"ova_path", "upload_piece_size", "show_upload_progress"},
 			},
@@ -91,16 +91,6 @@ func catalogItemDestroyed(catalog, itemName string) resource.TestCheckFunc {
 			return fmt.Errorf("catalog item %s not deleted", itemName)
 		}
 		return nil
-	}
-}
-
-func importStateIdByCatalogItem(objectName string) resource.ImportStateIdFunc {
-	return func(*terraform.State) (string, error) {
-		importId := testConfig.VCD.Org + "." + testConfig.VCD.Catalog.Name + "." + objectName
-		if testConfig.VCD.Org == "" || testConfig.VCD.Catalog.Name == "" || objectName == "" {
-			return "", fmt.Errorf("missing information to generate import path: %s", importId)
-		}
-		return importId, nil
 	}
 }
 

--- a/vcd/nsxv_nat.go
+++ b/vcd/nsxv_nat.go
@@ -143,7 +143,7 @@ func natRuleDelete(natType string) schema.DeleteFunc {
 // natRuleImporter returns a schema.StateFunc for both SNAT and DNAT rules
 func natRuleImport(natType string) schema.StateFunc {
 	return func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-		resourceURI := strings.Split(d.Id(), ".")
+		resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 		if len(resourceURI) != 4 {
 			return nil, fmt.Errorf("resource name must be specified in such way org.vdc.edge-gw.rule-id")
 		}

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -1,6 +1,8 @@
 package vcd
 
 import (
+	"os"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/vmware/go-vcloud-director/v2/util"
@@ -79,6 +81,12 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_API_LOGGING_FILE", "go-vcloud-director.log"),
 				Description: "Defines the full name of the logging file for API calls (requires 'logging')",
+			},
+			"import_separation_token": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("VCD_IMPORT_SEPARATOR", "."),
+				Description: "Defines the import separation string to be used with 'terraform import'",
 			},
 		},
 
@@ -168,6 +176,13 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			util.ApiLogFileName = loggingFile
 			util.InitLogging()
 		}
+	}
+
+	separator := os.Getenv("VCD_IMPORT_SEPARATOR")
+	if separator != "" {
+		ImportSeparationToken = separator
+	} else {
+		ImportSeparationToken = d.Get("import_separation_token").(string)
 	}
 
 	return config.Client()

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -82,7 +82,7 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("VCD_API_LOGGING_FILE", "go-vcloud-director.log"),
 				Description: "Defines the full name of the logging file for API calls (requires 'logging')",
 			},
-			"import_separation_token": &schema.Schema{
+			"import_separator": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_IMPORT_SEPARATOR", "."),
@@ -182,7 +182,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if separator != "" {
 		ImportSeparationToken = separator
 	} else {
-		ImportSeparationToken = d.Get("import_separation_token").(string)
+		ImportSeparationToken = d.Get("import_separator").(string)
 	}
 
 	return config.Client()

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -136,8 +136,9 @@ func resourceVcdCatalogDelete(d *schema.ResourceData, meta interface{}) error {
 // Expects the d.ID() to be a path to the resource made of org_name.catalog_name
 //
 // Example import path (id): org_name.catalog_name
+// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
 func resourceVcdCatalogImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	resourceURI := strings.Split(d.Id(), ".")
+	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 2 {
 		return nil, fmt.Errorf("resource name must be specified as org.catalog")
 	}

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -136,7 +136,7 @@ func resourceVcdCatalogDelete(d *schema.ResourceData, meta interface{}) error {
 // Expects the d.ID() to be a path to the resource made of org_name.catalog_name
 //
 // Example import path (id): org_name.catalog_name
-// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+// Note: the separator can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 func resourceVcdCatalogImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 2 {

--- a/vcd/resource_vcd_catalog_item.go
+++ b/vcd/resource_vcd_catalog_item.go
@@ -247,8 +247,9 @@ func createOrUpdateCatalogItemMetadata(d *schema.ResourceData, meta interface{})
 // Expects the d.ID() to be a path to the resource made of org_name.catalog_name.catalog_item_name
 //
 // Example import path (id): org_name.catalog_name.catalog_item_name
+// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
 func resourceVcdCatalogItemImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	resourceURI := strings.Split(d.Id(), ".")
+	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 3 {
 		return nil, fmt.Errorf("resource name must be specified as org.catalog.catalog_item")
 	}

--- a/vcd/resource_vcd_catalog_item.go
+++ b/vcd/resource_vcd_catalog_item.go
@@ -247,7 +247,7 @@ func createOrUpdateCatalogItemMetadata(d *schema.ResourceData, meta interface{})
 // Expects the d.ID() to be a path to the resource made of org_name.catalog_name.catalog_item_name
 //
 // Example import path (id): org_name.catalog_name.catalog_item_name
-// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+// Note: the separator can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 func resourceVcdCatalogItemImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 3 {

--- a/vcd/resource_vcd_edgegateway.go
+++ b/vcd/resource_vcd_edgegateway.go
@@ -404,7 +404,7 @@ func updateLoadBalancer(d *schema.ResourceData, egw govcd.EdgeGateway) error {
 //
 // Example resource name (_resource_name_): vcd_edgegateway.my-edge-gateway
 // Example import path (_the_id_string_): org.vdc.my-edge-gw
-// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+// Note: the separator can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 func resourceVcdEdgeGatewayImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 3 {

--- a/vcd/resource_vcd_edgegateway.go
+++ b/vcd/resource_vcd_edgegateway.go
@@ -404,8 +404,9 @@ func updateLoadBalancer(d *schema.ResourceData, egw govcd.EdgeGateway) error {
 //
 // Example resource name (_resource_name_): vcd_edgegateway.my-edge-gateway
 // Example import path (_the_id_string_): org.vdc.my-edge-gw
+// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
 func resourceVcdEdgeGatewayImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	resourceURI := strings.Split(d.Id(), ".")
+	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 3 {
 		return nil, fmt.Errorf("resource name must be specified as org-name.vdc-name.edge-gw-name")
 	}

--- a/vcd/resource_vcd_lb_app_profile.go
+++ b/vcd/resource_vcd_lb_app_profile.go
@@ -210,7 +210,7 @@ func resourceVcdLBAppProfileDelete(d *schema.ResourceData, meta interface{}) err
 // `terraform import` automatically performs `refresh` operation which loads up all other fields.
 //
 // Example import path (id): org.vdc.edge-gw.existing-app-profile
-// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+// Note: the separator can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 func resourceVcdLBAppProfileImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 4 {

--- a/vcd/resource_vcd_lb_app_profile.go
+++ b/vcd/resource_vcd_lb_app_profile.go
@@ -210,8 +210,9 @@ func resourceVcdLBAppProfileDelete(d *schema.ResourceData, meta interface{}) err
 // `terraform import` automatically performs `refresh` operation which loads up all other fields.
 //
 // Example import path (id): org.vdc.edge-gw.existing-app-profile
+// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
 func resourceVcdLBAppProfileImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	resourceURI := strings.Split(d.Id(), ".")
+	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 4 {
 		return nil, fmt.Errorf("resource name must be specified in such way org.vdc.edge-gw.existing-app-profile")
 	}

--- a/vcd/resource_vcd_lb_app_rule.go
+++ b/vcd/resource_vcd_lb_app_rule.go
@@ -157,8 +157,9 @@ func resourceVcdLBAppRuleDelete(d *schema.ResourceData, meta interface{}) error 
 //
 // Example resource name (_resource_name_): vcd_lb_app_rule.my-test-app-rule
 // Example import path (_the_id_string_): org.vdc.edge-gw.existing-app-rule
+// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
 func resourceVcdLBAppRuleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	resourceURI := strings.Split(d.Id(), ".")
+	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 4 {
 		return nil, fmt.Errorf("resource name must be specified in such way org.vdc.edge-gw.existing-app-rule")
 	}

--- a/vcd/resource_vcd_lb_app_rule.go
+++ b/vcd/resource_vcd_lb_app_rule.go
@@ -157,7 +157,7 @@ func resourceVcdLBAppRuleDelete(d *schema.ResourceData, meta interface{}) error 
 //
 // Example resource name (_resource_name_): vcd_lb_app_rule.my-test-app-rule
 // Example import path (_the_id_string_): org.vdc.edge-gw.existing-app-rule
-// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+// Note: the separator can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 func resourceVcdLBAppRuleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 4 {

--- a/vcd/resource_vcd_lb_server_pool.go
+++ b/vcd/resource_vcd_lb_server_pool.go
@@ -233,7 +233,7 @@ func resourceVcdLBServerPoolDelete(d *schema.ResourceData, meta interface{}) err
 // `terraform import` automatically performs `refresh` operation which loads up all other fields.
 //
 // Example import path (id): org.vdc.edge-gw.lb-server-pool
-// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+// Note: the separator can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 func resourceVcdLBServerPoolImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 4 {

--- a/vcd/resource_vcd_lb_server_pool.go
+++ b/vcd/resource_vcd_lb_server_pool.go
@@ -233,8 +233,9 @@ func resourceVcdLBServerPoolDelete(d *schema.ResourceData, meta interface{}) err
 // `terraform import` automatically performs `refresh` operation which loads up all other fields.
 //
 // Example import path (id): org.vdc.edge-gw.lb-server-pool
+// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
 func resourceVcdLBServerPoolImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	resourceURI := strings.Split(d.Id(), ".")
+	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 4 {
 		return nil, fmt.Errorf("resource name must be specified as org.vdc.edge-gw.lb-server-pool")
 	}

--- a/vcd/resource_vcd_lb_service_monitor.go
+++ b/vcd/resource_vcd_lb_service_monitor.go
@@ -220,7 +220,7 @@ func resourceVcdLbServiceMonitorDelete(d *schema.ResourceData, meta interface{})
 // `terraform import` automatically performs `refresh` operation which loads up all other fields.
 //
 // Example import path (id): org.vdc.edge-gw.lb-service-monitor
-// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+// Note: the separator can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 func resourceVcdLbServiceMonitorImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 
 	resourceURI := strings.Split(d.Id(), ImportSeparationToken)

--- a/vcd/resource_vcd_lb_service_monitor.go
+++ b/vcd/resource_vcd_lb_service_monitor.go
@@ -220,9 +220,10 @@ func resourceVcdLbServiceMonitorDelete(d *schema.ResourceData, meta interface{})
 // `terraform import` automatically performs `refresh` operation which loads up all other fields.
 //
 // Example import path (id): org.vdc.edge-gw.lb-service-monitor
+// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
 func resourceVcdLbServiceMonitorImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 
-	resourceURI := strings.Split(d.Id(), ".")
+	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 4 {
 		return nil, fmt.Errorf("resource name must be specified as org.vdc.edge-gw.lb-service-monitor")
 	}

--- a/vcd/resource_vcd_lb_virtual_server.go
+++ b/vcd/resource_vcd_lb_virtual_server.go
@@ -206,7 +206,7 @@ func resourceVcdLBVirtualServerDelete(d *schema.ResourceData, meta interface{}) 
 //
 // Example resource name (_resource_name_): vcd_lb_virtual_server.my-test-virtual-server
 // Example import path (_the_id_string_): org.vdc.edge-gw.existing-virtual-server
-// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+// Note: the separator can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 func resourceVcdLBVirtualServerImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 4 {

--- a/vcd/resource_vcd_lb_virtual_server.go
+++ b/vcd/resource_vcd_lb_virtual_server.go
@@ -206,8 +206,9 @@ func resourceVcdLBVirtualServerDelete(d *schema.ResourceData, meta interface{}) 
 //
 // Example resource name (_resource_name_): vcd_lb_virtual_server.my-test-virtual-server
 // Example import path (_the_id_string_): org.vdc.edge-gw.existing-virtual-server
+// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
 func resourceVcdLBVirtualServerImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	resourceURI := strings.Split(d.Id(), ".")
+	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 4 {
 		return nil, fmt.Errorf("resource name must be specified as org.vdc.edge-gw.lb-virtual-server")
 	}

--- a/vcd/resource_vcd_network_direct.go
+++ b/vcd/resource_vcd_network_direct.go
@@ -198,7 +198,7 @@ func genericVcdNetworkDirectRead(d *schema.ResourceData, meta interface{}, origi
 //
 // Example resource name (_resource_name_): vcd_network_direct.my-network
 // Example import path (_the_id_string_): org.vdc.my-network
-// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+// Note: the separator can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 func resourceVcdNetworkDirectImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 3 {

--- a/vcd/resource_vcd_network_direct.go
+++ b/vcd/resource_vcd_network_direct.go
@@ -198,8 +198,9 @@ func genericVcdNetworkDirectRead(d *schema.ResourceData, meta interface{}, origi
 //
 // Example resource name (_resource_name_): vcd_network_direct.my-network
 // Example import path (_the_id_string_): org.vdc.my-network
+// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
 func resourceVcdNetworkDirectImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	resourceURI := strings.Split(d.Id(), ".")
+	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 3 {
 		return nil, fmt.Errorf("[network direct import] resource name must be specified as org-name.vdc-name.network-name")
 	}

--- a/vcd/resource_vcd_network_isolated.go
+++ b/vcd/resource_vcd_network_isolated.go
@@ -340,7 +340,7 @@ func getDhcpPool(network *govcd.OrgVDCNetwork) []map[string]interface{} {
 //
 // Example resource name (_resource_name_): vcd_network_isolated.my-network
 // Example import path (_the_id_string_): org.vdc.my-network
-// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+// Note: the separator can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 func resourceVcdNetworkIsolatedImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 3 {

--- a/vcd/resource_vcd_network_isolated.go
+++ b/vcd/resource_vcd_network_isolated.go
@@ -340,8 +340,9 @@ func getDhcpPool(network *govcd.OrgVDCNetwork) []map[string]interface{} {
 //
 // Example resource name (_resource_name_): vcd_network_isolated.my-network
 // Example import path (_the_id_string_): org.vdc.my-network
+// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
 func resourceVcdNetworkIsolatedImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	resourceURI := strings.Split(d.Id(), ".")
+	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 3 {
 		return nil, fmt.Errorf("[network isolated import] resource name must be specified as org-name.vdc-name.network-name")
 	}

--- a/vcd/resource_vcd_network_routed.go
+++ b/vcd/resource_vcd_network_routed.go
@@ -482,8 +482,9 @@ func findEdgeGatewayConnection(client *VCDClient, vdc *govcd.Vdc, network *govcd
 //
 // Example resource name (_resource_name_): vcd_network_routed.my-network
 // Example import path (_the_id_string_): org.vdc.my-network
+// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
 func resourceVcdNetworkRoutedImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	resourceURI := strings.Split(d.Id(), ".")
+	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 3 {
 		return nil, fmt.Errorf("[network routed import] resource name must be specified as org-name.vdc-name.network-name")
 	}

--- a/vcd/resource_vcd_network_routed.go
+++ b/vcd/resource_vcd_network_routed.go
@@ -482,7 +482,7 @@ func findEdgeGatewayConnection(client *VCDClient, vdc *govcd.Vdc, network *govcd
 //
 // Example resource name (_resource_name_): vcd_network_routed.my-network
 // Example import path (_the_id_string_): org.vdc.my-network
-// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+// Note: the separator can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 func resourceVcdNetworkRoutedImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 3 {

--- a/vcd/resource_vcd_nsxv_dnat_test.go
+++ b/vcd/resource_vcd_nsxv_dnat_test.go
@@ -176,7 +176,10 @@ func importStateIdByResourceName(resource string) resource.ImportStateIdFunc {
 			return "", fmt.Errorf("no ID is set for %s resource", resource)
 		}
 
-		importId := testConfig.VCD.Org + "." + testConfig.VCD.Vdc + "." + testConfig.Networking.EdgeGateway + "." + rs.Primary.ID
+		importId := testConfig.VCD.Org +
+			ImportSeparationToken + testConfig.VCD.Vdc +
+			ImportSeparationToken + testConfig.Networking.EdgeGateway +
+			ImportSeparationToken + rs.Primary.ID
 		if testConfig.VCD.Org == "" || testConfig.VCD.Vdc == "" || testConfig.Networking.EdgeGateway == "" || rs.Primary.ID == "" {
 			return "", fmt.Errorf("missing information to generate import path: %s", importId)
 		}

--- a/vcd/resource_vcd_org_user.go
+++ b/vcd/resource_vcd_org_user.go
@@ -303,8 +303,9 @@ func resourceVcdOrgUserUpdate(d *schema.ResourceData, meta interface{}) error {
 // Expects the d.ID() to be a path to the resource made of Org name + dot + OrgUser name
 //
 // Example import path (id): my-org.my-user-admin
+// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
 func resourceVcdOrgUserImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	resourceURI := strings.Split(d.Id(), ".")
+	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 2 {
 		return nil, fmt.Errorf("resource name must be specified as org.org_user")
 	}

--- a/vcd/resource_vcd_org_user.go
+++ b/vcd/resource_vcd_org_user.go
@@ -303,7 +303,7 @@ func resourceVcdOrgUserUpdate(d *schema.ResourceData, meta interface{}) error {
 // Expects the d.ID() to be a path to the resource made of Org name + dot + OrgUser name
 //
 // Example import path (id): my-org.my-user-admin
-// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+// Note: the separator can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 func resourceVcdOrgUserImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 2 {

--- a/vcd/resource_vcd_org_vdc.go
+++ b/vcd/resource_vcd_org_vdc.go
@@ -849,8 +849,9 @@ func getStorageProfileHREF(vcdClient *VCDClient, name string) (string, error) {
 //
 // Example resource name (_resource_name_): vcd_org_vdc.my_existing_vdc
 // Example import path (_the_id_string_): org.my_existing_vdc
+// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
 func resourceVcdOrgVdcImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	resourceURI := strings.Split(d.Id(), ".")
+	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 2 {
 		return nil, fmt.Errorf("resource name must be specified as org.my_existing_vdc")
 	}

--- a/vcd/resource_vcd_org_vdc.go
+++ b/vcd/resource_vcd_org_vdc.go
@@ -849,7 +849,7 @@ func getStorageProfileHREF(vcdClient *VCDClient, name string) (string, error) {
 //
 // Example resource name (_resource_name_): vcd_org_vdc.my_existing_vdc
 // Example import path (_the_id_string_): org.my_existing_vdc
-// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+// Note: the separator can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 func resourceVcdOrgVdcImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 2 {

--- a/vcd/resource_vcd_org_vdc_test.go
+++ b/vcd/resource_vcd_org_vdc_test.go
@@ -249,22 +249,12 @@ func runOrgVdcTest(t *testing.T, params StringMap, allocationModel string) {
 				ResourceName:      "vcd_org_vdc." + TestAccVcdVdc,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: importStateIdByVdc(TestAccVcdVdc),
+				ImportStateIdFunc: importStateIdOrgObject(testConfig, TestAccVcdVdc),
 				// These fields can't be retrieved
 				ImportStateVerifyIgnore: []string{"delete_force", "delete_recursive"},
 			},
 		},
 	})
-}
-
-func importStateIdByVdc(objectName string) resource.ImportStateIdFunc {
-	return func(*terraform.State) (string, error) {
-		importId := testConfig.VCD.Org + "." + objectName
-		if testConfig.VCD.Org == "" || objectName == "" {
-			return "", fmt.Errorf("missing information to generate import path: %s", importId)
-		}
-		return importId, nil
-	}
 }
 
 func testAccCheckVcdVdcExists(name string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -687,7 +687,7 @@ func tryUndeploy(vapp govcd.VApp) error {
 // Example resource name (_resource_name_): vcd_vapp.vapp_name
 // Example import path (_the_id_string_): org-name.vdc-name.vapp-name
 func resourceVcdVappImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	resourceURI := strings.Split(d.Id(), ".")
+	resourceURI := strings.Split(d.Id(), ImportSeparationToken)
 	if len(resourceURI) != 3 {
 		return nil, fmt.Errorf("[vapp import] resource name must be specified as org-name.vdc-name.vapp-name")
 	}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -164,7 +164,7 @@ The following arguments are used to configure the VMware vCloud Director Provide
 * `logging_file` - (Optional; *v2.0+*) The name of the log file (when `logging` is enabled). By default is 
   `go-vcloud-director` and it can also be changed using the `VCD_API_LOGGING_FILE` environment variable.
   
-* `import_separation_token` - (Optional; *v2.5+*) The string to be used as separator with `terraform import`. By default
+* `import_separator` - (Optional; *v2.5+*) The string to be used as separator with `terraform import`. By default
   it is a dot (`.`).
 
 ## Connection Cache (*2.0+*)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -163,6 +163,9 @@ The following arguments are used to configure the VMware vCloud Director Provide
 
 * `logging_file` - (Optional; *v2.0+*) The name of the log file (when `logging` is enabled). By default is 
   `go-vcloud-director` and it can also be changed using the `VCD_API_LOGGING_FILE` environment variable.
+  
+* `import_separation_token` - (Optional; *v2.5+*) The string to be used as separator with `terraform import`. By default
+  it is a dot (`.`).
 
 ## Connection Cache (*2.0+*)
 

--- a/website/docs/r/catalog.html.markdown
+++ b/website/docs/r/catalog.html.markdown
@@ -58,7 +58,7 @@ You can import such catalog into terraform state using this command
 terraform import vcd_catalog.my-catalog my-org.my-catalog
 ```
 
-NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+NOTE: the default separator (.) can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 
 [docs-import]:https://www.terraform.io/docs/import/
 

--- a/website/docs/r/catalog.html.markdown
+++ b/website/docs/r/catalog.html.markdown
@@ -58,6 +58,8 @@ You can import such catalog into terraform state using this command
 terraform import vcd_catalog.my-catalog my-org.my-catalog
 ```
 
+NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+
 [docs-import]:https://www.terraform.io/docs/import/
 
 After that, you can expand the configuration file and either update or delete the catalog as needed. Running `terraform plan`

--- a/website/docs/r/catalog_item.html.markdown
+++ b/website/docs/r/catalog_item.html.markdown
@@ -69,7 +69,7 @@ You can import such catalog item into terraform state using this command
 terraform import vcd_catalog_item.my-item my-org.my-catalog.my-item
 ```
 
-NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+NOTE: the default separator (.) can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 
 [docs-import]:https://www.terraform.io/docs/import/
 

--- a/website/docs/r/catalog_item.html.markdown
+++ b/website/docs/r/catalog_item.html.markdown
@@ -69,6 +69,8 @@ You can import such catalog item into terraform state using this command
 terraform import vcd_catalog_item.my-item my-org.my-catalog.my-item
 ```
 
+NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+
 [docs-import]:https://www.terraform.io/docs/import/
 
 After that, you can expand the configuration file and either update or delete the catalog item as needed. Running `terraform plan`

--- a/website/docs/r/edgegateway.html.markdown
+++ b/website/docs/r/edgegateway.html.markdown
@@ -105,7 +105,7 @@ You can import such edge gateway into terraform state using this command
 ```
 terraform import vcd_edgegateway.tf-edgegateway my-org.my-vdc.my-edge-gw
 ```
-// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+// Note: the separator can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 
 [docs-import]:https://www.terraform.io/docs/import/
 

--- a/website/docs/r/edgegateway.html.markdown
+++ b/website/docs/r/edgegateway.html.markdown
@@ -105,6 +105,7 @@ You can import such edge gateway into terraform state using this command
 ```
 terraform import vcd_edgegateway.tf-edgegateway my-org.my-vdc.my-edge-gw
 ```
+// Note: the separator can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
 
 [docs-import]:https://www.terraform.io/docs/import/
 

--- a/website/docs/r/external_network.html.markdown
+++ b/website/docs/r/external_network.html.markdown
@@ -142,7 +142,7 @@ terraform import vcd_external_network.tf-external-network my-ext-net
 
 [docs-import]:https://www.terraform.io/docs/import/
 
-NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+NOTE: the default separator (.) can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 
 While the above structure is the minimum needed to get an import, it is not sufficient to run `terraform plan`,
 as it lacks several mandatory fields. To use the imported resource, you will need to add the missing properties

--- a/website/docs/r/external_network.html.markdown
+++ b/website/docs/r/external_network.html.markdown
@@ -142,6 +142,7 @@ terraform import vcd_external_network.tf-external-network my-ext-net
 
 [docs-import]:https://www.terraform.io/docs/import/
 
+NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
 
 While the above structure is the minimum needed to get an import, it is not sufficient to run `terraform plan`,
 as it lacks several mandatory fields. To use the imported resource, you will need to add the missing properties

--- a/website/docs/r/network_direct.html.markdown
+++ b/website/docs/r/network_direct.html.markdown
@@ -77,7 +77,7 @@ You can import such isolated network into terraform state using this command
 terraform import vcd_network_direct.tf-mynet my-org.my-vdc.my-net
 ```
 
-NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+NOTE: the default separator (.) can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 
 [docs-import]:https://www.terraform.io/docs/import/
 

--- a/website/docs/r/network_direct.html.markdown
+++ b/website/docs/r/network_direct.html.markdown
@@ -77,6 +77,8 @@ You can import such isolated network into terraform state using this command
 terraform import vcd_network_direct.tf-mynet my-org.my-vdc.my-net
 ```
 
+NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+
 [docs-import]:https://www.terraform.io/docs/import/
 
 After importing, if you run `terraform plan` you will see the rest of the values and modify the script accordingly for

--- a/website/docs/r/network_isolated.html.markdown
+++ b/website/docs/r/network_isolated.html.markdown
@@ -95,7 +95,7 @@ You can import such isolated network into terraform state using this command
 terraform import vcd_network_isolated.tf-mynet my-org.my-vdc.my-net
 ```
 
-NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+NOTE: the default separator (.) can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 
 [docs-import]:https://www.terraform.io/docs/import/
 

--- a/website/docs/r/network_isolated.html.markdown
+++ b/website/docs/r/network_isolated.html.markdown
@@ -95,6 +95,8 @@ You can import such isolated network into terraform state using this command
 terraform import vcd_network_isolated.tf-mynet my-org.my-vdc.my-net
 ```
 
+NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+
 [docs-import]:https://www.terraform.io/docs/import/
 
 After importing, if you run `terraform plan` you will see the rest of the values and modify the script accordingly for

--- a/website/docs/r/network_routed.html.markdown
+++ b/website/docs/r/network_routed.html.markdown
@@ -97,7 +97,7 @@ You can import such routed network into terraform state using this command
 terraform import vcd_network_routed.tf-mynet my-org.my-vdc.my-net
 ```
 
-NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+NOTE: the default separator (.) can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 
 [docs-import]:https://www.terraform.io/docs/import/
 

--- a/website/docs/r/network_routed.html.markdown
+++ b/website/docs/r/network_routed.html.markdown
@@ -97,6 +97,8 @@ You can import such routed network into terraform state using this command
 terraform import vcd_network_routed.tf-mynet my-org.my-vdc.my-net
 ```
 
+NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+
 [docs-import]:https://www.terraform.io/docs/import/
 
 After importing, if you run `terraform plan` you will see the rest of the values and modify the script accordingly for

--- a/website/docs/r/nsxv_dnat.html.markdown
+++ b/website/docs/r/nsxv_dnat.html.markdown
@@ -133,5 +133,7 @@ via supplying the full dot separated path for DNAT rule. An example is below:
 terraform import vcd_nsxv_dnat.imported my-org.my-org-vdc.my-edge-gw.my-dnat-rule-id
 ```
 
+NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+
 The above would import the application rule named `my-dnat-rule-id` that is defined on edge
 gateway `my-edge-gw` which is configured in organization named `my-org` and vDC named `my-org-vdc`.

--- a/website/docs/r/nsxv_dnat.html.markdown
+++ b/website/docs/r/nsxv_dnat.html.markdown
@@ -133,7 +133,7 @@ via supplying the full dot separated path for DNAT rule. An example is below:
 terraform import vcd_nsxv_dnat.imported my-org.my-org-vdc.my-edge-gw.my-dnat-rule-id
 ```
 
-NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+NOTE: the default separator (.) can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 
 The above would import the application rule named `my-dnat-rule-id` that is defined on edge
 gateway `my-edge-gw` which is configured in organization named `my-org` and vDC named `my-org-vdc`.

--- a/website/docs/r/nsxv_snat.html.markdown
+++ b/website/docs/r/nsxv_snat.html.markdown
@@ -77,5 +77,7 @@ via supplying the full dot separated path for SNAT rule. An example is below:
 terraform import vcd_nsxv_dnat.imported my-org.my-org-vdc.my-edge-gw.my-snat-rule-id
 ```
 
+NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+
 The above would import the application rule named `my-snat-rule-id` that is defined on edge
 gateway `my-edge-gw` which is configured in organization named `my-org` and vDC named `my-org-vdc`.

--- a/website/docs/r/nsxv_snat.html.markdown
+++ b/website/docs/r/nsxv_snat.html.markdown
@@ -77,7 +77,7 @@ via supplying the full dot separated path for SNAT rule. An example is below:
 terraform import vcd_nsxv_dnat.imported my-org.my-org-vdc.my-edge-gw.my-snat-rule-id
 ```
 
-NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+NOTE: the default separator (.) can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 
 The above would import the application rule named `my-snat-rule-id` that is defined on edge
 gateway `my-edge-gw` which is configured in organization named `my-org` and vDC named `my-org-vdc`.

--- a/website/docs/r/org_user.html.markdown
+++ b/website/docs/r/org_user.html.markdown
@@ -114,7 +114,7 @@ You can import such user into terraform state using this command
 terraform import vcd_org_user.my-org-admin my-org.my-org-admin
 ```
 
-NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+NOTE: the default separator (.) can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 
 [docs-import]:https://www.terraform.io/docs/import/
 

--- a/website/docs/r/org_user.html.markdown
+++ b/website/docs/r/org_user.html.markdown
@@ -114,6 +114,8 @@ You can import such user into terraform state using this command
 terraform import vcd_org_user.my-org-admin my-org.my-org-admin
 ```
 
+NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+
 [docs-import]:https://www.terraform.io/docs/import/
 
 The state (in `terraform.tfstate`) would look like this:

--- a/website/docs/r/org_vdc.html.markdown
+++ b/website/docs/r/org_vdc.html.markdown
@@ -121,6 +121,8 @@ below:
 terraform import vcd_org_vdc.my-vdc my-org.my-vdc
 ```
 
+NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+
 [docs-import]:https://www.terraform.io/docs/import/
 
 After that, you can expand the configuration file and either update or delete the VDC as needed. Running `terraform plan`

--- a/website/docs/r/org_vdc.html.markdown
+++ b/website/docs/r/org_vdc.html.markdown
@@ -121,7 +121,7 @@ below:
 terraform import vcd_org_vdc.my-vdc my-org.my-vdc
 ```
 
-NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+NOTE: the default separator (.) can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 
 [docs-import]:https://www.terraform.io/docs/import/
 

--- a/website/docs/r/vapp.html.markdown
+++ b/website/docs/r/vapp.html.markdown
@@ -181,6 +181,8 @@ You can import such vapp into terraform state using this command
 terraform import vcd_vapp.tf-vapp my-org.my-vdc.my-vapp
 ```
 
+NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+
 [docs-import]:https://www.terraform.io/docs/import/
 
 After importing, if you run `terraform plan` you will see the rest of the values and modify the script accordingly for

--- a/website/docs/r/vapp.html.markdown
+++ b/website/docs/r/vapp.html.markdown
@@ -181,7 +181,7 @@ You can import such vapp into terraform state using this command
 terraform import vcd_vapp.tf-vapp my-org.my-vdc.my-vapp
 ```
 
-NOTE: the default separator (.) can be changed using Provider.import_separation_token or variable VCD_IMPORT_SEPARATOR
+NOTE: the default separator (.) can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
 
 [docs-import]:https://www.terraform.io/docs/import/
 


### PR DESCRIPTION
Fixes Issue #343

The default separator for import is "."
Using Provider's property `import_separation_token` or environment
variable `VCD_IMPORT_SEPARATOR`, we can use any string as separator.

For example:
```
export VCD_IMPORT_SEPARATOR=":"
terraform import vcd_org_vdc.name_for_import datacloud:name.with.dots

export VCD_IMPORT_SEPARATOR="#"
terraform import vcd_org_vdc.name_for_import "datacloud#name:with.dots.and:colons"
```