### PR TITLE
Add extra step in binary tests to ensure plan is stable, fix `shared_secret` in vcd_edgegateway_vpn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,8 @@ BUG FIXES:
 * Wait for task completion on creation and update, where tasks were not handled at all.
 * `resource/vcd_firewall_rules` force recreation of the resource when attributes of the sub-element `rule` are changed (fixes a situation when it tried to update a rule).
 * `resource/vcd_network_isolated` Fix definition of DHCP, which was created automatically with leftovers from static IP pool even when not requested.
-* `resource/vcd_network_routed` Fix retrieval with early vCD versions [GH-344]
+* `resource/vcd_network_routed` Fix retrieval with early vCD versions. [GH-344]
+* `resource/vcd_edgegateway_vpn` Required replacement every time for `shared_secret` field.  [GH-361]
 
 DEPRECATIONS
 * The ability of deploying a VM implicitly within a vApp is deprecated. Users are encouraged to set an empty vApp and

--- a/TESTING.md
+++ b/TESTING.md
@@ -108,7 +108,7 @@ There are also a couple of commands that prepare and execute the terraform scrip
 $ make test-env-init && make test-env-apply
 ```
 
-Unlike other commands executed during `make binary`, these ones only run the `init` and `apply` stage of the script processing,
+Unlike other commands executed during `make test-binary`, these ones only run the `init` and `apply` stage of the script processing,
 producing a ready-to-use environment in a few minutes.
 If the commands were successful, you are ready to run the acceptance tests:
 
@@ -301,6 +301,7 @@ terraform tool through a shell script, and for every test we run
 * `terraform init`
 * `terraform plan`
 * `terraform apply -auto-approve`
+* `terraform plan -detailed-exitcode` (for ensuring that `plan` is empty right after `apply`)
 * `terraform destroy -auto-approve`
 
 The test runs from GNUMakefile, using

--- a/scripts/test-binary.sh
+++ b/scripts/test-binary.sh
@@ -351,10 +351,17 @@ do
                 run terraform apply -auto-approve $apply_options
                 ;;
             plancheck)
-                # -detailed-exitcode will return exit code 2 when the plan was not empty
-                # and this allows to validate if reads work properly and there is no immediate
-                # plan change right after apply succeeded
-                run terraform plan -detailed-exitcode $plan_options
+                # Skip plan check if a `.tf` example contains line "# skip-plan-check"
+                skip_plancheck=$(grep '^\s*#\s*skip-plan-check' "../$CF")
+                if [ -n "$skip_plancheck" ]
+                then
+                    echo "# $CF plan check skipped"
+                else
+                    # -detailed-exitcode will return exit code 2 when the plan was not empty
+                    # and this allows to validate if reads work properly and there is no immediate
+                    # plan change right after apply succeeded
+                    run terraform plan -detailed-exitcode $plancheck_options 
+                fi
                 ;;
             destroy)
                 if [ ! -f terraform.tfstate ]

--- a/vcd/resource_vcd_edgegateway_vpn.go
+++ b/vcd/resource_vcd_edgegateway_vpn.go
@@ -84,9 +84,10 @@ func resourceVcdEdgeGatewayVpn() *schema.Resource {
 			},
 
 			"shared_secret": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				Sensitive: true,
 			},
 
 			"local_subnets": &schema.Schema{
@@ -301,10 +302,8 @@ func resourceVcdEdgeGatewayVpnRead(d *schema.ResourceData, meta interface{}) err
 		_ = d.Set("mtu", tunnel.Mtu)
 		_ = d.Set("peer_ip_address", tunnel.PeerIPAddress)
 		_ = d.Set("peer_id", tunnel.PeerID)
-		_ = d.Set("shared_secret", tunnel.SharedSecret)
 		convertAndSet("local_subnets", tunnel.LocalSubnet, d)
 		convertAndSet("peer_subnets", tunnel.PeerSubnet, d)
-
 	} else {
 		return fmt.Errorf("multiple tunnels not currently supported")
 	}

--- a/vcd/resource_vcd_edgegateway_vpn_test.go
+++ b/vcd/resource_vcd_edgegateway_vpn_test.go
@@ -3,7 +3,6 @@
 package vcd
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -42,11 +41,6 @@ func TestAccVcdVpn_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: configText,
-				// We expect this error to happen, because Terraform will consider that the resource
-				// needs to be generated again. It's a known problem that often happens with security fields
-				// such as "sharedSecret" in our resource, and there is no general purpose solution.
-				// In this case, we accept that this error might show up, and take it as a clean run.
-				ExpectError: regexp.MustCompile(`After applying this step, the plan was not empty`),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"vcd_edgegateway_vpn."+vpnName, "encryption_protocol", "AES256"),

--- a/vcd/test-templates/misc2.tf
+++ b/vcd/test-templates/misc2.tf
@@ -75,7 +75,6 @@ resource "vcd_vapp_vm" "tf_vm_1" {
   network {
     type                 = "org"
     name                 = "${vcd_network_routed.tf_network.name}"
-    ip                   = "192.168.0.7"
     ip_allocation_mode   = "POOL"
   }
 
@@ -124,7 +123,6 @@ resource "vcd_vapp_vm" "tf_vm_second" {
   network {
     type                 = "vapp"
     name                 = "${vcd_vapp_network.tf_vapp_net.name}"
-    ip                   = "192.168.0.9"
     ip_allocation_mode   = "POOL"
   }
 


### PR DESCRIPTION
This PR adds an extra step for our `make test-binary` infrastructure. The step is `plancheck` and is called after `apply`.  It runs `terraform plan -detailed-exitcode`. The flag `-detailed-exitcode` forces `plan` command to emit exit code 2 (instead of 0 without it) when the plan is not empty.
This allows us to validate any field issues just after the resource is created.

In addition to this it fixes outstanding issues so that `make test-binary` works fine with this new step:
* `resource/vcd_edgegateway_vpn` - force replacement due to blank value set for `shared_secret` (because it is not returned from API). Closes #362
* remove `ip` setting because `POOL` is used in `cust.misc2.tf` sample config. It used to cause IP overrides because POOL assignes IP from the pool.
