### PR TITLE
Enable staticcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ language: go
 branches:
   only:
   - master
-  - vmware-stash-while-master-pr-open
 
 matrix:
   fast_finish: true
@@ -19,11 +18,13 @@ matrix:
       script:
         - make test
         - make vet
+        - make static
         - make website-test
     - go: "1.13.x"
       env: GO111MODULE=on
       script:
         - make test
         - make vet
+        - make static
         - make vendor-check
         - make website-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ IMPROVEMENTS:
   [GH-384]
 * `resource/vcd_nsxv_firewall_rule` `rule_tag` must be int to avoid vCD internal exception
   passthrough - [GH-384]
+* Fix code warnings from `staticcheck` and add command `make static` to Travis tests.
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ IMPROVEMENTS:
   [GH-384]
 * `resource/vcd_nsxv_firewall_rule` `rule_tag` must be int to avoid vCD internal exception
   passthrough - [GH-384]
-* Fix code warnings from `staticcheck` and add command `make static` to Travis tests.
+* Fix code warnings from `staticcheck` and add command `make static` to Travis tests
 
 BUG FIXES:
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -46,6 +46,10 @@ test-env-apply:
 test-env-destroy:
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' test-env-destroy"
 
+# runs staticcheck
+static: fmtcheck
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' static"
+
 # runs the unit tests
 testunit: fmtcheck
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' unit"
@@ -124,9 +128,6 @@ fmt:
 fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
-errcheck:
-	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
-
 # runs the vendor directory check
 vendor-check:
 	go mod tidy
