### PR TITLE
Add Env variable to enable Org user tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -24,8 +24,8 @@ test-binary-prepare: install
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' binary-prepare"
 
 # runs test using Terraform binary as Org user
-orguser-test-binary: install
-	@sh -c "'$(CURDIR)/scripts/runtest.sh' orguser-short-provider"
+test-binary-orguser: install
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' short-provider-orguser"
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' binary"
 
 # runs test using Terraform binary as system administrator
@@ -55,8 +55,8 @@ test: testunit
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' short"
 
 # Runs the full acceptance test as Org user
-orguser-testacc: testunit
-	@sh -c "'$(CURDIR)/scripts/runtest.sh' orguser-acceptance"
+testacc-orguser: testunit
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' acceptance-orguser"
 
 # Runs the full acceptance test as system administrator
 testacc: testunit

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,7 +25,7 @@ test-binary-prepare: install
 
 # runs test using Terraform binary as Org user
 orguser-test-binary: install
-	@sh -c "'$(CURDIR)/scripts/runtest.sh' short-provider"
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' orguser-short-provider"
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' binary"
 
 # runs test using Terraform binary as system administrator

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,8 +23,12 @@ test-binary-prepare: install
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' short-provider"
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' binary-prepare"
 
+# runs test using Terraform binary as Org user
+orguser-test-binary: install
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' short-provider"
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' binary"
 
-# runs test using Terraform binary
+# runs test using Terraform binary as system administrator
 test-binary: install
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' short-provider"
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' binary"
@@ -50,7 +54,11 @@ testunit: fmtcheck
 test: testunit
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' short"
 
-# Runs the full acceptance test
+# Runs the full acceptance test as Org user
+orguser-testacc: testunit
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' orguser-acceptance"
+
+# Runs the full acceptance test as system administrator
 testacc: testunit
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' acceptance"
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -432,3 +432,6 @@ borrow org and vcd from the provider.
 * `VCD_TEST_SUITE_CLEANUP=1` will clean up testing resources that were created in previous test runs.
 * `TEST_VERBOSE=1` enables verbose output in some tests, such as the list of used tags, or the version
 used in the documentation index.
+* `VCD_TEST_ORG_USER=1` will enable tests with Org User, using the credentials from the configuration file
+  (`testEnvBuild.OrgUser` and `testEnvBuild.OrgUserPassword`)
+  

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -24,7 +24,7 @@ fi
 
 accepted_commands=(short acceptance sequential-acceptance multiple binary 
     binary-prepare catalog gateway vapp vm network extnetwork multinetwork 
-    short-provider lb user orguser-acceptance orguser-short-provider)
+    short-provider lb user acceptance-orguser short-provider-orguser)
 
 accepted="[${accepted_commands[*]}]"
 
@@ -208,7 +208,7 @@ case $wanted in
         export VCD_SKIP_TEMPLATE_WRITING=1
         short_test
         ;;
-    orguser-short-provider)
+    short-provider-orguser)
         unset VCD_SKIP_TEMPLATE_WRITING
         export VCD_TEST_ORG_USER=1
         export VCD_ADD_PROVIDER=1
@@ -221,7 +221,7 @@ case $wanted in
         export MORE_TAGS=binary
         short_test
         ;;
-    orguser-acceptance)
+    acceptance-orguser)
         export VCD_TEST_ORG_USER=1
         acceptance_test functional
         ;;

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -206,6 +206,7 @@ case $wanted in
     orguser-acceptance)
         export VCD_TEST_ORG_USER=1
         acceptance_test functional
+        ;;
     acceptance)
         acceptance_test functional
         ;;

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -183,6 +183,10 @@ case $wanted in
         export NORUN=1
         binary_test
         ;;
+     orguser-binary)
+        export VCD_TEST_ORG_USER=1
+        binary_test
+        ;;
      binary)
         binary_test
         ;;
@@ -199,6 +203,9 @@ case $wanted in
         export MORE_TAGS=binary
         short_test
         ;;
