### PR TITLE
Enable org users to see direct network data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ BUG FIXES:
   [GH-379]
 * Fix `vcd_independent_disk` reapply issue, which was seen when optional `bus_sub_type` and `bus_type` wasn't used - [GH-394]
 * Fix `vcd_vapp_network` apply issue, where the property `guest_vlan_allowed` was applied only to the last of multiple networks.
+* Fix `vcd_network_direct` data reading from Org Users. Such users can now read the data from existing direct networks.
 
 DEPRECATIONS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ IMPROVEMENTS:
 * `resource/vcd_network_direct` Add property `description`
 * `resource/vcd_network_routed` Add check for valid IPs [GH-374]
 * `resource/vcd_network_isolated` Add check for valid IPs [GH-373]
-* `resource/vcd_network_direct` Org User can now read this resource (previously it was only Sys Admin) - this change makes it possible to get the details of External Network as Org User
 
 BUG FIXES:
 
@@ -48,6 +47,7 @@ BUG FIXES:
   [GH-379]
 * Fix `vcd_independent_disk` reapply issue, which was seen when optional `bus_sub_type` and `bus_type` wasn't used - [GH-394]
 * Fix `vcd_vapp_network` apply issue, where the property `guest_vlan_allowed` was applied only to the last of multiple networks.
+* `datasource/vcd_network_direct` is now readable by Org User (previously it was only by Sys Admin), as this change made it possible to get the details of External Network as Org User [GH-408]
 
 DEPRECATIONS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ IMPROVEMENTS:
 * `resource/vcd_network_direct` Add property `description`
 * `resource/vcd_network_routed` Add check for valid IPs [GH-374]
 * `resource/vcd_network_isolated` Add check for valid IPs [GH-373]
-
+* `resource/vcd_network_direct` Org User can now read this resource (previously it was only Sys Admin) - this change makes it possible to get the details of External Network as Org User
 
 BUG FIXES:
 
@@ -48,7 +48,6 @@ BUG FIXES:
   [GH-379]
 * Fix `vcd_independent_disk` reapply issue, which was seen when optional `bus_sub_type` and `bus_type` wasn't used - [GH-394]
 * Fix `vcd_vapp_network` apply issue, where the property `guest_vlan_allowed` was applied only to the last of multiple networks.
