### PR TITLE
Add support for IP sets in NSX-V firewall rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ IMPROVEMENTS:
 * `resource/vcd_network_direct` Add property `description`
 * `resource/vcd_network_routed` Add check for valid IPs [GH-374]
 * `resource/vcd_network_isolated` Add check for valid IPs [GH-373]
+* `resource/vcd_nsxv_firewall_rule` Add support for IP sets [GH-411]
 
 BUG FIXES:
 

--- a/vcd/datasource_vcd_nsxv_firewall.go
+++ b/vcd/datasource_vcd_nsxv_firewall.go
@@ -107,7 +107,7 @@ func datasourceVcdNsxvFirewallRule() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"ipsets": {
+						"ip_sets": {
 							Type:        schema.TypeSet,
 							Computed:    true,
 							Description: "Set of IP set names",
@@ -172,8 +172,8 @@ func datasourceVcdNsxvFirewallRule() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"ipsets": {
-							Optional:    true,
+						"ip_sets": {
+							Computed:    true,
 							Type:        schema.TypeSet,
 							Description: "Set of IP set names",
 							Elem: &schema.Schema{

--- a/vcd/datasource_vcd_nsxv_firewall.go
+++ b/vcd/datasource_vcd_nsxv_firewall.go
@@ -107,16 +107,15 @@ func datasourceVcdNsxvFirewallRule() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						// TODO - ipsets and security groups need further investigation and at least
-						// "Get" capability in govcd
-						// "ipsets": {
-						// 	Type:        schema.TypeSet,
-						// 	Computed:    true,
-						// 	Description: "Set of IP set names",
-						// 	Elem: &schema.Schema{
-						// 		Type: schema.TypeString,
-						// 	},
-						// },
+						"ipsets": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Description: "Set of IP set names",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						// TODO - uncomment once security groups are supported
 						// "security_groups": {
 						// 	Type:        schema.TypeSet,
 						// 	Computed:    true,
@@ -173,16 +172,15 @@ func datasourceVcdNsxvFirewallRule() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						// TODO - ipsets and security groups need further investigation and at least
-						// "Get" capability in govcd
-						// "ipsets": {
-						// 	Optional:    true,
-						// 	Type:        schema.TypeSet,
-						// 	Description: "Set of IP set names",
-						// 	Elem: &schema.Schema{
-						// 		Type: schema.TypeString,
-						// 	},
-						// },
+						"ipsets": {
+							Optional:    true,
+							Type:        schema.TypeSet,
+							Description: "Set of IP set names",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						// TODO - uncomment once security groups are supported
 						// "security_groups": {
 						// 	Optional:    true,
 						// 	Type:        schema.TypeSet,

--- a/vcd/datasource_vcd_vapp_vm_test.go
+++ b/vcd/datasource_vcd_vapp_vm_test.go
@@ -67,7 +67,7 @@ func TestAccVcdVappVmDS(t *testing.T) {
 }
 
 const datasourceTestVappVm = `
-data "vcd_vapp_vm" "{{.VmName}}" {
+data "vcd_vapp_vm" "vm-ds" {
   name             = "{{.VmName}}"
   org              = "{{.Org}}"
   vdc              = "{{.VDC}}"
@@ -75,17 +75,17 @@ data "vcd_vapp_vm" "{{.VmName}}" {
 }
 
 output "name" {
-  value = data.vcd_vapp_vm.{{.VmName}}.name
+  value = data.vcd_vapp_vm.vm-ds.name
 }
 
 output "description" {
-  value = data.vcd_vapp_vm.{{.VmName}}.description
+  value = data.vcd_vapp_vm.vm-ds.description
 }
 output "storage_profile" {
-  value = data.vcd_vapp_vm.{{.VmName}}.storage_profile
+  value = data.vcd_vapp_vm.vm-ds.storage_profile
 }
 
 output "href" {
-  value = data.vcd_vapp_vm.{{.VmName}}.href
+  value = data.vcd_vapp_vm.vm-ds.href
 }
 `

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -128,7 +128,7 @@ func Provider() terraform.ResourceProvider {
 			"vcd_nsxv_dnat":          resourceVcdNsxvDnat(),         // 2.5
 			"vcd_nsxv_snat":          resourceVcdNsxvSnat(),         // 2.5
 			"vcd_nsxv_firewall_rule": resourceVcdNsxvFirewallRule(), // 2.5
-			"vcd_ipset":              resourceVcdIpSet(),            // 2.6
+			"vcd_nsxv_ip_set":        resourceVcdIpSet(),            // 2.6
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -153,7 +153,7 @@ func Provider() terraform.ResourceProvider {
 			"vcd_nsxv_dnat":          datasourceVcdNsxvDnat(),         // 2.5
 			"vcd_nsxv_snat":          datasourceVcdNsxvSnat(),         // 2.5
 			"vcd_nsxv_firewall_rule": datasourceVcdNsxvFirewallRule(), // 2.5
-			"vcd_ipset":              datasourceVcdIpSet(),            // 2.6
+			"vcd_nsxv_ip_set":        datasourceVcdIpSet(),            // 2.6
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/vcd/resource_vcd_ipset.go
+++ b/vcd/resource_vcd_ipset.go
@@ -257,3 +257,70 @@ func setIpSetData(d *schema.ResourceData, ipSet *types.EdgeIpSet, vdc *govcd.Vdc
 
 	return nil
 }
+
+// ipSetIdsToNames looks up IP sets by IDs and returns list of their names
+func ipSetIdsToNames(ipSetIds []string, vdc *govcd.Vdc) ([]string, error) {
+	ipSetNames := make([]string, len(ipSetIds))
+
+	allIpSets, err := vdc.GetAllNsxvIpSets()
+	// If no IP sets are found - return empty list of names
+	if govcd.IsNotFound(err) {
+		return ipSetIds, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch all IP sets in vDC %s: %s", vdc.Vdc.Name, err)
+	}
+
+	for index, ipSetId := range ipSetIds {
+		var ipSetFound bool
+		for _, ipSet := range allIpSets {
+			if ipSet.ID == ipSetId {
+				ipSetNames[index] = ipSet.Name
+				ipSetFound = true
+			}
+		}
+		// If ID was not found - fail early
+		if !ipSetFound {
+			return nil, fmt.Errorf("could not find IP set with ID %s", ipSetId)
+		}
+	}
+
+	return ipSetNames, nil
+}
+
+// ipSetNamesToIds looks up IP set names by their IDs
+func ipSetNamesToIds(ipSetNames []string, vdc *govcd.Vdc) ([]string, error) {
+	ipSetIds := make([]string, len(ipSetNames))
+
+	// When no names are passed - there is no need to lookup IP sets
+	if len(ipSetNames) == 0 {
+		return ipSetIds, nil
+	}
+
+	allIpSets, err := vdc.GetAllNsxvIpSets()
+	// If no IP sets are found in vCD - return empty list of IDs
+	if govcd.IsNotFound(err) {
+		return ipSetIds, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch all IP sets in vDC %s: %s", vdc.Vdc.Name, err)
+	}
+
+	for index, ipSetName := range ipSetNames {
+		var ipSetFound bool
+		for _, ipSet := range allIpSets {
+			if ipSet.Name == ipSetName {
+				ipSetIds[index] = ipSet.ID
+				ipSetFound = true
+			}
+		}
+		// If ID was not found - fail early
+		if !ipSetFound {
+			return nil, fmt.Errorf("could not find IP set with Name %s", ipSetName)
+		}
+	}
+
+	return ipSetIds, nil
+}

--- a/vcd/resource_vcd_ipset_test.go
+++ b/vcd/resource_vcd_ipset_test.go
@@ -41,40 +41,40 @@ func TestAccVcdIpSet(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:    testAccProviders,
 		PreCheck:     func() { testAccPreCheck(t) },
-		CheckDestroy: testAccCheckVcdIpSetDestroy("vcd_ipset.test-ipset", params["IpSetName"].(string)),
+		CheckDestroy: testAccCheckVcdIpSetDestroy("vcd_nsxv_ip_set.test-ipset", params["IpSetName"].(string)),
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestMatchResourceAttr("vcd_ipset.test-ipset", "id", regexp.MustCompile(`.*ipset-\d*$`)),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "name", t.Name()),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "description", "test-ip-set-description"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "is_inheritance_allowed", "true"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "ip_addresses.#", "2"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "ip_addresses.2555711295", "192.168.1.1"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "ip_addresses.2329977041", "192.168.2.1"),
+					resource.TestMatchResourceAttr("vcd_nsxv_ip_set.test-ipset", "id", regexp.MustCompile(`.*ipset-\d*$`)),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "name", t.Name()),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "description", "test-ip-set-description"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "is_inheritance_allowed", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "ip_addresses.#", "2"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "ip_addresses.2555711295", "192.168.1.1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "ip_addresses.2329977041", "192.168.2.1"),
 
 					// Validate that datasource has all the same fields
-					resourceFieldsEqual("vcd_ipset.test-ipset", "data.vcd_ipset.test-ipset", []string{}),
+					resourceFieldsEqual("vcd_nsxv_ip_set.test-ipset", "data.vcd_nsxv_ip_set.test-ipset", []string{}),
 				),
 			},
 			resource.TestStep{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestMatchResourceAttr("vcd_ipset.test-ipset", "id", regexp.MustCompile(`.*ipset-\d*$`)),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "name", t.Name()+"-changed"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "is_inheritance_allowed", "true"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "description", "test-ip-set-changed-description"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "ip_addresses.#", "2"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "ip_addresses.1441693733", "10.10.10.1"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "ip_addresses.2766637002", "11.11.11.1"),
+					resource.TestMatchResourceAttr("vcd_nsxv_ip_set.test-ipset", "id", regexp.MustCompile(`.*ipset-\d*$`)),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "name", t.Name()+"-changed"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "is_inheritance_allowed", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "description", "test-ip-set-changed-description"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "ip_addresses.#", "2"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "ip_addresses.1441693733", "10.10.10.1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "ip_addresses.2766637002", "11.11.11.1"),
 
 					// Validate that datasource has all the same fields
-					resourceFieldsEqual("vcd_ipset.test-ipset", "data.vcd_ipset.test-ipset", []string{}),
+					resourceFieldsEqual("vcd_nsxv_ip_set.test-ipset", "data.vcd_nsxv_ip_set.test-ipset", []string{}),
 				),
 			},
 			resource.TestStep{
-				ResourceName:      "vcd_ipset.imported",
+				ResourceName:      "vcd_nsxv_ip_set.imported",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdOrgVdcObject(testConfig, "TestAccVcdIpSet-changed"),
@@ -82,30 +82,30 @@ func TestAccVcdIpSet(t *testing.T) {
 			resource.TestStep{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestMatchResourceAttr("vcd_ipset.test-ipset", "id", regexp.MustCompile(`.*ipset-\d*$`)),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "name", t.Name()+"-changed2"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "is_inheritance_allowed", "false"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "description", "test-ip-set-changed-description"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "ip_addresses.#", "2"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "ip_addresses.2083356021", "1.1.1.1/24"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "ip_addresses.3684382799", "10.10.10.100-10.10.10.110"),
+					resource.TestMatchResourceAttr("vcd_nsxv_ip_set.test-ipset", "id", regexp.MustCompile(`.*ipset-\d*$`)),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "name", t.Name()+"-changed2"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "is_inheritance_allowed", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "description", "test-ip-set-changed-description"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "ip_addresses.#", "2"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "ip_addresses.2083356021", "1.1.1.1/24"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "ip_addresses.3684382799", "10.10.10.100-10.10.10.110"),
 					// Validate that datasource has all the same fields
-					resourceFieldsEqual("vcd_ipset.test-ipset", "data.vcd_ipset.test-ipset", []string{}),
+					resourceFieldsEqual("vcd_nsxv_ip_set.test-ipset", "data.vcd_nsxv_ip_set.test-ipset", []string{}),
 				),
 			},
 			resource.TestStep{
 				Config: configText2,
-				Taint:  []string{"vcd_ipset.test-ipset"}, // Force provisioning from scratch instead of update
+				Taint:  []string{"vcd_nsxv_ip_set.test-ipset"}, // Force provisioning from scratch instead of update
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestMatchResourceAttr("vcd_ipset.test-ipset", "id", regexp.MustCompile(`.*ipset-\d*$`)),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "name", t.Name()+"-changed2"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "is_inheritance_allowed", "false"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "description", "test-ip-set-changed-description"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "ip_addresses.#", "2"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "ip_addresses.2083356021", "1.1.1.1/24"),
-					resource.TestCheckResourceAttr("vcd_ipset.test-ipset", "ip_addresses.3684382799", "10.10.10.100-10.10.10.110"),
+					resource.TestMatchResourceAttr("vcd_nsxv_ip_set.test-ipset", "id", regexp.MustCompile(`.*ipset-\d*$`)),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "name", t.Name()+"-changed2"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "is_inheritance_allowed", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "description", "test-ip-set-changed-description"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "ip_addresses.#", "2"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "ip_addresses.2083356021", "1.1.1.1/24"),
+					resource.TestCheckResourceAttr("vcd_nsxv_ip_set.test-ipset", "ip_addresses.3684382799", "10.10.10.100-10.10.10.110"),
 					// Validate that datasource has all the same fields
