### PR TITLE
Improve handling of "org" field in User resource

### DIFF
--- a/vcd/resource_vcd_org_user.go
+++ b/vcd/resource_vcd_org_user.go
@@ -88,6 +88,8 @@ func resourceVcdOrgUser() *schema.Resource {
 				Optional:    true,
 				ForceNew:    false,
 				Description: "The user's telephone",
+				// Re-enable when go-vcloud-director creation supports telephone
+				DiffSuppressFunc: suppressAlways(),
 			},
 			"instant_messaging": &schema.Schema{
 				Type:        schema.TypeString,
@@ -151,14 +153,14 @@ func resourceToUserData(d *schema.ResourceData, meta interface{}) (*govcd.OrgUse
 		orgName = vcdClient.Org
 	}
 	if orgName == "" {
-		return nil, nil, fmt.Errorf("missing org name")
+		return nil, nil, fmt.Errorf("[resourceToUserData] missing org name")
 	}
 	adminOrg, err := vcdClient.VCDClient.GetAdminOrgByName(orgName)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("[resourceToUserData] %s", err)
 	}
 	if adminOrg.AdminOrg == nil || adminOrg.AdminOrg.HREF == "" {
-		return nil, nil, fmt.Errorf("error retrieving org %s", orgName)
+		return nil, nil, fmt.Errorf("[resourceToUserData] error retrieving org %s", orgName)
 	}
 
 	var userData govcd.OrgUserConfiguration
@@ -207,15 +209,15 @@ func resourceToOrgUser(d *schema.ResourceData, meta interface{}) (*govcd.OrgUser
 	vcdClient := meta.(*VCDClient)
 	adminOrg, err := vcdClient.GetAdminOrgFromResource(d)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("[resourceToOrgUser] error retrieving org: %s", err)
 	}
 	if adminOrg.AdminOrg == nil || adminOrg.AdminOrg.HREF == "" {
-		return nil, nil, fmt.Errorf("error retrieving org %s", d.Get("org").(string))
+		return nil, nil, fmt.Errorf("[resourceToOrgUser ] error retrieving org %s", d.Get("org").(string))
 	}
 	userName := d.Get("name").(string)
 	orgUser, err := adminOrg.GetUserByName(userName, false)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("[resourceToOrgUser] error retrieving user %s: %s", userName, err)
 	}
 
 	return orgUser, adminOrg, nil
@@ -225,7 +227,6 @@ func resourceToOrgUser(d *schema.ResourceData, meta interface{}) (*govcd.OrgUser
 // Used after retrieving the user (read, import), to fill the Terraform container appropriately
 func setOrgUserData(d *schema.ResourceData, orgUser *govcd.OrgUser, adminOrg *govcd.AdminOrg) error {
 	d.SetId(orgUser.User.ID)
-	_ = d.Set("org", adminOrg.AdminOrg.Name)
 	_ = d.Set("name", orgUser.User.Name)
 	_ = d.Set("provider_type", orgUser.User.ProviderType)
 	_ = d.Set("is_group_role", orgUser.User.IsGroupRole)
@@ -265,7 +266,7 @@ func resourceVcdOrgUserDelete(d *schema.ResourceData, meta interface{}) error {
 	takeOwnership := d.Get("take_ownership").(bool)
 	orgUser, _, err := resourceToOrgUser(d, meta)
 	if err != nil {
-		return err
+		return fmt.Errorf("[user delete] %s", err)
 	}
 	return orgUser.Delete(takeOwnership)
 }
@@ -275,7 +276,7 @@ func resourceVcdOrgUserRead(d *schema.ResourceData, meta interface{}) error {
 
 	orgUser, adminOrg, err := resourceToOrgUser(d, meta)
 	if err != nil {
-		return err
+		return fmt.Errorf("[user read] error filling data %s", err)
 	}
 	return setOrgUserData(d, orgUser, adminOrg)
 }
@@ -319,9 +320,10 @@ func resourceVcdOrgUserImport(d *schema.ResourceData, meta interface{}) ([]*sche
 
 	user, err := adminOrg.GetUserByName(userName, false)
 	if err != nil {
-		return nil, govcd.ErrorEntityNotFound
+		return nil, fmt.Errorf("[user import] error retrieving user %s: %s", userName, err)
 	}
 
+	_ = d.Set("org", orgName)
 	err = setOrgUserData(d, user, adminOrg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Change handling of the "org" field in User resource.
The field was being updated for every Read, but that would affect the plan when the Org is set at provider level and not given in the resource.