@@ -153,5 +154,5 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test seqtestacc testacc vet fmt fmtcheck errcheck vendor-check test-compile website website-test
+.PHONY: build test seqtestacc testacc vet static fmt fmtcheck vendor-check test-compile website website-test
 

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -237,7 +237,7 @@ function check_static {
         $static_check -version
         echo -n "## Checking "
         pwd
-        $static_check -tags functional .
+        $static_check -tags ALL .
         exit_code=$?
         if [ "$exit_code" != "0" ]
         then

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -22,7 +22,7 @@ then
     VERBOSE=1
 fi
 
-accepted_commands=(short acceptance sequential-acceptance multiple binary 
+accepted_commands=(static short acceptance sequential-acceptance multiple binary 
     binary-prepare catalog gateway vapp vm network extnetwork multinetwork 
     short-provider lb user acceptance-orguser short-provider-orguser)
 
@@ -181,7 +181,43 @@ function binary_test {
      ./test-binary.sh
 }
 
+function exists_in_path {
+    what=$1
+    for dir in $(echo $PATH | tr ':' ' ')
+    do
+        wanted=$dir/$what
+        if [ -x $wanted ]
+        then
+            echo $wanted
+            return
+        fi
+    done
+}
+
+function check_static {
+    static_check=$(exists_in_path staticcheck)
+
+    if [ -n "$static_check" ]
+    then
+        echo "## Found $static_check"
+        echo -n "## "
+        staticcheck -version
+        echo -n "## Checking "
+        pwd
+        staticcheck -tags functional .
+        exit_code=$?
+        if [ "$exit_code" != "0" ]
+        then
+            exit $exit_code
+        fi
+    else
+        echo "*** staticcheck executable not found - Check skipped"
+    fi
+}
 case $wanted in
+    static)
+        check_static
+        ;;
     test-env-init)
         export VCD_ENV_INIT=1
         binary_test

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -196,15 +196,48 @@ function exists_in_path {
 
 function check_static {
     static_check=$(exists_in_path staticcheck)
+    if [  -z "$staticcheck" -a -n "$TRAVIS" ]
+    then
+        # Variables found in staticcheck-config.sh
+        # STATICCHECK_URL
+        # STATICCHECK_VERSION
+        # STATICCHECK_FILE
+        if [ -f $scripts_dir/staticcheck-config.sh ]
+        then
+            source $scripts_dir/staticcheck-config.sh
+        else
+            echo "File $scripts_dir/staticcheck-config.sh not found - Skipping check"
+            exit 0
+        fi
+        download_name=$STATICCHECK_URL/$STATICCHECK_VERSION/$STATICCHECK_FILE
+        wget=$(exists_in_path wget)
+        if [ -z "$wget" ]
+        then
+            echo "'wget' executable not found - Skipping check"
+            exit 0
+        fi
+        $wget $download_name
+        if [ -n "$STATICCHECK_FILE" ]
+        then
+            tar -xzf $STATICCHECK_FILE
+            executable=$PWD/staticcheck/staticcheck
+            if [ ! -f $executable ]
+            then
+                echo "Extracted executable not available - Skipping check"
+            fi
+            chmod +x $executable
+            static_check=$executable
+        fi
+    fi
 
     if [ -n "$static_check" ]
     then
         echo "## Found $static_check"
         echo -n "## "
-        staticcheck -version
+        $static_check -version
         echo -n "## Checking "
         pwd
-        staticcheck -tags functional .
+        $static_check -tags functional .
         exit_code=$?
         if [ "$exit_code" != "0" ]
         then

--- a/scripts/staticcheck-config.sh
+++ b/scripts/staticcheck-config.sh
@@ -1,0 +1,4 @@
+export STATICCHECK_URL=https://github.com/dominikh/go-tools/releases/download
+export STATICCHECK_VERSION=2019.2.3
+export STATICCHECK_FILE=staticcheck_linux_amd64.tar.gz
+

--- a/vcd/api_test.go
+++ b/vcd/api_test.go
@@ -64,14 +64,6 @@ Tagged tests can also run using make
 	t.Logf(helpText)
 }
 
-// Tells indirectly if a tag has been set
-// For every tag there is an `init` function that
-// fills an item in `testingTags`
-func isTagSet(tagName string) bool {
-	_, ok := testingTags[tagName]
-	return ok
-}
-
 // For troubleshooting:
 // Shows which tags were set, and in which file.
 func showTags() {
@@ -143,7 +135,7 @@ func getMajorVersion() string {
 	// We only need the first two numbers
 	reVersion := regexp.MustCompile(`v(\d+\.\d+)\.\d+`)
 	versionList := reVersion.FindAllStringSubmatch(string(versionText), -1)
-	if versionList == nil || len(versionList) == 0 {
+	if len(versionList) == 0 {
 		panic("empty or non-formatted version found in VERSION file")
 	}
 	if versionList[0] == nil || len(versionList[0]) < 2 {

--- a/vcd/catalogitem.go
+++ b/vcd/catalogitem.go
@@ -24,10 +24,11 @@ func deleteCatalogItem(d *schema.ResourceData, vcdClient *VCDClient) error {
 		return fmt.Errorf("unable to find catalog")
 	}
 
-	catalogItem, err := catalog.GetCatalogItemByName(d.Get("name").(string), false)
+	catalogItemName := d.Get("name").(string)
+	catalogItem, err := catalog.GetCatalogItemByName(catalogItemName, false)
 	if err != nil {
 		log.Printf("[DEBUG] Unable to find catalog item. Removing from tfstate")
-		return fmt.Errorf("unable to find catalog item")
+		return fmt.Errorf("unable to find catalog item %s", catalogItemName)
 	}
 
 	err = catalogItem.Delete()
@@ -36,11 +37,11 @@ func deleteCatalogItem(d *schema.ResourceData, vcdClient *VCDClient) error {
 		return fmt.Errorf("error removing catalog item %s", err)
 	}
 
-	catalogItem, err = catalog.GetCatalogItemByName(d.Get("name").(string), true)
-	if catalogItem != nil {
-		return fmt.Errorf("catalog item %s still found after deletion", d.Get("name").(string))
+	_, err = catalog.GetCatalogItemByName(catalogItemName, true)
+	if err == nil {
+		return fmt.Errorf("catalog item %s still found after deletion", catalogItemName)
 	}
-	log.Printf("[TRACE] Catalog item delete completed: %s", d.Get("name").(string))
+	log.Printf("[TRACE] Catalog item delete completed: %s", catalogItemName)
 
 	return nil
 }

--- a/vcd/provider_unit_test.go
+++ b/vcd/provider_unit_test.go
@@ -37,7 +37,7 @@ func TestProviderVersion(t *testing.T) {
 	} else {
 		foundList := reFoundVersion.FindAllStringSubmatch(string(indexText), -1)
 		foundText := ""
-		if foundList != nil && len(foundList) > 0 && len(foundList[0]) > 0 {
+		if len(foundList) > 0 && len(foundList[0]) > 0 {
 			foundText = foundList[0][0]
 			t.Logf("Expected text: <%s>", expectedText)
 			t.Logf("Found text   : <%s> in index.html.markdown", foundText)

--- a/vcd/resource_vcd_dnat.go
+++ b/vcd/resource_vcd_dnat.go
@@ -153,6 +153,7 @@ func resourceVcdDNATCreate(d *schema.ResourceData, meta interface{}) error {
 	} else {
 		// TODO remove when major release is done
 		_, _ = fmt.Fprint(getTerraformStdout(), "WARNING: This resource will require network_name and network_type in the next major version \n")
+		//lint:ignore SA1019 Preserving back compatibility until removal
 		task, err := edgeGateway.AddNATPortMapping("DNAT",
 			d.Get("external_ip").(string),
 			portString,
@@ -282,6 +283,7 @@ func resourceVcdDNATDelete(d *schema.ResourceData, meta interface{}) error {
 		}
 	} else {
 		// this for back compatibility when network name and network type isn't provided - TODO remove with major release
+		//lint:ignore SA1019 Preserving back compatibility until removal
 		task, err := edgeGateway.RemoveNATPortMapping("DNAT",
 			d.Get("external_ip").(string),
 			portString,
@@ -304,9 +306,9 @@ func resourceVcdDNATUpdate(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
 	// Update supports only when network name and network type provided
-	networkName := d.Get("network_name")
-	if networkName == nil || networkName.(string) == "" {
-		return fmt.Errorf("update works only when network_name and network_type is provided and rule created using them \n")
+	networkName, ok := d.GetOk("network_name")
+	if !ok || networkName == "" {
+		return fmt.Errorf("update works only when network_name and network_type is provided and rule created using them")
 	}
 
 	edgeGateway, err := vcdClient.GetEdgeGatewayFromResource(d, "edge_gateway")

--- a/vcd/resource_vcd_dnat_test.go
+++ b/vcd/resource_vcd_dnat_test.go
@@ -208,10 +208,10 @@ func testAccCheckVcdDNATDestroy(s *terraform.State) error {
 			return fmt.Errorf(errorUnableToFindEdgeGateway, err)
 		}
 
-		rule, err := edgeGateway.GetNatRule(rs.Primary.ID)
+		_, err = edgeGateway.GetNatRule(rs.Primary.ID)
 
-		if rule != nil {
-			return fmt.Errorf("DNAT rule still exists.")
+		if err == nil {
+			return fmt.Errorf("DNAT rule still exists")
 		}
 	}
 

--- a/vcd/resource_vcd_firewall_rules.go
+++ b/vcd/resource_vcd_firewall_rules.go
@@ -220,11 +220,11 @@ func matchFirewallRule(d *schema.ResourceData, prefix string, rules []*types.Fir
 			d.Get(prefix+".policy").(string) == m.Policy &&
 			strings.ToLower(d.Get(prefix+".protocol").(string)) == getProtocol(*m.Protocols) &&
 			strings.ToLower(d.Get(prefix+".destination_port").(string)) == getPortString(m.Port) &&
-			strings.ToLower(d.Get(prefix+".destination_ip").(string)) == strings.ToLower(m.DestinationIP) &&
+			strings.EqualFold(d.Get(prefix+".destination_ip").(string), m.DestinationIP) &&
 			strings.ToLower(d.Get(prefix+".source_port").(string)) == getPortString(m.SourcePort) &&
-			strings.ToLower(d.Get(prefix+".source_ip").(string)) == strings.ToLower(m.SourceIP) {
+			strings.EqualFold(d.Get(prefix+".source_ip").(string), m.SourceIP) {
 			return m.ID, nil
 		}
 	}
-	return "", fmt.Errorf("Unable to find rule")
+	return "", fmt.Errorf("unable to find rule")
 }

--- a/vcd/resource_vcd_independent_disk.go
+++ b/vcd/resource_vcd_independent_disk.go
@@ -327,7 +327,7 @@ func resourceVcdIndependentDiskDelete(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-var helpDiskError = fmt.Errorf(`resource id must be specified in one of these formats:
+var errHelpDiskImport = fmt.Errorf(`resource id must be specified in one of these formats:
 'org-name.vdc-name.my-independent-disk-id' to import by rule id
 'list@org-name.vdc-name.my-independent-disk-name' to get a list of disks with their IDs`)
 
@@ -355,14 +355,14 @@ func resourceVcdIndependentDiskImport(d *schema.ResourceData, meta interface{}) 
 	log.Printf("[DEBUG] importing vcd_independent_disk resource with provided id %s", d.Id())
 
 	if len(resourceURI) != 3 {
-		return nil, helpDiskError
+		return nil, errHelpDiskImport
 	}
 
 	if strings.Contains(d.Id(), "list@") {
 		commandOrgName, vdcName, diskName = resourceURI[0], resourceURI[1], resourceURI[2]
 		commandOrgNameSplit := strings.Split(commandOrgName, "@")
 		if len(commandOrgNameSplit) != 2 {
-			return nil, helpDiskError
+			return nil, errHelpDiskImport
 		}
 		orgName = commandOrgNameSplit[1]
 		return listDisksForImport(meta, orgName, vdcName, diskName)
@@ -413,5 +413,5 @@ func listDisksForImport(meta interface{}, orgName, vdcName, diskName string) ([]
 	}
 	writer.Flush()
 
-	return nil, fmt.Errorf("resource was not imported! %s", helpDiskError)
+	return nil, fmt.Errorf("resource was not imported! %s", errHelpDiskImport)
 }

--- a/vcd/resource_vcd_nsxv_firewall_rule.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule.go
@@ -591,22 +591,24 @@ func getEndpointData(endpoint types.EdgeFirewallEndpoint, edge *govcd.EdgeGatewa
 	// Different object types are in the same grouping object tag <groupingObjectId>
 	// They can be distinguished by 3rd element in ID
 	var (
-		endpointNetworks       []string
-		endpointVMs            []string
-		endpointIpSets         []string
-		endpointSecurityGroups []string
+		endpointNetworks []string
+		endpointVMs      []string
+		// TODO uncomment when IP sets and Security groups are supported
+		// endpointIpSets         []string
+		// endpointSecurityGroups []string
 	)
 
 	for _, groupingObject := range endpoint.GroupingObjectIds {
 		idSplit := strings.Split(groupingObject, ":")
 		idLen := len(idSplit)
-		subIdSplit := ""
-		if idLen == 2 {
-			subSplit := strings.Split(idSplit[1], "-")
-			if len(subSplit) == 2 {
-				subIdSplit = subSplit[0]
-			}
-		}
+		// TODO uncomment when IP sets and Security groups are supported
+		// subIdSplit := ""
+		// if idLen == 2 {
+		// 	subSplit := strings.Split(idSplit[1], "-")
+		// 	if len(subSplit) == 2 {
+		// 		subIdSplit = subSplit[0]
+		// 	}
+		// }
 		switch {
 		// Handle org vdc networks
 		// Sample ID: urn:vcloud:network:95bffe8e-7e67-452d-abf2-535ac298db2b
@@ -618,15 +620,16 @@ func getEndpointData(endpoint types.EdgeFirewallEndpoint, edge *govcd.EdgeGatewa
 		case idLen == 4 && idSplit[2] == "vm":
 			endpointVMs = append(endpointVMs, groupingObject)
 
+		// TODO uncomment when IP sets and Security groups are supported
 		// Handle ipsets
 		// Sample ID: f9daf2da-b4f9-4921-a2f4-d77a943a381c:ipset-2
-		case idLen == 2 && subIdSplit == "ipset":
-			endpointIpSets = append(endpointIpSets, groupingObject)
+		// case idLen == 2 && subIdSplit == "ipset":
+		// 	endpointIpSets = append(endpointIpSets, groupingObject)
 
 		// Handle security groups
 		// Sample ID: f9daf2da-b4f9-4921-a2f4-d77a943a381c:securitygroup-11
-		case idLen == 2 && subIdSplit == "securitygroup":
-			endpointSecurityGroups = append(endpointSecurityGroups, groupingObject)
+		// case idLen == 2 && subIdSplit == "securitygroup":
+		// 	endpointSecurityGroups = append(endpointSecurityGroups, groupingObject)
 
 		// Log the group ID if it was not one of above
 		default:

--- a/vcd/resource_vcd_org_vdc.go
+++ b/vcd/resource_vcd_org_vdc.go
@@ -523,7 +523,7 @@ func resourceVcdVdcDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error removing vdc %s", err)
 	}
 
-	vdc, err = adminOrg.GetVDCByName(vdcName, true)
+	_, err = adminOrg.GetVDCByName(vdcName, true)
 	if err == nil {
 		return fmt.Errorf("vdc %s still found after deletion", vdcName)
 	}

--- a/vcd/resource_vcd_snat.go
+++ b/vcd/resource_vcd_snat.go
@@ -104,6 +104,7 @@ func resourceVcdSNATCreate(d *schema.ResourceData, meta interface{}) error {
 		_, _ = fmt.Fprint(getTerraformStdout(), "WARNING: this resource will require network_name and network_type in the next major version \n")
 		// TODO remove when major release is done
 		// this for back compatibility  when network name and network type isn't provided - this assign rule only for first external network
+		//lint:ignore SA1019 Preserving back compatibility until removal
 		task, err := edgeGateway.AddNATMapping("SNAT", d.Get("internal_ip").(string),
 			d.Get("external_ip").(string))
 		if err != nil {
@@ -198,6 +199,7 @@ func resourceVcdSNATDelete(d *schema.ResourceData, meta interface{}) error {
 		}
 	} else {
 		// this for back compatibility when network name and network type isn't provided - TODO remove with major release
+		//lint:ignore SA1019 Preserving back compatibility until removal
 		task, err := edgeGateway.RemoveNATMapping("SNAT", d.Get("internal_ip").(string),
 			d.Get("external_ip").(string),
 			"")
@@ -218,9 +220,9 @@ func resourceVcdSNATUpdate(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
 	// Update supports only when network name and network type provided
-	networkName := d.Get("network_name")
-	if nil == networkName || networkName.(string) == "" {
-		return fmt.Errorf("update works only when network_name and network_type is provided and rule created using them \n")
+	networkName, ok := d.GetOk("network_name")
+	if !ok || networkName == "" {
+		return fmt.Errorf("update works only when network_name and network_type is provided and rule created using them")
 	}
 
 	edgeGateway, err := vcdClient.GetEdgeGatewayFromResource(d, "edge_gateway")

--- a/vcd/resource_vcd_snat_test.go
+++ b/vcd/resource_vcd_snat_test.go
@@ -131,9 +131,9 @@ func testAccCheckVcdSNATDestroy(s *terraform.State) error {
 			return fmt.Errorf(errorUnableToFindEdgeGateway, err)
 		}
 
-		rule, err := edgeGateway.GetNatRule(rs.Primary.ID)
+		_, err = edgeGateway.GetNatRule(rs.Primary.ID)
 
-		if rule != nil {
+		if err == nil {
 			return fmt.Errorf("SNAT rule still exists.")
 		}
 	}
@@ -251,7 +251,7 @@ func testAccCheckVcdSNATDestroyForBackCompability(s *terraform.State) error {
 		}
 
 		if found {
-			return fmt.Errorf("SNAT rule still exists.")
+			return fmt.Errorf("SNAT rule still exists")
 		}
 	}
 

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -257,6 +257,7 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 			}
 
 			if ovf, ok := d.GetOk("ovf"); ok {
+				//lint:ignore SA1019 Property "ovf" is deprecated. Preserving until removal
 				task, err := vapp.SetOvf(convertToStringMap(ovf.(map[string]interface{})))
 
 				if err != nil {
@@ -474,6 +475,7 @@ func resourceVcdVAppUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if ovf, ok := d.GetOk("ovf"); ok {
+			//lint:ignore SA1019 Property "ovf" is deprecated. Preserving until removal
 			task, err := vapp.SetOvf(convertToStringMap(ovf.(map[string]interface{})))
 
 			if err != nil {

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -86,6 +86,7 @@ func resourceVcdVAppVm() *schema.Resource {
 			"cpus": &schema.Schema{
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Default:     1,
 				Description: "The number of virtual CPUs to allocate to the VM",
 			},
 			"cpu_cores": &schema.Schema{

--- a/vcd/structure.go
+++ b/vcd/structure.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
@@ -108,10 +106,6 @@ func getPortString(port int) string {
 	}
 	portstring := strconv.Itoa(port)
 	return portstring
-}
-
-func retryCall(seconds int, f resource.RetryFunc) error {
-	return resource.Retry(time.Duration(seconds)*time.Second, f)
 }
 
 func convertToStringMap(param map[string]interface{}) map[string]string {

--- a/vcd/suppress_funcs.go
+++ b/vcd/suppress_funcs.go
@@ -72,8 +72,5 @@ func suppressAlways() schema.SchemaDiffSuppressFunc {
 
 // suppressCase is a schema.SchemaDiffSuppressFunc which ignore case changes
 func suppressCase(k, old, new string, d *schema.ResourceData) bool {
-	if strings.ToLower(old) == strings.ToLower(new) {
-		return true
-	}
-	return false
+	return strings.EqualFold(old, new)
 }

--- a/vcd/validate_funcs.go
+++ b/vcd/validate_funcs.go
@@ -21,6 +21,7 @@ func noopValueWarningValidator(fieldValue interface{}, warningText string) schem
 }
 
 // anyValueWarningValidator is a validator which only emits always warning string
+//lint:ignore U1000 For future use
 func anyValueWarningValidator(warningText string) schema.SchemaValidateFunc {
 	return func(i interface{}, k string) (warnings []string, errors []error) {
 		warnings = append(warnings, fmt.Sprintf("%s\n\n", warningText))

--- a/website/docs/r/vapp_vm.html.markdown
+++ b/website/docs/r/vapp_vm.html.markdown
@@ -128,8 +128,8 @@ The following arguments are supported:
 * `catalog_name` - (Required) The catalog name in which to find the given vApp Template
 * `template_name` - (Required) The name of the vApp Template to use
 * `memory` - (Optional) The amount of RAM (in MB) to allocate to the VM
-* `cpus` - (Optional) The number of virtual CPUs to allocate to the VM. Socket count is a result of: virtual logical processors/cores per socket
-* `cpu_cores` - (Optional; *v2.1+*) The number of cores per socket
+* `cpus` - (Optional) The number of virtual CPUs to allocate to the VM. Socket count is a result of: virtual logical processors/cores per socket. The default is 1
+* `cpu_cores` - (Optional; *v2.1+*) The number of cores per socket. The default is 1
 * `metadata` - (Optional; *v2.2+*) Key value map of metadata to assign to this VM
 * `initscript` (Optional) Script to run on initial boot or with customization.force=true set
 * `storage_profile` (Optional; *v2.6+*) Storage profile to override the default one


### PR DESCRIPTION
*  Add missing default value for 'cpus' in VM
*  Add command 'make static' to run staticckeck in CI
    * Add option 'static' to runtest.sh
    * Add command 'static' to GNUmakefile
    * Add command 'make static' to Travis actions
*  Fix staticcheck warnings in vcd code

```
staticcheck -tags functional .

## removed
* api_test.go:70:6: func isTagSet is unused (U1000)
* structure.go:113:6: func retryCall is unused (U1000)

## fixed
* api_test.go:146:5: should omit nil check; len() for nil slices is defined as zero (S1009)
* catalogitem.go:39:15: this value of err is never used (SA4006)
* resource_vcd_dnat.go:309:20: error strings should not end with punctuation or a newline (ST1005)
* resource_vcd_dnat_test.go:211:9: this value of err is never used (SA4006)
* resource_vcd_firewall_rules.go:223:4: should use strings.EqualFold(a, b) instead of strings.ToLower(a) == strings.ToLower(b) (SA6005)
* resource_vcd_firewall_rules.go:225:4: should use strings.EqualFold(a, b) instead of strings.ToLower(a) == strings.ToLower(b) (SA6005)
* resource_vcd_firewall_rules.go:229:23: error strings should not be capitalized (ST1005)
* resource_vcd_snat.go:223:20: error strings should not end with punctuation or a newline (ST1005)
* resource_vcd_independent_disk.go:330:5: error var helpDiskError should have name of the form errFoo (ST1012)
* resource_vcd_org_vdc.go:526:2: this value of vdc is never used (SA4006)
* resource_vcd_snat_test.go:134:9: this value of err is never used (SA4006)
* suppress_funcs.go:75:2: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (S1008)
* suppress_funcs.go:75:5: should use strings.EqualFold(a, b) instead of strings.ToLower(a) == strings.ToLower(b) (SA6005)

## commented out
* resource_vcd_nsxv_firewall_rule.go:624:27: this result of append is never used, except maybe in other appends (SA4010)
* resource_vcd_nsxv_firewall_rule.go:629:35: this result of append is never used, except maybe in other appends (SA4010)

## skipped with comment
* validate_funcs.go:24:6: func anyValueWarningValidator is unused (U1000)
* resource_vcd_snat.go:107:16: edgeGateway.AddNATMapping is deprecated: Use eGW.AddNATRule()  (SA1019)
* resource_vcd_snat.go:201:16: edgeGateway.RemoveNATMapping is deprecated: use one of RemoveNATRuleAsync, RemoveNATRule  (SA1019)
* resource_vcd_vapp.go:260:18: vapp.SetOvf is deprecated: Use vm.SetProductSectionList()  (SA1019)
* resource_vcd_vapp.go:477:17: vapp.SetOvf is deprecated: Use vm.SetProductSectionList()  (SA1019)
* resource_vcd_dnat.go:156:16: edgeGateway.AddNATPortMapping is deprecated: Use eGW.AddNATPortMappingWithUplink()  (SA1019)
* resource_vcd_dnat.go:285:16: edgeGateway.RemoveNATPortMapping is deprecated: use one of RemoveNATRuleAsync, RemoveNATRule  (SA1019)
```