-					resourceFieldsEqual("vcd_ipset.test-ipset", "data.vcd_ipset.test-ipset", []string{}),
+					resourceFieldsEqual("vcd_nsxv_ip_set.test-ipset", "data.vcd_nsxv_ip_set.test-ipset", []string{}),
 				),
 			},
 		},
@@ -139,7 +139,7 @@ func testAccCheckVcdIpSetDestroy(resource, ipSetName string) resource.TestCheckF
 }
 
 const testAccVcdIpSet = `
-resource "vcd_ipset" "test-ipset" {
+resource "vcd_nsxv_ip_set" "test-ipset" {
   org          = "{{.Org}}"
   vdc          = "{{.Vdc}}"
 
@@ -148,16 +148,16 @@ resource "vcd_ipset" "test-ipset" {
   ip_addresses = ["192.168.1.1","192.168.2.1"]
 }
 
-data "vcd_ipset" "test-ipset" {
+data "vcd_nsxv_ip_set" "test-ipset" {
 	org          = "{{.Org}}"
 	vdc          = "{{.Vdc}}"
   
-	name         = vcd_ipset.test-ipset.name
+	name         = vcd_nsxv_ip_set.test-ipset.name
 }
 `
 
 const testAccVcdIpSetUpdate = `
-resource "vcd_ipset" "test-ipset" {
+resource "vcd_nsxv_ip_set" "test-ipset" {
   org          = "{{.Org}}"
   vdc          = "{{.Vdc}}"
 
@@ -166,16 +166,16 @@ resource "vcd_ipset" "test-ipset" {
   ip_addresses = ["10.10.10.1","11.11.11.1"]
 }
 
-data "vcd_ipset" "test-ipset" {
+data "vcd_nsxv_ip_set" "test-ipset" {
 	org          = "{{.Org}}"
 	vdc          = "{{.Vdc}}"
   
-	name         = vcd_ipset.test-ipset.name
+	name         = vcd_nsxv_ip_set.test-ipset.name
 }
 `
 
 const testAccVcdIpSetUpdate2 = `
-resource "vcd_ipset" "test-ipset" {
+resource "vcd_nsxv_ip_set" "test-ipset" {
   org          = "{{.Org}}"
   vdc          = "{{.Vdc}}"
 
@@ -185,10 +185,10 @@ resource "vcd_ipset" "test-ipset" {
   ip_addresses           = ["1.1.1.1/24","10.10.10.100-10.10.10.110"]
 }
 
-data "vcd_ipset" "test-ipset" {
+data "vcd_nsxv_ip_set" "test-ipset" {
 	org          = "{{.Org}}"
 	vdc          = "{{.Vdc}}"
   
-	name         = vcd_ipset.test-ipset.name
+	name         = vcd_nsxv_ip_set.test-ipset.name
 }
 `

