### PR TITLE
Add ability of using authorization tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ IMPROVEMENTS:
 * Fix code warnings from `staticcheck` and add command `make static` to Travis tests
 * `resource/vcd_edge_gateway` and `datasource/vcd_edge_gateway` add `default_external_network_ip`
   field to export default edge gateway IP address - [GH-389]
+* The `vcd` provider now has the ability of connecting through an authorization token - [GH-280]
+* Add command `make token` to create an authorization token from testing credentials
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ IMPROVEMENTS:
 * Fix code warnings from `staticcheck` and add command `make static` to Travis tests
 * `resource/vcd_edge_gateway` and `datasource/vcd_edge_gateway` add `default_external_network_ip`
   field to export default edge gateway IP address - [GH-389]
-* The `vcd` provider now has the ability of connecting through an authorization token - [GH-280]
+* Add `token` to the `vcd` provider for the ability of connecting with an authorization token - [GH-280]
 * Add command `make token` to create an authorization token from testing credentials
 
 BUG FIXES:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -46,6 +46,10 @@ test-env-apply:
 test-env-destroy:
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' test-env-destroy"
 
+# Retrieves the authorization token
+token:
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' token"
+
 # runs staticcheck
 static: fmtcheck
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' static"

--- a/TESTING.md
+++ b/TESTING.md
@@ -434,4 +434,5 @@ borrow org and vcd from the provider.
 used in the documentation index.
 * `VCD_TEST_ORG_USER=1` will enable tests with Org User, using the credentials from the configuration file
   (`testEnvBuild.OrgUser` and `testEnvBuild.OrgUserPassword`)
-  
+* `VCD_TOKEN` : specifies the authentication token to use instead of username/password
+   (Use `./scripts/get_token.sh` to retrieve one)

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
 	github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.4
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.5

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,5 @@ go 1.13
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
-	github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.4
+	github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.5
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.5

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bsm/go-vlq v0.0.0-20150828105119-ec6e8d4f5f4e/go.mod h1:N+BjUcTjSxc2mtRGSCPsat1kze3CUtvJN3/jTXlp29k=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.5 h1:jtD4l+NnnhrLgzxQHj6Q1X+N5lKX9eVTU4+hQ0ZUtHo=
+github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.5/go.mod h1:VqfkCixIzRmj4EzF2yFJKB+aKDW6GkXlLbFh5xZ+qqs=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -187,8 +189,6 @@ github.com/ulikunitz/xz v0.5.5 h1:pFrO0lVpTBXLpYw+pnLj6TbvHuyjXMfjGeCwSqCVwok=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible h1:wapg9xDUZDzGCNFlwc5SqI1rvcciqcxEHac4CYj89xI=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.4 h1:O/gkoZ5aS7e/t3VeyJ4Emn02DTFZQzjGTHkXwXS03Lw=
-github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.4/go.mod h1:VqfkCixIzRmj4EzF2yFJKB+aKDW6GkXlLbFh5xZ+qqs=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bsm/go-vlq v0.0.0-20150828105119-ec6e8d4f5f4e/go.mod h1:N+BjUcTjSxc2mtRGSCPsat1kze3CUtvJN3/jTXlp29k=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.5 h1:jtD4l+NnnhrLgzxQHj6Q1X+N5lKX9eVTU4+hQ0ZUtHo=
-github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.5/go.mod h1:VqfkCixIzRmj4EzF2yFJKB+aKDW6GkXlLbFh5xZ+qqs=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -189,6 +187,8 @@ github.com/ulikunitz/xz v0.5.5 h1:pFrO0lVpTBXLpYw+pnLj6TbvHuyjXMfjGeCwSqCVwok=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible h1:wapg9xDUZDzGCNFlwc5SqI1rvcciqcxEHac4CYj89xI=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.5 h1:hQDzS94JgM2E36jxetpcGzeRJBK3M9ergjej9wPBDhk=
+github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.5/go.mod h1:VqfkCixIzRmj4EzF2yFJKB+aKDW6GkXlLbFh5xZ+qqs=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/scripts/get_token.sh
+++ b/scripts/get_token.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# This script will connect to the vCD using username and password,
+# and show the header that cointains an authorization token.
+#
+user=$1
+password=$2
+org=$3
+IP=$4
+
+if [ -z "$IP" ]
+then
+    echo "Syntax $0 user password organization IP_address"
+    exit 1
+fi
+
+auth=$(echo -n "$user@$org:$password" |base64)
+
+curl -I -k --header "Accept: application/*;version=27.0" \
+    --header "Authorization: Basic $auth" \
+    --request POST https://$IP/api/sessions
+
+# If successful, the output of this command will include a line like the following
+# x-vcloud-authorization: 08a321735de84f1d9ec80c3b3e18fa8b
+#
+# The string after `x-vcloud-authorization:` is the token.