+    orguser-acceptance)
+        export VCD_TEST_ORG_USER=1
+        acceptance_test functional
     acceptance)
         acceptance_test functional
         ;;

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -398,6 +398,18 @@ func getConfigStruct(config string) TestConfig {
 	if configStruct.Provider.SysOrg == "" {
 		configStruct.Provider.SysOrg = configStruct.VCD.Org
 	}
+
+	if os.Getenv("VCD_TEST_ORG_USER") != "" {
+		user := configStruct.TestEnvBuild.OrgUser
+		password := configStruct.TestEnvBuild.OrgUserPassword
+		if user == "" || password == "" {
+			panic("VCD_TEST_ORG_USER was enabled, but org user credentials were not found in the configuration file")
+		}
+		configStruct.Provider.User = user
+		configStruct.Provider.Password = password
+		configStruct.Provider.SysOrg = configStruct.VCD.Org
+		fmt.Println("VCD_TEST_USER was enabled. Using Org User credentials from configuration file")
+	}
 	_ = os.Setenv("VCD_USER", configStruct.Provider.User)
 	_ = os.Setenv("VCD_PASSWORD", configStruct.Provider.Password)
 	_ = os.Setenv("VCD_URL", configStruct.Provider.Url)

--- a/vcd/datasource_vcd_independent_disk_test.go
+++ b/vcd/datasource_vcd_independent_disk_test.go
@@ -14,6 +14,9 @@ import (
 // Test independent disk data resource
 // Using a disk data source we reference a disk data source
 func TestAccVcdDataSourceIndependentDisk(t *testing.T) {
+	if !usingSysAdmin() {
+		t.Skip("TestAccVcdDataSourceIndependentDisk requires system admin privileges")
+	}
 	resourceName := "TestAccVcdDataSourceIndependentDisk_1"
 	datasourceName := "TestAccVcdDataSourceIndependentDisk_Data"
 	datasourceNameWithId := "TestAccVcdDataSourceIndependentDiskWithId_Data"

--- a/vcd/resource_vcd_dnat_test.go
+++ b/vcd/resource_vcd_dnat_test.go
@@ -72,6 +72,9 @@ func TestAccVcdDNAT_WithOrgNetw(t *testing.T) {
 }
 
 func TestAccVcdDNAT_WithExtNetw(t *testing.T) {
+	if !usingSysAdmin() {
+		t.Skip("TestAccVcdDNAT_WithExtNetw requires system admin privileges")
+	}
 	if testConfig.Networking.ExternalIp == "" {
 		t.Skip("Variable networking.externalIp must be set to run DNAT tests")
 		return

--- a/vcd/resource_vcd_independent_disk_test.go
+++ b/vcd/resource_vcd_independent_disk_test.go
@@ -16,6 +16,9 @@ var resourceName = "TestAccVcdIndependentDiskBasic_1"
 var name = "TestAccVcdIndependentDiskBasic"
 
 func TestAccVcdIndependentDiskBasic(t *testing.T) {
+	if !usingSysAdmin() {
+		t.Skip("TestAccVcdIndependentDiskBasic requires system admin privileges")
+	}
 
 	var params = StringMap{
 		"Org":                testConfig.VCD.Org,


### PR DESCRIPTION
* Add variable `VCD_TEST_ORG_USER` that uses the Org User credentials from the configuration file to run the tests.
* Adds skip statements for two tests that were missing it.

To run the test:
1. make sure that in your configuration file the fields `TestEnvBuild.OrgUserPassword` and `TestEnvBuild.OrgUser` are filled;
2. run the command
```
VCD_TEST_ORG_USER=1 make testacc
VCD_TEST_ORG_USER=1 make test-binary
```
or
```
make testacc-orguser
make test-binary-orguser
```

The following tests are skipped when running as OrgUser:

```
--- SKIP: TestAccVcdNetworkDirectDS (4.37s)
    datasource_vcd_network_test.go:129: no direct network found << [note: the network exists, but an Org user can't get all the details and the retrieval fails]
--- SKIP: TestAccVcdDatasourceOrg (0.00s)
    datasource_vcd_org_test.go:15: TestAccVcdDatasourceOrg requires system admin privileges
--- SKIP: TestAccVcdVdcDatasource (0.00s)
    resource_vcd_org_vdc_test.go:90: TestAccVcdVdcBasic requires system admin privileges
--- SKIP: TestAccVcdVappDS (1.87s)
    datasource_vcd_vapp_test.go:55: No suitable vApp found for this test
--- SKIP: TestAccVcdEdgeGatewayBasic (0.00s)
    resource_vcd_edgegateway_test.go:50: Edge gateway tests requires system admin privileges
--- SKIP: TestAccVcdEdgeGatewayComplex (0.00s)
    resource_vcd_edgegateway_test.go:117: Edge gateway tests requires system admin privileges
=== RUN   TestAccVcdExternalNetworkBasic
--- SKIP: TestAccVcdExternalNetworkBasic (0.00s)
    resource_vcd_external_network_test.go:20: TestAccVcdExternalNetworkBasic requires system admin privileges
--- SKIP: TestAccVcdNetworkDirect (0.00s)
    resource_vcd_network_test.go:166: TestAccVcdNetworkDirect requires system admin privileges
--- SKIP: TestAccVcdOrgBasic (0.00s)
    resource_vcd_org_test.go:28: TestAccVcdOrgBasic requires system admin privileges
--- SKIP: TestAccVcdOrgFull (0.00s)
    resource_vcd_org_test.go:65: TestAccVcdOrgFull requires system admin privileges
--- SKIP: TestAccVcdOrgVdcReservationPool (0.00s)
    resource_vcd_org_vdc_test.go:90: TestAccVcdVdcBasic requires system admin privileges
--- SKIP: TestAccVcdOrgVdcAllocationPool (0.00s)
    resource_vcd_org_vdc_test.go:90: TestAccVcdVdcBasic requires system admin privileges
--- SKIP: TestAccVcdOrgVdcAllocationVApp (0.00s)
    resource_vcd_org_vdc_test.go:90: TestAccVcdVdcBasic requires system admin privileges
--- SKIP: TestAccVcdDataSourceIndependentDisk (0.00s)
    datasource_vcd_independent_disk_test.go:18: TestAccVcdDataSourceIndependentDisk requires system admin privileges
--- SKIP: TestAccVcdDNAT_WithExtNetw (0.00s)
    resource_vcd_dnat_test.go:76: TestAccVcdDNAT_WithExtNetw requires system admin privileges
```