--- a/vcd/resource_vcd_nsxv_firewall_rule.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule.go
@@ -135,7 +135,7 @@ func resourceVcdNsxvFirewallRule() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"ipsets": {
+						"ip_sets": {
 							Optional:    true,
 							Type:        schema.TypeSet,
 							Description: "Set of IP set names",
@@ -201,7 +201,7 @@ func resourceVcdNsxvFirewallRule() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"ipsets": {
+						"ip_sets": {
 							Optional:    true,
 							Type:        schema.TypeSet,
 							Description: "Set of IP set names",
@@ -680,7 +680,7 @@ func getEndpointData(endpoint types.EdgeFirewallEndpoint, edge *govcd.EdgeGatewa
 	endpointMap["gateway_interfaces"] = endpointGatewayInterfaceSet
 	endpointMap["org_networks"] = endpointNetworksSet
 	endpointMap["virtual_machine_ids"] = endpointVmSet
-	endpointMap["ipsets"] = endpointIpSetSet
+	endpointMap["ip_sets"] = endpointIpSetSet
 	// TODO - uncomment when security groups are supported
 	// endpointMap["security_groups"] = endpointSecurityGroupSet
 
@@ -748,7 +748,7 @@ func getFirewallRuleEndpoint(endpoint []interface{}, edge *govcd.EdgeGateway, vd
 	result.GroupingObjectIds = append(result.GroupingObjectIds, endpointOrgNetworkIdStrings...)
 
 	// Extract ipset IDs from set and add them to endpoint structure
-	endpointIpSetNameStrings := convertSchemaSetToSliceOfStrings(endpointMap["ipsets"].(*schema.Set))
+	endpointIpSetNameStrings := convertSchemaSetToSliceOfStrings(endpointMap["ip_sets"].(*schema.Set))
 	endpointIpSetIdStrings, err := ipSetNamesToIds(endpointIpSetNameStrings, vdc)
 	if err != nil {
 		return nil, fmt.Errorf("could not lookup IP set names by their IDs : %s", err)

--- a/vcd/resource_vcd_nsxv_firewall_rule.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule.go
@@ -599,7 +599,6 @@ func getEndpointData(endpoint types.EdgeFirewallEndpoint, edge *govcd.EdgeGatewa
 	for _, groupingObject := range endpoint.GroupingObjectIds {
 		idSplit := strings.Split(groupingObject, ":")
 		idLen := len(idSplit)
-		// TODO uncomment when IP sets and Security groups are supported
 		subIdSplit := ""
 		if idLen == 2 {
 			subSplit := strings.Split(idSplit[1], "-")
@@ -865,58 +864,6 @@ func orgNetworksIdsToNames(networkIds []string, vdc *govcd.Vdc) ([]string, error
 
 	}
 	return orgNetworkNames, nil
-}
-
-// ipSetIdsToNames looks up IP sets by IDs and returns list of their names
-func ipSetIdsToNames(ipSetIds []string, vdc *govcd.Vdc) ([]string, error) {
-	ipSetNames := make([]string, len(ipSetIds))
-
-	allIpSets, err := vdc.GetAllNsxvIpSets()
-	if err != nil {
-		return nil, fmt.Errorf("unable to fetch all IP sets in vDC %s: %s", vdc.Vdc.Name, err)
-	}
-
-	for index, ipSetId := range ipSetIds {
-		var ipSetFound bool
-		for _, ipSet := range allIpSets {
-			if ipSet.ID == ipSetId {
-				ipSetNames[index] = ipSet.Name
-				ipSetFound = true
-			}
-		}
-		// If ID was not found - fail early
-		if !ipSetFound {
-			return nil, fmt.Errorf("could not find IP set with ID %s", ipSetId)
-		}
-	}
-
-	return ipSetNames, nil
-}
-
-// ipSetNamesToIds looks up IP set names by their IDs
-func ipSetNamesToIds(ipSetNames []string, vdc *govcd.Vdc) ([]string, error) {
-	ipSetIds := make([]string, len(ipSetNames))
-
-	allIpSets, err := vdc.GetAllNsxvIpSets()
-	if err != nil {
-		return nil, fmt.Errorf("unable to fetch all IP sets in vDC %s: %s", vdc.Vdc.Name, err)
-	}
-
-	for index, ipSetName := range ipSetNames {
-		var ipSetFound bool
-		for _, ipSet := range allIpSets {
-			if ipSet.Name == ipSetName {
-				ipSetIds[index] = ipSet.ID
-				ipSetFound = true
-			}
-		}
-		// If ID was not found - fail early
-		if !ipSetFound {
-			return nil, fmt.Errorf("could not find IP set with Name %s", ipSetName)
-		}
-	}
-
-	return ipSetIds, nil
 }
 
 // stringInSlice checks if a string exists in slice of strings

--- a/vcd/resource_vcd_nsxv_firewall_rule.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule.go
@@ -870,28 +870,52 @@ func orgNetworksIdsToNames(networkIds []string, vdc *govcd.Vdc) ([]string, error
 // ipSetIdsToNames looks up IP sets by IDs and returns list of their names
 func ipSetIdsToNames(ipSetIds []string, vdc *govcd.Vdc) ([]string, error) {
 	ipSetNames := make([]string, len(ipSetIds))
-	for index, ipSetId := range ipSetIds {
-		ipSet, err := vdc.GetNsxvIpSetById(ipSetId)
-		if err != nil {
-			return nil, fmt.Errorf("could not find IP set with ID %s: %s", ipSetId, err)
-		}
-		ipSetNames[index] = ipSet.Name
 
+	allIpSets, err := vdc.GetAllNsxvIpSets()
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch all IP sets in vDC %s: %s", vdc.Vdc.Name, err)
 	}
+
+	for index, ipSetId := range ipSetIds {
+		var ipSetFound bool
+		for _, ipSet := range allIpSets {
+			if ipSet.ID == ipSetId {
+				ipSetNames[index] = ipSet.Name
+				ipSetFound = true
+			}
+		}
+		// If ID was not found - fail early
+		if !ipSetFound {
+			return nil, fmt.Errorf("could not find IP set with ID %s", ipSetId)
+		}
+	}
+
 	return ipSetNames, nil
 }
 
 // ipSetNamesToIds looks up IP set names by their IDs
 func ipSetNamesToIds(ipSetNames []string, vdc *govcd.Vdc) ([]string, error) {
 	ipSetIds := make([]string, len(ipSetNames))
-	for index, ipSetName := range ipSetNames {
-		ipSet, err := vdc.GetNsxvIpSetByName(ipSetName)
-		if err != nil {
-			return nil, fmt.Errorf("could not find IP set with name %s: %s", ipSetName, err)
-		}
-		ipSetIds[index] = ipSet.ID
 
+	allIpSets, err := vdc.GetAllNsxvIpSets()
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch all IP sets in vDC %s: %s", vdc.Vdc.Name, err)
 	}
+
+	for index, ipSetName := range ipSetNames {
+		var ipSetFound bool
+		for _, ipSet := range allIpSets {
+			if ipSet.Name == ipSetName {
+				ipSetIds[index] = ipSet.ID
+				ipSetFound = true
+			}
+		}
+		// If ID was not found - fail early
+		if !ipSetFound {
+			return nil, fmt.Errorf("could not find IP set with Name %s", ipSetName)
+		}
+	}
+
 	return ipSetIds, nil
 }
 

--- a/vcd/resource_vcd_nsxv_firewall_rule_test.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule_test.go
@@ -66,7 +66,7 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 		return
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		Providers:    testAccProviders,
 		PreCheck:     func() { testAccPreCheck(t) },
 		CheckDestroy: testAccCheckVcdFirewallRuleDestroy("vcd_nsxv_firewall_rule.rule6"),

--- a/vcd/resource_vcd_nsxv_firewall_rule_test.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule_test.go
@@ -878,3 +878,369 @@ resource "vcd_nsxv_firewall_rule" "rule6-6" {
 	depends_on = ["vcd_nsxv_firewall_rule.rule6"]
 }
 `
+
+func TestAccVcdNsxvEdgeFirewallRuleIpSets(t *testing.T) {
+	// String map to fill the template
+	var params = StringMap{
+		"Org":              testConfig.VCD.Org,
+		"Vdc":              testConfig.VCD.Vdc,
+		"EdgeGateway":      testConfig.Networking.EdgeGateway,
+		"ExternalIp":       testConfig.Networking.ExternalIp,
+		"InternalIp":       testConfig.Networking.InternalIp,
+		"NetworkName":      testConfig.Networking.ExternalNetwork,
+		"RouteNetworkName": "TestAccVcdVAppVmNet",
+		"Catalog":          testSuiteCatalogName,
+		"CatalogItem":      testSuiteCatalogOVAItem,
+		"VappName":         vappName2,
+		"VmName":           vmName,
+		"Tags":             "gateway firewall",
+	}
+
+	configText := templateFill(testAccVcdEdgeFirewallRuleIpSets, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 0: %s", configText)
+
+	params["FuncName"] = t.Name() + "-step1"
+	configText1 := templateFill(testAccVcdEdgeFirewallRuleIpSetsUpdate, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckVcdFirewallRuleDestroy("vcd_nsxv_firewall_rule.ipsets"),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.ipsets", "id", regexp.MustCompile(`\d*`)),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "name", "rule-with-ipsets"),
+					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.ipsets", "rule_tag", regexp.MustCompile(`\d*`)),
+
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "action", "accept"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "logging_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.exclude", "false"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.gateway_interfaces"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.virtual_machine_ids"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.org_networks"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.ip_addresses"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.security_groups"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.exclude", "false"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.gateway_interfaces"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.virtual_machine_ids"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.org_networks"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.ip_addresses"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.security_groups"),
+
+					// Test object counts
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.ipsets.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.ipsets.1692753458", "acceptance test IPset 1"),
+
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.ipsets.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.ipsets.1338510833", "acceptance test IPset 2"),
+
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "service.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "service.455563319.port", "any"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "service.455563319.protocol", "any"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "service.455563319.source_port", "any"),
+				),
+			},
+			resource.TestStep{
+				Config: configText1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.ipsets", "id", regexp.MustCompile(`\d*`)),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "name", "updated-rule-with-ipsets"),
+					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.ipsets", "rule_tag", regexp.MustCompile(`\d*`)),
+
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "action", "accept"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "logging_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.exclude", "false"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.gateway_interfaces"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.virtual_machine_ids"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.org_networks"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.ip_addresses"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.security_groups"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.exclude", "false"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.gateway_interfaces"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.virtual_machine_ids"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.org_networks"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.ip_addresses"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.security_groups"),
+
+					// Test object counts
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.ipsets.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.ipsets.1692753458", "acceptance test IPset 1"),
+
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.ipsets.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.ipsets.1338510833", "acceptance test IPset 2"),
+
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "service.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "service.1865210680.protocol", "icmp"),
+				),
+			},
+		},
+	})
+}
+
+const testAccVcdEdgeFirewallRuleIpSets = `
+resource "vcd_nsxv_firewall_rule" "ipsets" {
+	org          = "{{.Org}}"
+	vdc          = "{{.Vdc}}"
+	edge_gateway = "{{.EdgeGateway}}"
+	name = "rule-with-ipsets"
+	action = "accept"
+
+	source {
+		ipsets = [vcd_ipset.aceeptance-ipset-1.name]
+	}
+  
+	destination {
+		ipsets = [vcd_ipset.aceeptance-ipset-2.name]
+	}
+
+	service {
+		protocol = "any"
+	}
+}
+
+resource "vcd_ipset" "aceeptance-ipset-1" {
+	name = "acceptance test IPset 1"
+	ip_addresses = ["222.222.222.1/24"]
+}
+
+resource "vcd_ipset" "aceeptance-ipset-2" {
+	name = "acceptance test IPset 2"
+	ip_addresses = ["11.11.11.1-11.11.11.100", "12.12.12.1"]
+}
+`
+
+const testAccVcdEdgeFirewallRuleIpSetsUpdate = `
+resource "vcd_nsxv_firewall_rule" "ipsets" {
+	org          = "{{.Org}}"
+	vdc          = "{{.Vdc}}"
+	edge_gateway = "{{.EdgeGateway}}"
+	name = "updated-rule-with-ipsets"
+	action = "accept"
+
+	source {
+		ipsets = [vcd_ipset.aceeptance-ipset-2.name]
+	}
+  
+	destination {
+		ipsets = [vcd_ipset.aceeptance-ipset-1.name]
+	}
+
+	service {
+		protocol = "icmp"
+	}
+}
+
+resource "vcd_ipset" "aceeptance-ipset-1" {
+	name = "acceptance test IPset 1"
+	ip_addresses = ["222.222.222.1/24"]
+}
+
+resource "vcd_ipset" "aceeptance-ipset-2" {
+	name = "acceptance test IPset 2"
+	ip_addresses = ["11.11.11.1-11.11.11.100", "12.12.12.1"]
+}
+`
+
+func TestAccVcdNsxvEdgeFirewallRuleVms(t *testing.T) {
+	// String map to fill the template
+	var params = StringMap{
+		"Org":              testConfig.VCD.Org,
+		"Vdc":              testConfig.VCD.Vdc,
+		"EdgeGateway":      testConfig.Networking.EdgeGateway,
+		"ExternalIp":       testConfig.Networking.ExternalIp,
+		"InternalIp":       testConfig.Networking.InternalIp,
+		"NetworkName":      testConfig.Networking.ExternalNetwork,
+		"RouteNetworkName": "TestAccVcdVAppVmNet",
+		"Catalog":          testSuiteCatalogName,
+		"CatalogItem":      testSuiteCatalogOVAItem,
+		"VappName":         vappName2,
+		"VmName":           vmName,
+		"Tags":             "gateway firewall",
+	}
+
+	configText := templateFill(testAccVcdEdgeFirewallRuleVms, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 0: %s", configText)
+
+	params["FuncName"] = t.Name() + "-step1"
+	configText1 := templateFill(testAccVcdEdgeFirewallRuleVmsUpdate, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckVcdFirewallRuleDestroy("vcd_nsxv_firewall_rule.vms"),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.vms", "id", regexp.MustCompile(`\d*`)),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "name", "rule-with-ipsets"),
+					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.vms", "rule_tag", regexp.MustCompile(`\d*`)),
+
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "action", "accept"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "logging_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.exclude", "false"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.gateway_interfaces"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.org_networks"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.ip_addresses"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.security_groups"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.exclude", "false"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.gateway_interfaces"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.virtual_machine_ids"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.org_networks"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.security_groups"),
+
+					// Test object counts
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.virtual_machine_ids.#", "1"),
+
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.ip_addresses.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.ip_addresses.2942403275", "any"),
+
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "service.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "service.455563319.port", "any"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "service.455563319.protocol", "any"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "service.455563319.source_port", "any"),
+				),
+			},
+
+			resource.TestStep{
+				Config: configText1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.vms", "id", regexp.MustCompile(`\d*`)),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "name", "rule-with-ipsets"),
+					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.vms", "rule_tag", regexp.MustCompile(`\d*`)),
+
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "action", "accept"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "logging_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.exclude", "false"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.gateway_interfaces"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.org_networks"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.virtual_machine_ids"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.security_groups"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.exclude", "false"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.gateway_interfaces"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.ip_addresses"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.org_networks"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.security_groups"),
+
+					// Test object counts
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.virtual_machine_ids.#", "1"),
+
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.ip_addresses.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.ip_addresses.2942403275", "any"),
+
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "service.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "service.455563319.port", "any"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "service.455563319.protocol", "any"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "service.455563319.source_port", "any"),
+				),
+			},
+		},
+	})
+}
+
+const testAccVcdEdgeFirewallRuleVmsPrereqs = `
+
+resource "vcd_network_routed" "net" {
+	org = "{{.Org}}"
+	vdc = "{{.Vdc}}"
+  
+	name         = "fw-routed-net"
+	edge_gateway = "{{.EdgeGateway}}"
+	gateway      = "47.10.0.1"
+
+	static_ip_pool {
+	  start_address = "47.10.0.152"
+	  end_address   = "47.10.0.254"
+	}
+}
+resource "vcd_vapp" "fw-test" {
+  name = "fw-test"
+
+  depends_on = [vcd_network_routed.net]
+}
+
+resource "vcd_vapp_vm" "fw-vm" {
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  vapp_name     = vcd_vapp.fw-test.name
+  name          = "fw-test"
+  computer_name = "fw-test"
+  catalog_name  = "{{.Catalog}}"
+  template_name = "{{.CatalogItem}}"
+  memory        = 1024
+  cpus          = 2
+  cpu_cores     = 1
+
+  network {
+    name               = vcd_network_routed.net.name
+    type               = "org"
+    ip_allocation_mode = "POOL"
+  }
+}
+`
+
+const testAccVcdEdgeFirewallRuleVms = testAccVcdEdgeFirewallRuleVmsPrereqs + `
+resource "vcd_nsxv_firewall_rule" "vms" {
+	org          = "{{.Org}}"
+	vdc          = "{{.Vdc}}"
+	edge_gateway = "{{.EdgeGateway}}"
+	name = "rule-with-ipsets"
+	action = "accept"
+
+	source {
+		virtual_machine_ids = [vcd_vapp_vm.fw-vm.id]
+	}
+  
+	destination {
+		ip_addresses = ["any"]
+	}
+
+	service {
+		protocol = "any"
+	}
+}
+`
+
+const testAccVcdEdgeFirewallRuleVmsUpdate = testAccVcdEdgeFirewallRuleVmsPrereqs + `
+resource "vcd_nsxv_firewall_rule" "vms" {
+	org          = "{{.Org}}"
+	vdc          = "{{.Vdc}}"
+	edge_gateway = "{{.EdgeGateway}}"
+	name = "rule-with-ipsets"
+	action = "accept"
+
+	source {
+		ip_addresses = ["any"]
+	}
+  
+	destination {
+		virtual_machine_ids = [vcd_vapp_vm.fw-vm.id]
+	}
+
+	service {
+		protocol = "any"
+	}
+}
+`

--- a/vcd/resource_vcd_nsxv_firewall_rule_test.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule_test.go
@@ -84,13 +84,13 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0", "source.0.gateway_interfaces"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0", "source.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0", "source.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0", "source.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0", "source.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0", "source.0.security_groups"),
 					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.rule0", "destination.0.exclude", "false"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0", "destination.0.gateway_interfaces"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0", "destination.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0", "destination.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0", "destination.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0", "destination.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0", "destination.0.security_groups"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0", "destination.0.ip_addresses"),
 					// Test object counts
@@ -115,13 +115,13 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0-2", "source.0.gateway_interfaces"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0-2", "source.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0-2", "source.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0-2", "source.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0-2", "source.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0-2", "source.0.security_groups"),
 					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.rule0-2", "destination.0.exclude", "false"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0-2", "destination.0.gateway_interfaces"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0-2", "destination.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0-2", "destination.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0-2", "destination.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0-2", "destination.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule0-2", "destination.0.security_groups"),
 
 					// Test object counts
@@ -156,13 +156,13 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule1", "source.0.ip_addresses"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule1", "source.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule1", "source.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule1", "source.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule1", "source.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule1", "source.0.security_groups"),
 					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.rule1", "destination.0.exclude", "false"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule1", "destination.0.ip_addresses"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule1", "destination.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule1", "destination.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule1", "destination.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule1", "destination.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule1", "destination.0.security_groups"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule1", "destination.0.ip_addresses"),
 					// Test object counts
@@ -189,13 +189,13 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule2", "source.0.ip_addresses"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule2", "source.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule2", "source.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule2", "source.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule2", "source.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule2", "source.0.security_groups"),
 					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.rule2", "destination.0.exclude", "false"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule2", "destination.0.ip_addresses"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule2", "destination.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule2", "destination.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule2", "destination.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule2", "destination.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule2", "destination.0.security_groups"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule2", "destination.0.ip_addresses"),
 					// Test object counts
@@ -222,13 +222,13 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule3", "source.0.ip_addresses"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule3", "source.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule3", "source.0.gateway_interfaces"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule3", "source.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule3", "source.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule3", "source.0.security_groups"),
 					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.rule3", "destination.0.exclude", "true"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule3", "destination.0.ip_addresses"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule3", "destination.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule3", "destination.0.gateway_interfaces"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule3", "destination.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule3", "destination.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule3", "destination.0.security_groups"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule3", "destination.0.ip_addresses"),
 					// Test object counts
@@ -255,13 +255,13 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule4", "source.0.ip_addresses"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule4", "source.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule4", "source.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule4", "source.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule4", "source.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule4", "source.0.security_groups"),
 					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.rule4", "destination.0.exclude", "false"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule4", "destination.0.ip_addresses"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule4", "destination.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule4", "destination.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule4", "destination.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule4", "destination.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule4", "destination.0.security_groups"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule4", "destination.0.ip_addresses"),
 					// Test object counts
@@ -303,13 +303,13 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 					resource.TestCheckResourceAttrPair("vcd_nsxv_firewall_rule.rule4", "source.0.gateway_interfaces", "data.vcd_nsxv_firewall_rule.rule4", "source.0.gateway_interfaces"),
 					resource.TestCheckResourceAttrPair("vcd_nsxv_firewall_rule.rule4", "source.0.virtual_machine_ids", "data.vcd_nsxv_firewall_rule.rule4", "source.0.virtual_machine_ids"),
 					resource.TestCheckResourceAttrPair("vcd_nsxv_firewall_rule.rule4", "source.0.org_networks", "data.vcd_nsxv_firewall_rule.rule4", "source.0.org_networks"),
-					resource.TestCheckResourceAttrPair("vcd_nsxv_firewall_rule.rule4", "source.0.ipsets", "data.vcd_nsxv_firewall_rule.rule4", "source.0.ipsets"),
+					resource.TestCheckResourceAttrPair("vcd_nsxv_firewall_rule.rule4", "source.0.ip_sets", "data.vcd_nsxv_firewall_rule.rule4", "source.0.ip_sets"),
 					resource.TestCheckResourceAttrPair("vcd_nsxv_firewall_rule.rule4", "source.0.security_groups", "data.vcd_nsxv_firewall_rule.rule4", "source.0.security_groups"),
 					resource.TestCheckResourceAttrPair("vcd_nsxv_firewall_rule.rule4", "destination.0.exclude", "data.vcd_nsxv_firewall_rule.rule4", "destination.0.exclude"),
 					resource.TestCheckResourceAttrPair("vcd_nsxv_firewall_rule.rule4", "destination.0.gateway_interfaces", "data.vcd_nsxv_firewall_rule.rule4", "destination.0.gateway_interfaces"),
 					resource.TestCheckResourceAttrPair("vcd_nsxv_firewall_rule.rule4", "destination.0.virtual_machine_ids", "data.vcd_nsxv_firewall_rule.rule4", "destination.0.virtual_machine_ids"),
 					resource.TestCheckResourceAttrPair("vcd_nsxv_firewall_rule.rule4", "destination.0.org_networks", "data.vcd_nsxv_firewall_rule.rule4", "destination.0.org_networks"),
-					resource.TestCheckResourceAttrPair("vcd_nsxv_firewall_rule.rule4", "destination.0.ipsets", "data.vcd_nsxv_firewall_rule.rule4", "destination.0.ipsets"),
+					resource.TestCheckResourceAttrPair("vcd_nsxv_firewall_rule.rule4", "destination.0.ip_sets", "data.vcd_nsxv_firewall_rule.rule4", "destination.0.ip_sets"),
 					resource.TestCheckResourceAttrPair("vcd_nsxv_firewall_rule.rule4", "destination.0.security_groups", "data.vcd_nsxv_firewall_rule.rule4", "destination.0.security_groups"),
 					resource.TestCheckResourceAttrPair("vcd_nsxv_firewall_rule.rule4", "destination.0.ip_addresses", "data.vcd_nsxv_firewall_rule.rule4", "destination.0.ip_addresses"),
 					resource.TestCheckResourceAttrPair("vcd_nsxv_firewall_rule.rule4", "source.0.ip_addresses.#", "data.vcd_nsxv_firewall_rule.rule4", "source.0.ip_addresses.#"),
@@ -333,13 +333,13 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule5", "source.0.ip_addresses"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule5", "source.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule5", "source.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule5", "source.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule5", "source.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule5", "source.0.security_groups"),
 					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.rule5", "destination.0.exclude", "false"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule5", "destination.0.ip_addresses"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule5", "destination.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule5", "destination.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule5", "destination.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule5", "destination.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule5", "destination.0.security_groups"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule5", "destination.0.ip_addresses"),
 					// Test object counts
@@ -386,13 +386,13 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6", "source.0.gateway_interfaces"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6", "source.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6", "source.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6", "source.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6", "source.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6", "source.0.security_groups"),
 					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.rule6", "destination.0.exclude", "false"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6", "destination.0.gateway_interfaces"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6", "destination.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6", "destination.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6", "destination.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6", "destination.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6", "destination.0.security_groups"),
 
 					// Test object counts
@@ -420,13 +420,13 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6-6", "source.0.gateway_interfaces"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6-6", "source.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6-6", "source.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6-6", "source.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6-6", "source.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6-6", "source.0.security_groups"),
 					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.rule6-6", "destination.0.exclude", "false"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6-6", "destination.0.gateway_interfaces"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6-6", "destination.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6-6", "destination.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6-6", "destination.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6-6", "destination.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.rule6-6", "destination.0.security_groups"),
 
 					// Test object counts
@@ -911,76 +911,76 @@ func TestAccVcdNsxvEdgeFirewallRuleIpSets(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:    testAccProviders,
 		PreCheck:     func() { testAccPreCheck(t) },
-		CheckDestroy: testAccCheckVcdFirewallRuleDestroy("vcd_nsxv_firewall_rule.ipsets"),
+		CheckDestroy: testAccCheckVcdFirewallRuleDestroy("vcd_nsxv_firewall_rule.ip_sets"),
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.ipsets", "id", regexp.MustCompile(`\d*`)),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "name", "rule-with-ipsets"),
-					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.ipsets", "rule_tag", regexp.MustCompile(`\d*`)),
+					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "id", regexp.MustCompile(`\d*`)),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "name", "rule-with-ip_sets"),
+					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "rule_tag", regexp.MustCompile(`\d*`)),
 
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "action", "accept"),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "enabled", "true"),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "logging_enabled", "false"),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.exclude", "false"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.gateway_interfaces"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.virtual_machine_ids"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.ip_addresses"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.security_groups"),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.exclude", "false"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.gateway_interfaces"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.virtual_machine_ids"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.ip_addresses"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.security_groups"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "action", "accept"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "logging_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "source.0.exclude", "false"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "source.0.gateway_interfaces"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "source.0.virtual_machine_ids"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "source.0.org_networks"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "source.0.ip_addresses"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "source.0.security_groups"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "destination.0.exclude", "false"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "destination.0.gateway_interfaces"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "destination.0.virtual_machine_ids"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "destination.0.org_networks"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "destination.0.ip_addresses"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "destination.0.security_groups"),
 
 					// Test object counts
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.ipsets.#", "1"),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.ipsets.1692753458", "acceptance test IPset 1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "source.0.ip_sets.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "source.0.ip_sets.1692753458", "acceptance test IPset 1"),
 
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.ipsets.#", "1"),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.ipsets.1338510833", "acceptance test IPset 2"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "destination.0.ip_sets.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "destination.0.ip_sets.1338510833", "acceptance test IPset 2"),
 
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "service.#", "1"),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "service.455563319.port", "any"),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "service.455563319.protocol", "any"),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "service.455563319.source_port", "any"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "service.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "service.455563319.port", "any"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "service.455563319.protocol", "any"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "service.455563319.source_port", "any"),
 				),
 			},
 			resource.TestStep{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.ipsets", "id", regexp.MustCompile(`\d*`)),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "name", "updated-rule-with-ipsets"),
-					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.ipsets", "rule_tag", regexp.MustCompile(`\d*`)),
+					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "id", regexp.MustCompile(`\d*`)),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "name", "updated-rule-with-ip_sets"),
+					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "rule_tag", regexp.MustCompile(`\d*`)),
 
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "action", "accept"),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "enabled", "true"),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "logging_enabled", "false"),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.exclude", "false"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.gateway_interfaces"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.virtual_machine_ids"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.ip_addresses"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.security_groups"),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.exclude", "false"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.gateway_interfaces"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.virtual_machine_ids"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.ip_addresses"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.security_groups"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "action", "accept"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "logging_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "source.0.exclude", "false"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "source.0.gateway_interfaces"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "source.0.virtual_machine_ids"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "source.0.org_networks"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "source.0.ip_addresses"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "source.0.security_groups"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "destination.0.exclude", "false"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "destination.0.gateway_interfaces"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "destination.0.virtual_machine_ids"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "destination.0.org_networks"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "destination.0.ip_addresses"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "destination.0.security_groups"),
 
 					// Test object counts
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.ipsets.#", "1"),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "destination.0.ipsets.1692753458", "acceptance test IPset 1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "destination.0.ip_sets.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "destination.0.ip_sets.1692753458", "acceptance test IPset 1"),
 
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.ipsets.#", "1"),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "source.0.ipsets.1338510833", "acceptance test IPset 2"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "source.0.ip_sets.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "source.0.ip_sets.1338510833", "acceptance test IPset 2"),
 
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "service.#", "1"),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ipsets", "service.1865210680.protocol", "icmp"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "service.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "service.1865210680.protocol", "icmp"),
 				),
 			},
 		},
@@ -988,19 +988,19 @@ func TestAccVcdNsxvEdgeFirewallRuleIpSets(t *testing.T) {
 }
 
 const testAccVcdEdgeFirewallRuleIpSets = `
-resource "vcd_nsxv_firewall_rule" "ipsets" {
+resource "vcd_nsxv_firewall_rule" "ip_sets" {
 	org          = "{{.Org}}"
 	vdc          = "{{.Vdc}}"
 	edge_gateway = "{{.EdgeGateway}}"
-	name = "rule-with-ipsets"
+	name = "rule-with-ip_sets"
 	action = "accept"
 
 	source {
-		ipsets = [vcd_ipset.aceeptance-ipset-1.name]
+		ip_sets = [vcd_ipset.aceeptance-ipset-1.name]
 	}
   
 	destination {
-		ipsets = [vcd_ipset.aceeptance-ipset-2.name]
+		ip_sets = [vcd_ipset.aceeptance-ipset-2.name]
 	}
 
 	service {
@@ -1020,19 +1020,19 @@ resource "vcd_ipset" "aceeptance-ipset-2" {
 `
 
 const testAccVcdEdgeFirewallRuleIpSetsUpdate = `
-resource "vcd_nsxv_firewall_rule" "ipsets" {
+resource "vcd_nsxv_firewall_rule" "ip_sets" {
 	org          = "{{.Org}}"
 	vdc          = "{{.Vdc}}"
 	edge_gateway = "{{.EdgeGateway}}"
-	name = "updated-rule-with-ipsets"
+	name = "updated-rule-with-ip_sets"
 	action = "accept"
 
 	source {
-		ipsets = [vcd_ipset.aceeptance-ipset-2.name]
+		ip_sets = [vcd_ipset.aceeptance-ipset-2.name]
 	}
   
 	destination {
-		ipsets = [vcd_ipset.aceeptance-ipset-1.name]
+		ip_sets = [vcd_ipset.aceeptance-ipset-1.name]
 	}
 
 	service {
@@ -1089,7 +1089,7 @@ func TestAccVcdNsxvEdgeFirewallRuleVms(t *testing.T) {
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.vms", "id", regexp.MustCompile(`\d*`)),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "name", "rule-with-ipsets"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "name", "rule-with-ip_sets"),
 					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.vms", "rule_tag", regexp.MustCompile(`\d*`)),
 
 					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "action", "accept"),
@@ -1097,7 +1097,7 @@ func TestAccVcdNsxvEdgeFirewallRuleVms(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "logging_enabled", "false"),
 					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.exclude", "false"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.gateway_interfaces"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.org_networks"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.ip_addresses"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.security_groups"),
@@ -1105,7 +1105,7 @@ func TestAccVcdNsxvEdgeFirewallRuleVms(t *testing.T) {
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.gateway_interfaces"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.security_groups"),
 
 					// Test object counts
@@ -1125,7 +1125,7 @@ func TestAccVcdNsxvEdgeFirewallRuleVms(t *testing.T) {
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.vms", "id", regexp.MustCompile(`\d*`)),
-					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "name", "rule-with-ipsets"),
+					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "name", "rule-with-ip_sets"),
 					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.vms", "rule_tag", regexp.MustCompile(`\d*`)),
 
 					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "action", "accept"),
@@ -1133,7 +1133,7 @@ func TestAccVcdNsxvEdgeFirewallRuleVms(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "logging_enabled", "false"),
 					resource.TestCheckResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.exclude", "false"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.gateway_interfaces"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.org_networks"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.virtual_machine_ids"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "source.0.security_groups"),
@@ -1141,7 +1141,7 @@ func TestAccVcdNsxvEdgeFirewallRuleVms(t *testing.T) {
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.gateway_interfaces"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.ip_addresses"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.org_networks"),
-					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.ipsets"),
+					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.ip_sets"),
 					resource.TestCheckNoResourceAttr("vcd_nsxv_firewall_rule.vms", "destination.0.security_groups"),
 
 					// Test object counts
@@ -1206,7 +1206,7 @@ resource "vcd_nsxv_firewall_rule" "vms" {
 	org          = "{{.Org}}"
 	vdc          = "{{.Vdc}}"
 	edge_gateway = "{{.EdgeGateway}}"
-	name = "rule-with-ipsets"
+	name = "rule-with-ip_sets"
 	action = "accept"
 
 	source {
@@ -1228,7 +1228,7 @@ resource "vcd_nsxv_firewall_rule" "vms" {
 	org          = "{{.Org}}"
 	vdc          = "{{.Vdc}}"
 	edge_gateway = "{{.EdgeGateway}}"
-	name = "rule-with-ipsets"
+	name = "rule-with-ip_sets"
 	action = "accept"
 
 	source {

--- a/vcd/resource_vcd_nsxv_firewall_rule_test.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule_test.go
@@ -996,11 +996,11 @@ resource "vcd_nsxv_firewall_rule" "ip_sets" {
 	action = "accept"
 
 	source {
-		ip_sets = [vcd_ipset.aceeptance-ipset-1.name]
+		ip_sets = [vcd_nsxv_ip_set.aceeptance-ipset-1.name]
 	}
   
 	destination {
-		ip_sets = [vcd_ipset.aceeptance-ipset-2.name]
+		ip_sets = [vcd_nsxv_ip_set.aceeptance-ipset-2.name]
 	}
 
 	service {
@@ -1008,12 +1008,12 @@ resource "vcd_nsxv_firewall_rule" "ip_sets" {
 	}
 }
 
-resource "vcd_ipset" "aceeptance-ipset-1" {
+resource "vcd_nsxv_ip_set" "aceeptance-ipset-1" {
 	name = "acceptance test IPset 1"
 	ip_addresses = ["222.222.222.1/24"]
 }
 
-resource "vcd_ipset" "aceeptance-ipset-2" {
+resource "vcd_nsxv_ip_set" "aceeptance-ipset-2" {
 	name = "acceptance test IPset 2"
 	ip_addresses = ["11.11.11.1-11.11.11.100", "12.12.12.1"]
 }
@@ -1028,11 +1028,11 @@ resource "vcd_nsxv_firewall_rule" "ip_sets" {
 	action = "accept"
 
 	source {
-		ip_sets = [vcd_ipset.aceeptance-ipset-2.name]
+		ip_sets = [vcd_nsxv_ip_set.aceeptance-ipset-2.name]
 	}
   
 	destination {
-		ip_sets = [vcd_ipset.aceeptance-ipset-1.name]
+		ip_sets = [vcd_nsxv_ip_set.aceeptance-ipset-1.name]
 	}
 
 	service {
@@ -1040,12 +1040,12 @@ resource "vcd_nsxv_firewall_rule" "ip_sets" {
 	}
 }
 
-resource "vcd_ipset" "aceeptance-ipset-1" {
+resource "vcd_nsxv_ip_set" "aceeptance-ipset-1" {
 	name = "acceptance test IPset 1"
 	ip_addresses = ["222.222.222.1/24"]
 }
 
-resource "vcd_ipset" "aceeptance-ipset-2" {
+resource "vcd_nsxv_ip_set" "aceeptance-ipset-2" {
 	name = "acceptance test IPset 2"
 	ip_addresses = ["11.11.11.1-11.11.11.100", "12.12.12.1"]
 }

--- a/website/docs/d/ipset.html.markdown
+++ b/website/docs/d/ipset.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "vcd"
-page_title: "vCloudDirector: vcd_ipset"
+page_title: "vCloudDirector: vcd_nsxv_ip_set"
 sidebar_current: "docs-vcd-datasource-ipset"
 description: |-
   Provides an IP set data source.
 ---
 
-# vcd\_ipset
+# vcd\_nsxv\_ip\_set
 
 Provides a vCloud Director IP set data source. An IP set is a group of IP addresses that you can add
   as the source or destination in a firewall rule or in DHCP relay configuration.
@@ -16,7 +16,7 @@ Supported in provider *v2.6+*
 ## Example Usage
 
 ```hcl
-data "vcd_ipset" "ip-set DS" {
+data "vcd_nsxv_ip_set" "ip-set DS" {
   org                 = "my-org"
   vdc                 = "my-org-vdc"
 
@@ -34,4 +34,4 @@ The following arguments are supported:
 
 ## Attribute Reference
 
-All the attributes defined in [`vcd_ipset`](/docs/providers/vcd/r/ipset.html) resource are available.
+All the attributes defined in [`vcd_nsxv_ip_set`](/docs/providers/vcd/r/ipset.html) resource are available.

--- a/website/docs/r/ipset.html.markdown
+++ b/website/docs/r/ipset.html.markdown
@@ -37,6 +37,45 @@ resource "vcd_ipset" "test-ipset" {
 }
 ```
 
+## Example Usage 3 (use IP set in firewall rules)
+
+```hcl
+resource "vcd_ipset" "test-ipset" {
+  org          = "my-org"
+  vdc          = "my-org-vdc"
+
+  name                   = "ipset-one"
+  is_inheritance_allowed = true
+  description            = "test-ip-set-changed-description"
+  ip_addresses           = ["1.1.1.1/24","10.10.10.100-10.10.10.110"]
+}
+
+resource "vcd_ipset" "test-ipset2" {
+  name                   = "ipset-two"
+  ip_addresses           = ["192.168.1.1"]
+}
+
+resource "vcd_nsxv_firewall_rule" "ipsets" {
+	org          = "my-org"
+	vdc          = "my-org-vdc"
+	edge_gateway = "my-edge-gw"
+	name = "rule-with-ipsets"
+	action = "accept"
+
+	source {
+		ipsets = [vcd_ipset.test-ipset.name]
+	}
+  
+	destination {
+		ipsets = [vcd_ipset.test-ipset2.name]
+	}
+
+	service {
+		protocol = "any"
+	}
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/ipset.html.markdown
+++ b/website/docs/r/ipset.html.markdown
@@ -63,11 +63,11 @@ resource "vcd_nsxv_firewall_rule" "ipsets" {
 	action = "accept"
 
 	source {
-		ipsets = [vcd_ipset.test-ipset.name]
+		ip_sets = [vcd_ipset.test-ipset.name]
 	}
   
 	destination {
-		ipsets = [vcd_ipset.test-ipset2.name]
+		ip_sets = [vcd_ipset.test-ipset2.name]
 	}
 
 	service {

--- a/website/docs/r/ipset.html.markdown
+++ b/website/docs/r/ipset.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "vcd"
-page_title: "vCloudDirector: vcd_ipset"
+page_title: "vCloudDirector: vcd_nsxv_ip_set"
 sidebar_current: "docs-vcd-resource-ipset"
 description: |-
   Provides an IP set resource.
 ---
 
-# vcd\_ipset
+# vcd\_nsxv\_ip\_set
 
 Provides a vCloud Director IP set resource. An IP set is a group of IP addresses that you can add as
   the source or destination in a firewall rule or in DHCP relay configuration.
@@ -17,7 +17,7 @@ Supported in provider *v2.6+*
 ## Example Usage 1
 
 ```hcl
-resource "vcd_ipset" "test-ipset" {
+resource "vcd_nsxv_ip_set" "test-ipset" {
   org          = "my-org"
   vdc          = "my-org-vdc"
 
@@ -31,7 +31,7 @@ resource "vcd_ipset" "test-ipset" {
 ## Example Usage 2 (minimal example)
 
 ```hcl
-resource "vcd_ipset" "test-ipset" {
+resource "vcd_nsxv_ip_set" "test-ipset" {
   name                   = "ipset-two"
   ip_addresses           = ["192.168.1.1"]
 }
@@ -40,7 +40,7 @@ resource "vcd_ipset" "test-ipset" {
 ## Example Usage 3 (use IP set in firewall rules)
 
 ```hcl
-resource "vcd_ipset" "test-ipset" {
+resource "vcd_nsxv_ip_set" "test-ipset" {
   org          = "my-org"
   vdc          = "my-org-vdc"
 
@@ -50,7 +50,7 @@ resource "vcd_ipset" "test-ipset" {
   ip_addresses           = ["1.1.1.1/24","10.10.10.100-10.10.10.110"]
 }
 
-resource "vcd_ipset" "test-ipset2" {
+resource "vcd_nsxv_ip_set" "test-ipset2" {
   name                   = "ipset-two"
   ip_addresses           = ["192.168.1.1"]
 }
@@ -59,15 +59,16 @@ resource "vcd_nsxv_firewall_rule" "ipsets" {
 	org          = "my-org"
 	vdc          = "my-org-vdc"
 	edge_gateway = "my-edge-gw"
-	name = "rule-with-ipsets"
+	
+  name = "rule-with-ipsets"
 	action = "accept"
 
 	source {
-		ip_sets = [vcd_ipset.test-ipset.name]
+		ip_sets = [vcd_nsxv_ip_set.test-ipset.name]
 	}
   
 	destination {
-		ip_sets = [vcd_ipset.test-ipset2.name]
+		ip_sets = [vcd_nsxv_ip_set.test-ipset2.name]
 	}
 
 	service {
@@ -104,7 +105,7 @@ separated path IP set. An example is below:
 [docs-import]: https://www.terraform.io/docs/import/
 
 ```
-terraform import vcd_ipset.imported org-name.vdc-name.ipset-name
+terraform import vcd_nsxv_ip_set.imported org-name.vdc-name.ipset-name
 ```
 
 The above would import the IP set named `ipset-name` that is defined in org named `org-name` and vDC

--- a/website/docs/r/nsxv_firewall_rule.markdown
+++ b/website/docs/r/nsxv_firewall_rule.markdown
@@ -31,7 +31,7 @@ resource "vcd_nsxv_firewall_rule" "my-rule-1" {
   edge_gateway = "my-edge-gateway"
 
   source {
-    ipsets = [vcd_ipset.test-ipset2.name]
+    ip_sets = [vcd_ipset.test-ipset2.name]
   }
 
   destination {
@@ -185,7 +185,7 @@ accepted as a parameter.
 * `gateway_interfaces` - (Optional) A set of with either three keywords `vse` (UI names it as `any`), `internal`, `external` or an org network name. It automatically looks up vNic in the backend.
 * `virtual_machine_ids` - (Optional) A set of `.id` fields of `vcd_vapp_vm` resources.
 * `org_networks` - (Optional) A set of org network names.
-* `ipsets` - (Optional) A set of IP set names.
+* `ip_sets` - (Optional) A set of IP set names.
 
 
 <a id="service"></a>

--- a/website/docs/r/nsxv_firewall_rule.markdown
+++ b/website/docs/r/nsxv_firewall_rule.markdown
@@ -185,7 +185,7 @@ accepted as a parameter.
 * `gateway_interfaces` - (Optional) A set of with either three keywords `vse` (UI names it as `any`), `internal`, `external` or an org network name. It automatically looks up vNic in the backend.
 * `virtual_machine_ids` - (Optional) A set of `.id` fields of `vcd_vapp_vm` resources.
 * `org_networks` - (Optional) A set of org network names.
-* `ip_sets` - (Optional) A set of existing IP set names. (Either created manually or configured using `vcd_nsxv_ip_set` resource)
+* `ip_sets` - (Optional) A set of existing IP set names (either created manually or configured using `vcd_nsxv_ip_set` resource)
 
 
 <a id="service"></a>

--- a/website/docs/r/nsxv_firewall_rule.markdown
+++ b/website/docs/r/nsxv_firewall_rule.markdown
@@ -31,7 +31,7 @@ resource "vcd_nsxv_firewall_rule" "my-rule-1" {
   edge_gateway = "my-edge-gateway"
 
   source {
-    ip_addresses = ["any"]
+    ipsets = [vcd_ipset.test-ipset2.name]
   }
 
   destination {
@@ -185,6 +185,7 @@ accepted as a parameter.
 * `gateway_interfaces` - (Optional) A set of with either three keywords `vse` (UI names it as `any`), `internal`, `external` or an org network name. It automatically looks up vNic in the backend.
 * `virtual_machine_ids` - (Optional) A set of `.id` fields of `vcd_vapp_vm` resources.
 * `org_networks` - (Optional) A set of org network names.
+* `ipsets` - (Optional) A set of IP set names.
 
 
 <a id="service"></a>

--- a/website/docs/r/nsxv_firewall_rule.markdown
+++ b/website/docs/r/nsxv_firewall_rule.markdown
@@ -185,7 +185,7 @@ accepted as a parameter.
 * `gateway_interfaces` - (Optional) A set of with either three keywords `vse` (UI names it as `any`), `internal`, `external` or an org network name. It automatically looks up vNic in the backend.
 * `virtual_machine_ids` - (Optional) A set of `.id` fields of `vcd_vapp_vm` resources.
 * `org_networks` - (Optional) A set of org network names.
-* `ip_sets` - (Optional) A set of IP set names.
+* `ip_sets` - (Optional) A set of existing IP set names. (Either created manually or configured using `vcd_nsxv_ip_set` resource)
 
 
 <a id="service"></a>

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -77,7 +77,7 @@
               <a href="/docs/providers/vcd/d/vapp_vm.html">vcd_vapp_vm</a>
             </li>
             <li<%= sidebar_current("docs-vcd-datasource-ipset") %>>
-              <a href="/docs/providers/vcd/d/ipset.html">vcd_ipset</a>
+              <a href="/docs/providers/vcd/d/ipset.html">vcd_nsxv_ip_set</a>
             </li>
           </ul>
         </li>
@@ -173,7 +173,7 @@
               <a href="/docs/providers/vcd/r/nsxv_firewall_rule.html">vcd_nsxv_firewall_rule</a>
             </li>
             <li<%= sidebar_current("docs-vcd-resource-ipset") %>>
-              <a href="/docs/providers/vcd/r/ipset.html">vcd_ipset</a>
+              <a href="/docs/providers/vcd/r/ipset.html">vcd_nsxv_ip_set</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
This PR adds support for IP sets in `vcd_nsxv_firewall_rule` resource.

It also adds extra testing to better cover firewall_rule testing.

Additionally it changes name of unreleased resource `vcd_ipset` to `vcd_nsxv_ip_set`.

Note. Acceptance tests passe on vcd 9.5 and 10. Binary tests passed on 9.5.