--- a/scripts/get_token.sh
+++ b/scripts/get_token.sh
@@ -9,13 +9,13 @@ IP=$4
 
 if [ -z "$IP" ]
 then
-    echo "Syntax $0 user password organization IP_address"
+    echo "Syntax $0 user password organization hostname_or_IP_address"
     exit 1
 fi
 
 auth=$(echo -n "$user@$org:$password" |base64)
 
-curl -I -k --header "Accept: application/*;version=27.0" \
+curl -I -k --header "Accept: application/*;version=29.0" \
     --header "Authorization: Basic $auth" \
     --request POST https://$IP/api/sessions
 

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -233,7 +233,7 @@ function make_token {
 
   echo "# Connecting to $url"
   curl --silent --head --insecure \
-    --header "Accept: application/*;version=27.0" \
+    --header "Accept: application/*;version=29.0" \
     --header "Authorization: Basic $auth" \
     --request POST $url/sessions | grep -i authorization
 }

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -22,7 +22,7 @@ then
     VERBOSE=1
 fi
 
-accepted_commands=(static short acceptance sequential-acceptance multiple binary 
+accepted_commands=(static token short acceptance sequential-acceptance multiple binary
     binary-prepare catalog gateway vapp vm network extnetwork multinetwork 
     short-provider lb user acceptance-orguser short-provider-orguser)
 
@@ -194,6 +194,50 @@ function exists_in_path {
     done
 }
 
+function make_token {
+  jq=$(exists_in_path jq)
+  if [ -z "$jq" ]
+  then
+    echo "program jq not found"
+    exit 1
+  fi
+  curl=$(exists_in_path curl)
+  if [ -z "$curl" ]
+  then
+    echo "program curl not found"
+    exit 1
+  fi
+  check_for_config_file
+  echo "# Using credentials from $config_file"
+  user=$(jq -r '.provider.user' $config_file)
+  password=$(jq -r '.provider.password' $config_file)
+  url=$(jq -r '.provider.url' $config_file)
+  org=$(jq -r '.provider.sysOrg' $config_file)
+
+  if [ -z "$user" -o "$user" == "null" ]
+  then
+    echo "missing user from configuration file. Can't retrieve token"
+    exit 1
+  fi
+  if [ -z "$password" -o "$password" == "null" ]
+  then
+    echo "missing password from configuration file. Can't retrieve token"
+    exit 1
+  fi
+  if [ -z "$org" -o "$org" == "null" ]
+  then
+    echo "missing org from configuration file. Can't retrieve token"
+    exit 1
+  fi
+  auth=$(echo -n "$user@$org:$password" |base64)
+
+  echo "# Connecting to $url"
+  curl --silent --head --insecure \
+    --header "Accept: application/*;version=27.0" \
+    --header "Authorization: Basic $auth" \
+    --request POST $url/sessions | grep -i authorization
+}
+
 function check_static {
     static_check=$(exists_in_path staticcheck)
     if [  -z "$staticcheck" -a -n "$TRAVIS" ]
@@ -250,6 +294,9 @@ function check_static {
 case $wanted in
     static)
         check_static
+        ;;
+    token)
+        make_token
         ;;
     test-env-init)
         export VCD_ENV_INIT=1

--- a/vcd/datasource_vcd_network_test.go
+++ b/vcd/datasource_vcd_network_test.go
@@ -58,7 +58,7 @@ func getAvailableNetworks() error {
 	if err != nil {
 		return fmt.Errorf("error getting client configuration: %s", err)
 	}
-	err = vcdClient.Authenticate(testConfig.Provider.User, testConfig.Provider.Password, testConfig.Provider.SysOrg)
+	err = ProviderAuthenticate(vcdClient, testConfig.Provider.User, testConfig.Provider.Password, testConfig.Provider.Token, testConfig.Provider.SysOrg)
 	if err != nil {
 		return fmt.Errorf("authentication error: %s", err)
 	}

--- a/vcd/datasource_vcd_vapp_test.go
+++ b/vcd/datasource_vcd_vapp_test.go
@@ -17,7 +17,7 @@ func getAvailableVapp() (*govcd.VApp, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting client configuration: %s", err)
 	}
-	err = vcdClient.Authenticate(testConfig.Provider.User, testConfig.Provider.Password, testConfig.Provider.SysOrg)
+	err = ProviderAuthenticate(vcdClient, testConfig.Provider.User, testConfig.Provider.Password, testConfig.Provider.Token, testConfig.Provider.SysOrg)
 	if err != nil {
 		return nil, fmt.Errorf("authentication error: %s", err)
 	}

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -28,6 +28,13 @@ func Provider() terraform.ResourceProvider {
 				Description: "The user password for VCD API operations.",
 			},
 
+			"token": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("VCD_TOKEN", nil),
+				Description: "The token used instead of username/password for VCD API operations.",
+			},
+
 			"sysorg": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -166,6 +173,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		User:            d.Get("user").(string),
 		Password:        d.Get("password").(string),
