### PR TITLE
Do not send fips_mode_enabled when it is not set (needed for vCD 9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ IMPROVEMENTS:
 * `resource/vcd_network_routed` Add check for valid IPs [GH-374]
 * `resource/vcd_network_isolated` Add check for valid IPs [GH-373]
 * `resource/vcd_edgegateway` new fields `fips_mode_enabled`, `use_default_route_for_dns_relay`
-  - [GH-401]
+  - [GH-401,GH-414]
 * `resource/vcd_edgegateway`  new `external_network` block for advanced configurations of external
   networks including multiple subnets, IP pool sub-allocation and rate limits - [GH-401]
 * `resource/vcd_edgegateway` enables read support for field `distributed_routing` after switch to

--- a/vcd/resource_vcd_edgegateway.go
+++ b/vcd/resource_vcd_edgegateway.go
@@ -353,8 +353,8 @@ func resourceVcdEdgeGatewayCreate(d *schema.ResourceData, meta interface{}) erro
 	// field value must be sent only if user specified its value
 	if fipsModeEnabled, ok := d.GetOkExists("fips_mode_enabled"); ok {
 		if vcdClient.APIVCDMaxVersionIs("<= 29.0") { // vCD 9.0 or less
-			_, _ = fmt.Fprint(getTerraformStdout(), "WARNING! FIPS mode is only supported starting"+
-				" with vCD 9.1. Please do not set this field when using with vCD 9.0\n")
+			return fmt.Errorf("ERROR! FIPS mode is only supported starting" +
+				" with vCD 9.1. Please do not set this field when using with vCD 9.0")
 		}
 		fipsModeEnabledBool := fipsModeEnabled.(bool)
 		log.Printf("[TRACE] edge gateway creation. FIPS mode was set with value %t", fipsModeEnabledBool)

--- a/vcd/resource_vcd_edgegateway_test.go
+++ b/vcd/resource_vcd_edgegateway_test.go
@@ -275,7 +275,7 @@ func TestAccVcdEdgeGatewayExternalNetworks(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_edgegateway.egw", "configuration", "compact"),
 					resource.TestCheckResourceAttr("vcd_edgegateway.egw", "advanced", "true"),
 					resource.TestCheckResourceAttr("vcd_edgegateway.egw", "distributed_routing", "false"),
-					resource.TestCheckResourceAttr("vcd_edgegateway.egw", "fips_mode_enabled", "false"),
+					resource.TestCheckNoResourceAttr("vcd_edgegateway.egw", "fips_mode_enabled"),
 					resource.TestCheckResourceAttr("vcd_edgegateway.egw", "use_default_route_for_dns_relay", "true"),
 					resource.TestCheckResourceAttr("vcd_edgegateway.egw", "default_gateway_network", newExternalNetworkVcd),
 					resource.TestCheckResourceAttr("vcd_edgegateway.egw", "default_external_network_ip", "192.168.30.51"),
@@ -311,7 +311,7 @@ func TestAccVcdEdgeGatewayExternalNetworks(t *testing.T) {
 					resource.TestCheckResourceAttrPair("vcd_edgegateway.egw", "external_network_ips.#", "data.vcd_edgegateway.egw", "external_network_ips.#"),
 					resource.TestCheckResourceAttrPair("vcd_edgegateway.egw", "external_network_ips.0", "data.vcd_edgegateway.egw", "external_network_ips.0"),
 					resource.TestCheckResourceAttrPair("vcd_edgegateway.egw", "external_network_ips.1", "data.vcd_edgegateway.egw", "external_network_ips.1"),
-					resource.TestCheckResourceAttrPair("vcd_edgegateway.egw", "fips_mode_enabled", "data.vcd_edgegateway.egw", "fips_mode_enabled"),
+					resource.TestCheckNoResourceAttr("data.vcd_edgegateway.egw", "fips_mode_enabled"),
 					resource.TestCheckResourceAttrPair("vcd_edgegateway.egw", "use_default_route_for_dns_relay", "data.vcd_edgegateway.egw", "use_default_route_for_dns_relay"),
 					resource.TestCheckResourceAttrPair("vcd_edgegateway.egw", "advanced", "data.vcd_edgegateway.egw", "advanced"),
 					resource.TestCheckResourceAttrPair("vcd_edgegateway.egw", "distributed_routing", "data.vcd_edgegateway.egw", "distributed_routing"),
@@ -340,7 +340,7 @@ func TestAccVcdEdgeGatewayExternalNetworks(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_edgegateway.egw", "configuration", "compact"),
 					resource.TestCheckResourceAttr("vcd_edgegateway.egw", "advanced", "true"),
 					resource.TestCheckResourceAttr("vcd_edgegateway.egw", "distributed_routing", "false"),
-					resource.TestCheckResourceAttr("vcd_edgegateway.egw", "fips_mode_enabled", "false"),
+					resource.TestCheckNoResourceAttr("vcd_edgegateway.egw", "fips_mode_enabled"),
 					resource.TestCheckResourceAttr("vcd_edgegateway.egw", "ha_enabled", "false"),
 					resource.TestCheckResourceAttr("vcd_edgegateway.egw", "description", ""),
 
@@ -573,7 +573,9 @@ resource "vcd_edgegateway" "egw" {
 	configuration           = "compact"
 	advanced                = true
   
-	fips_mode_enabled               = false
+	# FIPS mode is not set because otherwise provider would try to send this field
+	# and vCD 9.0 complains about it, because it was introduced in vCD 9.1 only
+	# fips_mode_enabled               = false
 	use_default_route_for_dns_relay = true
 	distributed_routing             = false
   

--- a/website/docs/r/edgegateway.html.markdown
+++ b/website/docs/r/edgegateway.html.markdown
@@ -137,11 +137,13 @@ The following arguments are supported:
   a subnet which should be used as a default route.
 * `advanced` - (Optional) True if the gateway uses advanced networking. Default is `true`.
 * `ha_enabled` - (Optional) Enable high availability on this edge gateway. Default is `false`.
-* `distributed_routing` - (Optional) If advanced networking enabled, also enable distributed routing. Default is `false`.
+* `distributed_routing` - (Optional) If advanced networking enabled, also enable distributed
+  routing. Default is `false`.
 * `fips_mode_enabled` - (Optional) When FIPS mode is enabled, any secure communication to or from
   the NSX Edge uses cryptographic algorithms or protocols that are allowed by United States Federal
   Information Processing Standards (FIPS). FIPS mode turns on the cipher suites that comply with
-  FIPS. Default is `false`. **Note:** to use FIPS mode it must be enabled in vCD system settings. 
+  FIPS. Default is `false`. **Note:** to use FIPS mode it must be enabled in vCD system settings and
+  is only supported starting with vCD version 9.1. This field __must not__ be set for vCD 9.0.
 * `use_default_route_for_dns_relay` - (Optional) When default route is set, it will be used for
   gateways' default routing and DNS forwarding. Default is `false`.
 * `lb_enabled` - (Optional) Enable load balancing. Default is `false`.


### PR DESCRIPTION
vCD 9.0 edge gateway does not support FIPS mode and API throws error if the XML field `FipsModeEnabled` is sent. This modifies edge gateway creation so that if the field `fips_mode_enabled` is not set - it is not sent.

The problem was identified here - https://github.com/terraform-providers/terraform-provider-vcd/issues/323#issuecomment-561575052