-* Fix `vcd_network_direct` data reading from Org Users. Such users can now read the data from existing direct networks.
 
 DEPRECATIONS:
 

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.13
 require (
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/terraform-plugin-sdk v1.3.0
-	github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.8
+	github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.9
 )

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/vmihailenco/msgpack v3.3.3+incompatible h1:wapg9xDUZDzGCNFlwc5SqI1rvc
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.8 h1:v9ti+uUG5MJLDI2RRMTp4wF3XXcF1Z/N5FxVUxAXWNA=
-github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.8/go.mod h1:zjondbeyTfZlzhwxOzyF4K2sWWYgMEv5H91dp5dPbU8=
+github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.9 h1:jHcYDaWZtSbHdgO6Q/th0fDZxP86S0oRgM79r02BPno=
+github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.9/go.mod h1:zjondbeyTfZlzhwxOzyF4K2sWWYgMEv5H91dp5dPbU8=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/vcd/datasource_vcd_network_test.go
+++ b/vcd/datasource_vcd_network_test.go
@@ -70,10 +70,7 @@ func getAvailableNetworks() error {
 		switch net.LinkType {
 		case 0:
 			networkType = "vcd_network_direct"
-			parentNetwork := network.OrgVDCNetwork.Configuration.ParentNetwork
-			if parentNetwork != nil {
-				parent = parentNetwork.Name
-			}
+			parent = net.ConnectedTo
 		case 1:
 			networkType = "vcd_network_routed"
 			parent = net.ConnectedTo

--- a/vcd/resource_vcd_network_direct.go
+++ b/vcd/resource_vcd_network_direct.go
@@ -95,6 +95,9 @@ func resourceVcdNetworkDirect() *schema.Resource {
 func resourceVcdNetworkDirectCreate(d *schema.ResourceData, meta interface{}) error {
 	vcdClient := meta.(*VCDClient)
 
+	if !vcdClient.Client.IsSysAdmin {
+		return fmt.Errorf("creation of a vcd_network_routed requires system administrator privileges")
+	}
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {
 		return fmt.Errorf(errorRetrievingOrgAndVdc, err)
@@ -167,26 +170,28 @@ func genericVcdNetworkDirectRead(d *schema.ResourceData, meta interface{}, origi
 	_ = d.Set("href", network.OrgVDCNetwork.HREF)
 	_ = d.Set("shared", network.OrgVDCNetwork.IsShared)
 
-	parentNetwork := network.OrgVDCNetwork.Configuration.ParentNetwork
-	if parentNetwork == nil {
-		return fmt.Errorf("[network direct read] no parent network found for %s", network.OrgVDCNetwork.Name)
-	}
-	_ = d.Set("external_network", parentNetwork.Name)
-
-	externalNetwork, err := vcdClient.GetExternalNetworkByName(parentNetwork.Name)
+	// Getting external network data through network list, as a direct call to external network
+	// structure requires system admin privileges.
+	// Org Users can't create a direct network, but should be able to see the connection info.
+	networkList, err := vdc.GetNetworkList()
 	if err != nil {
-		return fmt.Errorf("[network direct read] error fetching external network %s ", parentNetwork.Name)
+		return fmt.Errorf("error retrieving network list for VDC %s : %s", vdc.Vdc.Name, err)
 	}
+	var currentNetwork *types.QueryResultOrgVdcNetworkRecordType
+	for _, net := range networkList {
+		if net.Name == network.OrgVDCNetwork.Name {
+			currentNetwork = net
+		}
+	}
+	if currentNetwork == nil {
+		return fmt.Errorf("error retrieving network %s from network list", network.OrgVDCNetwork.Name)
+	}
+	_ = d.Set("external_network", currentNetwork.ConnectedTo)
+	_ = d.Set("external_network_netmask", currentNetwork.Netmask)
+	_ = d.Set("external_network_dns1", currentNetwork.Dns1)
+	_ = d.Set("external_network_dns2", currentNetwork.Dns2)
+	_ = d.Set("external_network_dns_suffix", currentNetwork.DnsSuffix)
 
-	enConf := externalNetwork.ExternalNetwork.Configuration
-	if enConf == nil || enConf.IPScopes == nil || len(enConf.IPScopes.IPScope) == 0 {
-		return fmt.Errorf("[network direct read] error retrieving details from external network %s", externalNetwork.ExternalNetwork.Name)
-	}
-	_ = d.Set("external_network_gateway", externalNetwork.ExternalNetwork.Configuration.IPScopes.IPScope[0].Gateway)
-	_ = d.Set("external_network_netmask", externalNetwork.ExternalNetwork.Configuration.IPScopes.IPScope[0].Netmask)
-	_ = d.Set("external_network_dns1", externalNetwork.ExternalNetwork.Configuration.IPScopes.IPScope[0].DNS1)
-	_ = d.Set("external_network_dns2", externalNetwork.ExternalNetwork.Configuration.IPScopes.IPScope[0].DNS2)
-	_ = d.Set("external_network_dns_suffix", externalNetwork.ExternalNetwork.Configuration.IPScopes.IPScope[0].DNSSuffix)
 	_ = d.Set("description", network.OrgVDCNetwork.Description)
 
 	d.SetId(network.OrgVDCNetwork.ID)

--- a/vcd/resource_vcd_network_direct.go
+++ b/vcd/resource_vcd_network_direct.go
@@ -96,7 +96,7 @@ func resourceVcdNetworkDirectCreate(d *schema.ResourceData, meta interface{}) er
 	vcdClient := meta.(*VCDClient)
 
 	if !vcdClient.Client.IsSysAdmin {
-		return fmt.Errorf("creation of a vcd_network_routed requires system administrator privileges")
+		return fmt.Errorf("creation of a vcd_network_direct requires system administrator privileges")
 	}
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/edgegateway.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/edgegateway.go
@@ -1059,7 +1059,9 @@ func (egw *EdgeGateway) HasDefaultGateway() bool {
 
 // HasAdvancedNetworking returns true if the edge gateway has advanced network configuration enabled
 func (egw *EdgeGateway) HasAdvancedNetworking() bool {
-	return egw.EdgeGateway.Configuration != nil && egw.EdgeGateway.Configuration.AdvancedNetworkingEnabled
+	return egw.EdgeGateway.Configuration != nil &&
+		egw.EdgeGateway.Configuration.AdvancedNetworkingEnabled != nil &&
+		*egw.EdgeGateway.Configuration.AdvancedNetworkingEnabled
 }
 
 // buildProxiedEdgeEndpointURL helps to get root endpoint for Edge Gateway using the

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/system.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/system.go
@@ -128,10 +128,10 @@ func CreateEdgeGatewayAsync(vcdClient *VCDClient, egwc EdgeGatewayCreation) (Tas
 		Name:        egwc.Name,
 		Description: egwc.Description,
 		Configuration: &types.GatewayConfiguration{
-			UseDefaultRouteForDNSRelay: egwc.UseDefaultRouteForDNSRelay,
-			HaEnabled:                  egwc.HAEnabled,
+			UseDefaultRouteForDNSRelay: &egwc.UseDefaultRouteForDNSRelay,
+			HaEnabled:                  &egwc.HAEnabled,
 			GatewayBackingConfig:       egwc.BackingConfiguration,
-			AdvancedNetworkingEnabled:  egwc.AdvancedNetworkingEnabled,
+			AdvancedNetworkingEnabled:  &egwc.AdvancedNetworkingEnabled,
 			DistributedRoutingEnabled:  &distributed,
 			GatewayInterfaces: &types.GatewayInterfaces{
 				GatewayInterface: []*types.GatewayInterface{},

--- a/vendor/github.com/vmware/go-vcloud-director/v2/types/v56/types.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/types/v56/types.go
@@ -1575,15 +1575,35 @@ type EdgeGateway struct {
 // Since: 5.1
 type GatewayConfiguration struct {
 	Xmlns string `xml:"xmlns,attr,omitempty"`
-	// Elements
-	BackwardCompatibilityMode       bool               `xml:"BackwardCompatibilityMode,omitempty"`       // Compatibility mode. Default is false. If set to true, will allow users to write firewall rules in the old 1.5 format. The new format does not require to use direction in firewall rules. Also, for firewall rules to allow NAT traffic the filter is applied on the original IP addresses. Once set to true cannot be reverted back to false.
-	GatewayBackingConfig            string             `xml:"GatewayBackingConfig"`                      // Configuration of the vShield edge VM for this gateway. One of: compact, full.
-	GatewayInterfaces               *GatewayInterfaces `xml:"GatewayInterfaces"`                         // List of Gateway interfaces.
-	EdgeGatewayServiceConfiguration *GatewayFeatures   `xml:"EdgeGatewayServiceConfiguration,omitempty"` // Represents Gateway Features.
-	HaEnabled                       bool               `xml:"HaEnabled,omitempty"`                       // True if this gateway is highly available. (Requires two vShield edge VMs.)
-	AdvancedNetworkingEnabled       bool               `xml:"AdvancedNetworkingEnabled,omitempty"`       // True if the gateway uses advanced networking
-	DistributedRoutingEnabled       *bool              `xml:"DistributedRoutingEnabled,omitempty"`       // True if gateway is attached to a Distributed Logical Router
-	UseDefaultRouteForDNSRelay      bool               `xml:"UseDefaultRouteForDnsRelay,omitempty"`      // True if the default gateway on the external network selected for default route should be used as the DNS relay.
+	// BackwardCompatibilityMode. Default is false. If set to true, will allow users to write firewall
+	// rules in the old 1.5 format. The new format does not require to use direction in firewall
+	// rules. Also, for firewall rules to allow NAT traffic the filter is applied on the original IP
+	// addresses. Once set to true cannot be reverted back to false.
+	BackwardCompatibilityMode bool `xml:"BackwardCompatibilityMode,omitempty"`
+	// GatewayBackingConfig defines configuration of the vShield edge VM for this gateway. One of:
+	// compact, full.
+	GatewayBackingConfig string `xml:"GatewayBackingConfig"`
+	// GatewayInterfaces holds configuration for edge gateway interfaces, ip allocations, traffic
+	// rate limits and ip sub-allocations
+	GatewayInterfaces *GatewayInterfaces `xml:"GatewayInterfaces"`
+	// EdgeGatewayServiceConfiguration represents Gateway Features.
+	EdgeGatewayServiceConfiguration *GatewayFeatures `xml:"EdgeGatewayServiceConfiguration,omitempty"`
+	// True if this gateway is highly available. (Requires two vShield edge VMs.)
+	HaEnabled *bool `xml:"HaEnabled,omitempty"`
+	// UseDefaultRouteForDNSRelay defines if the default gateway on the external network selected
+	// for default route should be used as the DNS relay.
+	UseDefaultRouteForDNSRelay *bool `xml:"UseDefaultRouteForDnsRelay,omitempty"`
+	// AdvancedNetworkingEnabled allows to use NSX capabilities such dynamic routing (BGP, OSPF),
+	// zero trust networking (DLR), enchanced VPN support (IPsec VPN, SSL VPN-Plus).
+	AdvancedNetworkingEnabled *bool `xml:"AdvancedNetworkingEnabled,omitempty"`
+	// DistributedRoutingEnabled enables distributed routing on the gateway to allow creation of
+	// many more organization VDC networks. Traffic in those networks is optimized for VM-to-VM
+	// communication.
+	DistributedRoutingEnabled *bool `xml:"DistributedRoutingEnabled,omitempty"`
+	// FipsModeEnabled allows any secure communication to or from the NSX Edge uses cryptographic
+	// algorithms or protocols that are allowed by United States Federal Information Processing
+	// Standards (FIPS). FIPS mode turns on the cipher suites that comply with FIPS.
+	FipsModeEnabled *bool `xml:"FipsModeEnabled,omitempty"`
 }
 
 // GatewayInterfaces is a list of Gateway Interfaces.
@@ -1612,16 +1632,27 @@ type GatewayInterface struct {
 	UseForDefaultRoute  bool                   `xml:"UseForDefaultRoute,omitempty"`  // True if this network is default route for the gateway.
 }
 
+// SortBySubnetParticipationGateway allows to sort SubnetParticipation property slice by gateway
+// address
+func (g *GatewayInterface) SortBySubnetParticipationGateway() {
+	sort.SliceStable(g.SubnetParticipation, func(i, j int) bool {
+		return g.SubnetParticipation[i].Gateway < g.SubnetParticipation[j].Gateway
+	})
+}
+
 // SubnetParticipation allows to chose which subnets a gateway can be a part of
 // Type: SubnetParticipationType
 // Namespace: http://www.vmware.com/vcloud/v1.5
 // Description: Allows to chose which subnets a gateway can be part of
 // Since: 5.1
+//
+// Note. Field order is important and should not be changed as API returns errors if IPRanges come
+// before Gateway and Netmask
 type SubnetParticipation struct {
 	Gateway            string    `xml:"Gateway"`                      // Gateway for subnet
+	Netmask            string    `xml:"Netmask"`                      // Netmask for the subnet.
 	IPAddress          string    `xml:"IpAddress,omitempty"`          // Ip Address to be assigned. Keep empty or omit element for auto assignment
 	IPRanges           *IPRanges `xml:"IpRanges,omitempty"`           // Range of IP addresses available for external interfaces.
-	Netmask            string    `xml:"Netmask"`                      // Netmask for the subnet
 	UseForDefaultRoute bool      `xml:"UseForDefaultRoute,omitempty"` // True if this network is default route for the gateway.
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -224,7 +224,7 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.8
+# github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.9
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util


### PR DESCRIPTION
Until now, direct network data was only visible to system administrators, because we were fetching the external network data directly, and such operation requires system administrator privileges.
We are now using a call to `GetNetworkList`, which is available to Org users, and they are now able to read the data.

Note that Org users are still unable to create a direct network, as such operation is still restricted to system users.