### PR TITLE
Address outstanding issues before the release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 FEATURES:
 * **New Resource:** `vcd_nsxv_dnat` DNAT for advanced edge gateways using proxied NSX-V API - [#328]
 * **New Resource:** `vcd_nsxv_snat`  SNAT for advanced edge gateways using proxied NSX-V API - [#328]
-* **New Resource:** `vcd_nsxv_firewall_rule`  firewall for advanced edge gateways using proxied NSX-V API - [#341]
+* **New Resource:** `vcd_nsxv_firewall_rule`  firewall for advanced edge gateways using proxied NSX-V API - [#341, #358]
 * **New Data Source:** `vcd_org` Organization - ([#218])
 * **New Data Source:** `vcd_catalog` Catalog - ([#218])
 * **New Data Source:** `vcd_catalog_item` CatalogItem - ([#218])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,63 +1,63 @@
 ## 2.5.0 (Unreleased)
 
 FEATURES:
-* **New Resource:** `vcd_nsxv_dnat` DNAT for advanced edge gateways using proxied NSX-V API - [#328]
-* **New Resource:** `vcd_nsxv_snat`  SNAT for advanced edge gateways using proxied NSX-V API - [#328]
-* **New Resource:** `vcd_nsxv_firewall_rule`  firewall for advanced edge gateways using proxied NSX-V API - [#341, #358]
-* **New Data Source:** `vcd_org` Organization - ([#218])
-* **New Data Source:** `vcd_catalog` Catalog - ([#218])
-* **New Data Source:** `vcd_catalog_item` CatalogItem - ([#218])
-* **New Data Source:** `vcd_org_vdc` Organization VDC - ([#324])
-* **New Data Source:** `vcd_external_network` External Network - ([#218])
-* **New Data Source:** `vcd_edgegateway` Edge Gateway - ([#218])
-* **New Data Source:** `vcd_network_routed` Routed Network - ([#218])
-* **New Data Source:** `vcd_network_isolated` Isolated Network - ([#218])
-* **New Data Source:** `vcd_network_direct` Direct Network - ([#218])
-* **New Data Source:** `vcd_vapp` vApp - ([#218])
-* **New Data Source:** `vcd_nsxv_dnat` DNAT for advanced edge gateways using proxied NSX-V API - [#328]
-* **New Data Source:** `vcd_nsxv_snat` SNAT for advanced edge gateways using proxied NSX-V API - [#328]
-* **New Data Source:** `vcd_nsxv_firewall_rule` firewall for advanced edge gateways using proxied NSX-V API - [#341]
-* **New Data Source:** `vcd_independent_disk` Independent disk - [#349]
-* **New Data Source:** `vcd_catalog_media` Media item - [#340]
+* **New Resource:** `vcd_nsxv_dnat` DNAT for advanced edge gateways using proxied NSX-V API - [GH-328]
+* **New Resource:** `vcd_nsxv_snat`  SNAT for advanced edge gateways using proxied NSX-V API - [GH-328]
+* **New Resource:** `vcd_nsxv_firewall_rule`  firewall for advanced edge gateways using proxied NSX-V API - [GH-341, GH-358]
+* **New Data Source:** `vcd_org` Organization - [GH-218]
+* **New Data Source:** `vcd_catalog` Catalog - [GH-218]
+* **New Data Source:** `vcd_catalog_item` CatalogItem - [GH-218]
+* **New Data Source:** `vcd_org_vdc` Organization VDC - [GH-324]
+* **New Data Source:** `vcd_external_network` External Network - [GH-218]
+* **New Data Source:** `vcd_edgegateway` Edge Gateway - [GH-218]
+* **New Data Source:** `vcd_network_routed` Routed Network - [GH-218]
+* **New Data Source:** `vcd_network_isolated` Isolated Network - [GH-218]
+* **New Data Source:** `vcd_network_direct` Direct Network - [GH-218]
+* **New Data Source:** `vcd_vapp` vApp - [GH-218]
+* **New Data Source:** `vcd_nsxv_dnat` DNAT for advanced edge gateways using proxied NSX-V API - [GH-328]
+* **New Data Source:** `vcd_nsxv_snat` SNAT for advanced edge gateways using proxied NSX-V API - [GH-328]
+* **New Data Source:** `vcd_nsxv_firewall_rule` firewall for advanced edge gateways using proxied NSX-V API - [GH-341]
+* **New Data Source:** `vcd_independent_disk` Independent disk - [GH-349]
+* **New Data Source:** `vcd_catalog_media` Media item - [GH-340]
 
 IMPROVEMENTS:
 
 * Add support for vCD 10.0
-* `resource/vcd_org` Add import capability and full read support [#218]
-* `resource/vcd_catalog` Add import capability and full read support [#218]
-* `resource/vcd_catalog_item` Add import capability and full read support [#218]
-* `resource/vcd_external_network` Add import capability and full read support [#218]
-* `resource/vcd_edgegateway` Add import capability and full read support [#218]
-* `resource/vcd_network_routed` Add import capability and full read support [#218]
-* `resource/vcd_network_isolated` Add import capability and full read support [#218]
-* `resource/vcd_network_direct` Add import capability and full read support [#218]
-* `resource/vcd_vapp` Add import capability and full read support [#218]
+* `resource/vcd_org` Add import capability and full read support [GH-218]
+* `resource/vcd_catalog` Add import capability and full read support [GH-218]
+* `resource/vcd_catalog_item` Add import capability and full read support [GH-218]
+* `resource/vcd_external_network` Add import capability and full read support [GH-218]
+* `resource/vcd_edgegateway` Add import capability and full read support [GH-218]
+* `resource/vcd_network_routed` Add import capability and full read support [GH-218]
+* `resource/vcd_network_isolated` Add import capability and full read support [GH-218]
+* `resource/vcd_network_direct` Add import capability and full read support [GH-218]
+* `resource/vcd_vapp` Add import capability and full read support [GH-218]
 * `resource/vcd_network_direct`: Direct network state ID changed from network name to vCD ID 
 * `resource/vcd_network_isolated`: Isolated network state ID changed from network name to vCD ID 
 * `resource/vcd_network_routed`: Routed network state ID changed from network name to vCD ID 
 * `resource/vcd_vapp`: vApp state ID changed from vApp name to vCD ID
 * `resource/vcd_vapp`: Add properties `status` and `status_text`
-* `resource/catalog_item` added catalog item metadata support [#285] 
+* `resource/catalog_item` added catalog item metadata support [GH-285] 
 * `resource/vcd_catalog`: Catalog state ID changed from catalog name to vCD ID 
 * `resource/vcd_catalog_item`: CatalogItem state ID changed from colon separated list of catalog name and item name to vCD ID 
-* `resource/catalog_item` added catalog item metadata support [#298] 
-* `resource/catalog_media` added catalog media item metadata support [#298]
-* `resource/vcd_vapp_vm` supports update for `network` block [#310]
-* `resource/vcd_vapp_vm` allows to force guest customization [#310]
-* `resource/vcd_vapp` supports guest properties [#319]
-* `resource/vcd_vapp_vm` supports guest properties [#319]
-* `resource/vcd_network_direct` Add computed properties (external network gateway, netmask, DNS, and DNS suffix) [#330]
-* `vcd_org_vdc` Add import capability and full read support [#218]
-* Upgrade Terraform SDK dependency to 0.12.8 [#320]
-* `resource/vcd_vapp_vm` has new field `computer_name` [#334]
-* Import functions can now use custom separators instead of "." [#343]
-* `resource/vcd_independent_disk` Add computed properties (`iops`, `owner_name`, `datastore_name`, `is_attached`) and read support for all fields except the `size` [#349]
-* `resource/vcd_independent_disk` Disk state ID changed from name of disk to vCD ID [#349]
-* Import functions can now use a custom separator instead of "." [#343]
-* `resource/vcd_catalog_media` Add computed properties (`is_iso`, `owner_name`, `is_published`, `creation_date`, `size`, `status`, `storage_profile_name`) and full read support [#340]
-* `resource/vcd_catalog_media` MediaItem state ID changed from colon separated list of catalog name and media name to vCD ID [#340]
-* Import functions can now use custom separators instead of "." [#343]
-* `resource/vcd_vapp_vm` has new field `computer_name` [#334] [#347]
+* `resource/catalog_item` added catalog item metadata support [GH-298] 
+* `resource/catalog_media` added catalog media item metadata support [GH-298]
+* `resource/vcd_vapp_vm` supports update for `network` block [GH-310]
+* `resource/vcd_vapp_vm` allows to force guest customization [GH-310]
+* `resource/vcd_vapp` supports guest properties [GH-319]
+* `resource/vcd_vapp_vm` supports guest properties [GH-319]
+* `resource/vcd_network_direct` Add computed properties (external network gateway, netmask, DNS, and DNS suffix) [GH-330]
+* `vcd_org_vdc` Add import capability and full read support [GH-218]
+* Upgrade Terraform SDK dependency to 0.12.8 [GH-320]
+* `resource/vcd_vapp_vm` has new field `computer_name` [GH-334]
+* Import functions can now use custom separators instead of "." [GH-343]
+* `resource/vcd_independent_disk` Add computed properties (`iops`, `owner_name`, `datastore_name`, `is_attached`) and read support for all fields except the `size` [GH-349]
+* `resource/vcd_independent_disk` Disk state ID changed from name of disk to vCD ID [GH-349]
+* Import functions can now use a custom separator instead of "." [GH-343]
+* `resource/vcd_catalog_media` Add computed properties (`is_iso`, `owner_name`, `is_published`, `creation_date`, `size`, `status`, `storage_profile_name`) and full read support [GH-340]
+* `resource/vcd_catalog_media` MediaItem state ID changed from colon separated list of catalog name and media name to vCD ID [GH-340]
+* Import functions can now use custom separators instead of "." [GH-343]
+* `resource/vcd_vapp_vm` has new field `computer_name` [GH-334, GH-347]
 
 BUG FIXES:
 * Change default value for `vcd_org.deployed_vm_quota` and `vcd_org.stored_vm_quota`. It was incorrectly set at `-1` instead of `0`.
@@ -65,7 +65,7 @@ BUG FIXES:
 * Wait for task completion on creation and update, where tasks were not handled at all.
 * `resource/vcd_firewall_rules` force recreation of the resource when attributes of the sub-element `rule` are changed (fixes a situation when it tried to update a rule).
 * `resource/vcd_network_isolated` Fix definition of DHCP, which was created automatically with leftovers from static IP pool even when not requested.
-* `resource/vcd_network_routed` Fix retrieval with early vCD versions [#344]
+* `resource/vcd_network_routed` Fix retrieval with early vCD versions [GH-344]
 
 DEPRECATIONS
 * The ability of deploying a VM implicitly within a vApp is deprecated. Users are encouraged to set an empty vApp and

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -38,3 +38,27 @@ A possible solution is to delete the resource from the state file and import it 
 1. `terraform state list` (it will show `vcd_network_routed.my-net`)
 2. `terraform state rm vcd_network_routed.my-net`
 3. `terraform import vcd_network_routed.mynet my-org.my-vdc.my-net`
+
+
+## Migrating to new NSX-V API based NAT (vcd_nsxv_dnat and vcd_nsxv_snat) and firewall (vcd_nsxv_firewall_rule) resources
+
+Version 2.5 introduced new resources for NAT and firewall rules. They only work with advanced edge
+gateways (NSX-V). Previous resources (vcd_dnat, vcd_snat and vcd_firewall_rules) used vCD API
+which is not recommended anymore as it may cause configuration problems and lacks features. It is
+recommended to start using newer resources to avoid problems and access new features (including data
+sources).
+
+### For migrating DNAT and SNAT rules similar operation to the one above can be used:
+
+1. `terraform state list` (it will show `vcd_dnat.my-dnat`, `vcd_snat.my-snat`)
+2. `terraform state rm vcd_dnat.my-dnat`
+3. `terraform import vcd_nsxv_dnat.my-dnat my-org-name.my-vdc-name.my-edge-gw-name.my-dnat-rule-id`
+
+Note. NAT rule ID can be checked in the UI
+
+### For migrating firewall rules 
+For migrating firewall rules there should be one resource per one firewall rule. Similar process as
+for NAT can be used, but firewall rules do not show real ID (only their number) in the UI. For this
+reason there is an extra `list@` helper in the import command. Read more about it in `import` section
+of the [`vcd_nsxv_firewall_rule`](https://www.terraform.io/docs/providers/vcd/r/nsxv_firewall_rule.html#importing)
+resource.

--- a/vcd/resource_vcd_edgegateway.go
+++ b/vcd/resource_vcd_edgegateway.go
@@ -229,7 +229,10 @@ func resourceVcdEdgeGatewayCreate(d *schema.ResourceData, meta interface{}) erro
 		log.Printf("[TRACE] edge gateway firewall configured")
 
 		// update load balancer and firewall configuration in statefile
-		setEdgeGatewayComponentValues(d, edge)
+		err = setEdgeGatewayComponentValues(d, edge)
+		if err != nil {
+			return err
+		}
 	}
 
 	// TODO double validate if we need to use partial state here

--- a/vcd/resource_vcd_edgegateway.go
+++ b/vcd/resource_vcd_edgegateway.go
@@ -228,6 +228,8 @@ func resourceVcdEdgeGatewayCreate(d *schema.ResourceData, meta interface{}) erro
 
 		log.Printf("[TRACE] edge gateway firewall configured")
 
+		// update load balancer and firewall configuration in statefile
+		setEdgeGatewayComponentValues(d, edge)
 	}
 
 	// TODO double validate if we need to use partial state here
@@ -398,8 +400,15 @@ func setEdgeGatewayValues(d *schema.ResourceData, egw govcd.EdgeGateway) error {
 	//	return err
 	//}
 
+	d.SetId(egw.EdgeGateway.ID)
+	return nil
+}
+
+// setEdgeGatewayComponentValues sets component values to the statefile which are created with
+// additional API calls
+func setEdgeGatewayComponentValues(d *schema.ResourceData, egw govcd.EdgeGateway) error {
 	if egw.HasAdvancedNetworking() {
-		err = setLoadBalancerData(d, egw)
+		err := setLoadBalancerData(d, egw)
 		if err != nil {
 			return err
 		}
@@ -409,8 +418,6 @@ func setEdgeGatewayValues(d *schema.ResourceData, egw govcd.EdgeGateway) error {
 			return err
 		}
 	}
-
-	d.SetId(egw.EdgeGateway.ID)
 	return nil
 }
 

--- a/vcd/resource_vcd_edgegateway_test.go
+++ b/vcd/resource_vcd_edgegateway_test.go
@@ -165,11 +165,14 @@ func TestAccVcdEdgeGatewayComplex(t *testing.T) {
 			},
 			resource.TestStep{
 				Config: configText4,
+				// Taint the resource to force recreation of edge gateway because this step
+				// attempts to test creation problems.
+				Taint: []string{"vcd_edgegateway." + edgeGatewayNameComplex},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"vcd_edgegateway.EdgeWithFwAndLb", "default_gateway_network", newExternalNetworkVcd),
-					resource.TestCheckResourceAttr("vcd_edgegateway.EdgeWithFwAndLb", "fw_enabled", "true"),
-					resource.TestCheckResourceAttr("vcd_edgegateway.EdgeWithFwAndLb", "lb_enabled", "true"),
+						"vcd_edgegateway."+edgeGatewayNameComplex, "default_gateway_network", newExternalNetworkVcd),
+					resource.TestCheckResourceAttr("vcd_edgegateway."+edgeGatewayNameComplex, "lb_enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_edgegateway."+edgeGatewayNameComplex, "fw_enabled", "true"),
 				),
 			},
 		},
@@ -302,10 +305,10 @@ resource "vcd_edgegateway" "{{.EdgeGateway}}" {
 `
 
 const testAccEdgeGatewayComplexEnableFwLbOnCreate = testAccEdgeGatewayComplexNetwork + `
-resource "vcd_edgegateway" "EdgeWithFwAndLb" {
+resource "vcd_edgegateway" "{{.EdgeGateway}}" {
   org                     = "{{.Org}}"
   vdc                     = "{{.Vdc}}"
-  name                    = "{{.EdgeGatewayVcd}}-fwlb"
+  name                    = "{{.EdgeGatewayVcd}}"
   description             = "Description"
   configuration           = "compact"
   default_gateway_network = "${vcd_external_network.{{.NewExternalNetwork}}.name}"

--- a/website/docs/r/firewall_rules.html.markdown
+++ b/website/docs/r/firewall_rules.html.markdown
@@ -14,6 +14,10 @@ modify, and delete firewall settings and rules.
 ~> **Note:** Please use the improved [`vcd_nsxv_firewall_rule`](/docs/providers/vcd/r/nsxv_firewall_rule.html)
 resource with advanced edge gateways (NSX-V).
 
+~> **Note:** Using this resource automatically enables default firewall rule logging. This may cause
+[`vcd_edgegateway`](/docs/providers/vcd/r/edgegateway.html) resource to report changes for field
+ `fw_default_rule_logging_enabled` during `plan`/`apply` phases.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/nsxv_dnat.html.markdown
+++ b/website/docs/r/nsxv_dnat.html.markdown
@@ -16,6 +16,9 @@ modify, and delete destination NATs to map an external IP/port to an internal IP
 ~> **Note:** This resource requires advanced edge gateway. For non-advanced edge gateways please
 use the [`vcd_dnat`](/docs/providers/vcd/r/dnat.html) resource.
 
+!> **Warning:** Do not use older [`vcd_dnat`](/docs/providers/vcd/r/dnat.html) resource with this one
+because it will change IDs and this resource will not be able to lookup rules.
+
 ## Example Usage 1 (Minimal input)
 
 ```hcl

--- a/website/docs/r/nsxv_snat.html.markdown
+++ b/website/docs/r/nsxv_snat.html.markdown
@@ -16,6 +16,9 @@ can be used to create, modify, and delete source NATs to allow vApps to send ext
 ~> **Note:** This resource requires advanced edge gateway. For non-advanced edge gateways please
 use the [`vcd_snat`](/docs/providers/vcd/r/snat.html) resource.
 
+!> **Warning:** Do not use older [`vcd_snat`](/docs/providers/vcd/r/snat.html) resource with this one
+because it will change IDs and this resource will not be able to lookup rules.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
This PR solves the following:
* Adds correct CHANGELOG github issue format as per https://www.terraform.io/docs/extend/best-practices/versioning.html#example-changelog
* Splits load balancer and firewall statefile update from setEdgeGatewayValues to separate function setEdgeGatewayComponentValues and runs it after firewall and load balancer is configured during creation. There is also one more test step to cover this problem. Previously the problem was that it is called before firewall and load balancer general config is applied. Later on, when then config is being applied the d.Get() already read values from what was set using setEdgeGatewayValues
* Adds note to avoid mixing old and new dnat/snat resources in documentation website.
* Adds note about migrating to new DNAT/SNAT and firewall resources into `TROUBLESHOOTING.md`