+		Token:           d.Get("token").(string),
 		SysOrg:          connectOrg,            // Connection org
 		Org:             d.Get("org").(string), // Default org for operations
 		Vdc:             d.Get("vdc").(string), // Default vdc

--- a/vcd/provider_test.go
+++ b/vcd/provider_test.go
@@ -26,10 +26,10 @@ func TestProvider_impl(t *testing.T) {
 // Therefore, we can safely require that testConfig fields have been filled.
 func testAccPreCheck(t *testing.T) {
 	if testConfig.Provider.User == "" && testConfig.Provider.Token == "" {
-		t.Fatal("provider.user must be set for acceptance tests")
+		t.Fatal("provider.user or provider.token must be set for acceptance tests")
 	}
 	if testConfig.Provider.Password == "" && testConfig.Provider.Token == "" {
-		t.Fatal("provider.password must be set for acceptance tests")
+		t.Fatal("provider.password or provider.token must be set for acceptance tests")
 	}
 	if testConfig.Provider.SysOrg == "" {
 		t.Fatal("provider.sysOrg must be set for acceptance tests")

--- a/vcd/provider_test.go
+++ b/vcd/provider_test.go
@@ -25,10 +25,10 @@ func TestProvider_impl(t *testing.T) {
 // When this function is called, the initialization in config_test.go has already happened.
 // Therefore, we can safely require that testConfig fields have been filled.
 func testAccPreCheck(t *testing.T) {
-	if testConfig.Provider.User == "" {
+	if testConfig.Provider.User == "" && testConfig.Provider.Token == "" {
 		t.Fatal("provider.user must be set for acceptance tests")
 	}
-	if testConfig.Provider.Password == "" {
+	if testConfig.Provider.Password == "" && testConfig.Provider.Token == "" {
 		t.Fatal("provider.password must be set for acceptance tests")
 	}
 	if testConfig.Provider.SysOrg == "" {
@@ -58,6 +58,7 @@ func createTemporaryVCDConnection() *VCDClient {
 	config := Config{
 		User:            testConfig.Provider.User,
 		Password:        testConfig.Provider.Password,
+		Token:           testConfig.Provider.Token,
 		SysOrg:          testConfig.Provider.SysOrg,
 		Org:             testConfig.VCD.Org,
 		Vdc:             testConfig.VCD.Vdc,

--- a/vcd/sample_vcd_test_config.json
+++ b/vcd/sample_vcd_test_config.json
@@ -5,6 +5,7 @@
     "//"  : "This section contains credentials related to the vCD connection of Sys or Org user",
     "user": "root",
     "password": "somePassword",
+    "token": "Access token to be used instead of username/password",
     "url": "https://10.13.21.20/api",
     "//": "Use 'System' if you are Sys admin and Org name if you tenant",
     "sysOrg": "System",

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/api.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/api.go
@@ -36,6 +36,9 @@ type Client struct {
 	MaxRetryTimeout int
 }
 
+// The header key used by default to set the authorization token.
+const AuthorizationHeader = "X-Vcloud-Authorization"
+
 // General purpose error to be used whenever an entity is not found from a "GET" request
 // Allows a simpler checking of the call result
 // such as

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/sample_govcd_test_config.json
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/sample_govcd_test_config.json
@@ -3,6 +3,8 @@
 	"provider": {
 		"user": "someuser",
 		"password": "somepassword",
+    "//": "If token is provided, username and password are ignored",
+    "token": "an_auth_token",
 		"url": "https://11.111.1.111/api",
 		"sysOrg": "System",
 		"//": "(Optional) In some cases the vCloud Director SDK must wait. It can be",

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/sample_govcd_test_config.yaml
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/sample_govcd_test_config.yaml
@@ -11,6 +11,8 @@ provider:
     # (Providing org credentials will skip some tests)
     user: someuser
     password: somepassword
+    # If token is provided, username and password are ignored
+    token: an_auth_token
     #
     # The vCD address, in the format https://vCD_IP/api
     # or https://vCD_host_name/api

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/system.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/system.go
@@ -818,7 +818,7 @@ func (vcdClient *VCDClient) GetOrgByName(orgName string) (*Org, error) {
 	org := NewOrg(&vcdClient.Client)
 
 	_, err = vcdClient.Client.ExecuteRequest(orgUrl, http.MethodGet,
-		"", "error retrieving org list: %s", nil, org.Org)
+		"", "error retrieving org: %s", nil, org.Org)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -212,7 +212,7 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v3.3.3+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.4 => github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.5
+# github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.5
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -212,7 +212,7 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v3.3.3+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.4
+# github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.4 => github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.5
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -111,6 +111,61 @@ resource "vcd_network_routed" "net2" {
 }
 ```
 
+## Connecting with authorization token
+
+You can connect using an authorization token instead of username and password.
+
+```hcl
+provider "vcd" {
+  user                 = ""
+  password             = ""
+  token                = "${var.token}"
+  sysorg               = "System"
+  org                  = "${var.vcd_org}"                  # Default for resources
+  vdc                  = "${var.vcd_vdc}"                  # Default for resources
+  url                  = "${var.vcd_url}"
+  max_retry_timeout    = "${var.vcd_max_retry_timeout}"
+  allow_unverified_ssl = "${var.vcd_allow_unverified_ssl}"
+}
+
+# Create a new network in the default organization and VDC
+resource "vcd_network_routed" "net1" {
+  # ...
+}
+```
+When using a token, the fields `user` and `password` will be ignored, but they need to be in the script.
+
+To obtain a token you can use this sample shell script:
+
+```shell script
+#!/bin/bash
+user=$1
+password=$2
+org=$3
+IP=$4
+
+if [ -z "$IP" ]
+then
+    echo "Syntax $0 user password organization IP_address"
+    exit 1
+fi
+
+auth=$(echo -n "$user@$org:$password" | base64)
+
+curl -I -k --header "Accept: application/*;version=27.0" \
+    --header "Authorization: Basic $auth" \
+    --request POST https://$IP/api/sessions
+```
+
+If successful, the output of this command will include a line like the following
+```
+x-vcloud-authorization: 08a321735de84f1d9ec80c3b3e18fa8b
+```
+The string after `x-vcloud-authorization:` is the token.
+
+The token will grant the same abilities as the account used to run the above script. Using a token produced
+by an org admin to run a task that requires a system administrator will fail.
+
 ## Argument Reference
 
 The following arguments are used to configure the VMware vCloud Director Provider:
@@ -122,6 +177,10 @@ The following arguments are used to configure the VMware vCloud Director Provide
 * `password` - (Required) This is the password for vCloud Director API operations. Can
   also be specified with the `VCD_PASSWORD` environment variable.
   
+* `token` - (Optional; *v2.6+*) This is the authorization token that can be used
+   instead of username and password. When this is set, username and password will not
+    be used and may be left empty, or may contain other remarks.
+    
 * `org` - (Required) This is the vCloud Director Org on which to run API
   operations. Can also be specified with the `VCD_ORG` environment
   variable.  

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -178,8 +178,8 @@ The following arguments are used to configure the VMware vCloud Director Provide
   also be specified with the `VCD_PASSWORD` environment variable.
   
 * `token` - (Optional; *v2.6+*) This is the authorization token that can be used
-   instead of username and password. When this is set, username and password will not
-    be used and may be left empty, or may contain other remarks.
+   instead of username and password. When this is set, username and password will
+    be ignored, but should be left in configuration either empty or with any custom values.
     
 * `org` - (Required) This is the vCloud Director Org on which to run API
   operations. Can also be specified with the `VCD_ORG` environment

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -146,13 +146,13 @@ IP=$4
 
 if [ -z "$IP" ]
 then
-    echo "Syntax $0 user password organization IP_address"
+    echo "Syntax $0 user password organization hostname_or_IP_address"
     exit 1
 fi
 
 auth=$(echo -n "$user@$org:$password" | base64)
 
-curl -I -k --header "Accept: application/*;version=27.0" \
+curl -I -k --header "Accept: application/*;version=29.0" \
     --header "Authorization: Basic $auth" \
     --request POST https://$IP/api/sessions
 ```
@@ -180,6 +180,7 @@ The following arguments are used to configure the VMware vCloud Director Provide
 * `token` - (Optional; *v2.6+*) This is the authorization token that can be used
    instead of username and password. When this is set, username and password will
     be ignored, but should be left in configuration either empty or with any custom values.
+    A token can be specified with the `VCD_TOKEN` environment variable.
     
 * `org` - (Required) This is the vCloud Director Org on which to run API
   operations. Can also be specified with the `VCD_ORG` environment


### PR DESCRIPTION
* Provider can connect using property 'token'
* When token is used, username and password are ignored
* Add script get_token.sh
* Add command 'make token'

Implementation notes:

* As mentioned in [go-vcloud-director PR #262](https://github.com/vmware/go-vcloud-director/pull/262), the user/password information and the token are not correlated within the provider code, meaning that we may accidentally use a token that was not created using those credentials.

* Properties `user` and `password` are still mandatory when using tokens. They can be empty, but not missing from the HCL script. If we make them optional, we may break compatibility with current functionality, where a missing property is detected during plan.

* `make token` is not mentioned in the provider documentation, as users of the provider may not be using the code, but downloading the provider directly. Also, the example on how to get the token is Unix only. The alternative would be creating a cross-platform tool, but it may be overkill.