### PR TITLE
vCD 9.0 testing bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@ BUG FIXES:
 * Fix `vcd_independent_disk` reapply issue, which was seen when optional `bus_sub_type` and `bus_type` wasn't used - [GH-394]
 * Fix `vcd_vapp_network` apply issue, where the property `guest_vlan_allowed` was applied only to the last of multiple networks.
 * `datasource/vcd_network_direct` is now readable by Org User (previously it was only by Sys Admin), as this change made it possible to get the details of External Network as Org User [GH-408]
-* vCD 9.0 - TBD
 
 DEPRECATIONS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ BUG FIXES:
 * Fix `vcd_independent_disk` reapply issue, which was seen when optional `bus_sub_type` and `bus_type` wasn't used - [GH-394]
 * Fix `vcd_vapp_network` apply issue, where the property `guest_vlan_allowed` was applied only to the last of multiple networks.
 * `datasource/vcd_network_direct` is now readable by Org User (previously it was only by Sys Admin), as this change made it possible to get the details of External Network as Org User [GH-408]
+* vCD 9.0 - TBD
 
 DEPRECATIONS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ IMPROVEMENTS:
 * `resource/vcd_edgegateway` new fields `fips_mode_enabled`, `use_default_route_for_dns_relay`
   - [GH-401,GH-414]
 * `resource/vcd_edgegateway`  new `external_network` block for advanced configurations of external
-  networks including multiple subnets, IP pool sub-allocation and rate limits - [GH-401]
+  networks including multiple subnets, IP pool sub-allocation and rate limits - [GH-401,GH-418]
 * `resource/vcd_edgegateway` enables read support for field `distributed_routing` after switch to
   vCD API v29.0 - [GH-401]
 

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.13
 require (
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/terraform-plugin-sdk v1.3.0
-	github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.11
+	github.com/vmware/go-vcloud-director/v2 v2.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/vmihailenco/msgpack v3.3.3+incompatible h1:wapg9xDUZDzGCNFlwc5SqI1rvc
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.11 h1:VyJTHIPwwQZkCbIX2TPQ4ddnhJZIWZ5HCkSy/cHiSkc=
-github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.11/go.mod h1:zjondbeyTfZlzhwxOzyF4K2sWWYgMEv5H91dp5dPbU8=
+github.com/vmware/go-vcloud-director/v2 v2.5.0 h1:Jriz+tpmDd/vkT/FuCDqGTJ1NHKkWnP/oPsoKTQqhxI=
+github.com/vmware/go-vcloud-director/v2 v2.5.0/go.mod h1:zjondbeyTfZlzhwxOzyF4K2sWWYgMEv5H91dp5dPbU8=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/vcd/resource_vcd_edgegateway_test.go
+++ b/vcd/resource_vcd_edgegateway_test.go
@@ -417,7 +417,7 @@ func TestAccVcdEdgeGatewayRateLimits(t *testing.T) {
 
 	if !isPgDistributed {
 		t.Skipf("Skipping test because specified portgroup is from standard vSwitch and " +
-			"does not support rate limitting")
+			"does not support rate limiting")
 	}
 
 	var (

--- a/vcd/resource_vcd_ipset.go
+++ b/vcd/resource_vcd_ipset.go
@@ -290,7 +290,7 @@ func ipSetIdsToNames(ipSetIds []string, vdc *govcd.Vdc) ([]string, error) {
 }
 
 // ipSetNamesToIds looks up IP set names by their IDs
-func ipSetNamesToIds(ipSetNames []string, vdc *govcd.Vdc) ([]string, error) {
+func ipSetNamesToIds(ipSetNames []string, vdc *govcd.Vdc, isShortFormat bool) ([]string, error) {
 	ipSetIds := make([]string, len(ipSetNames))
 
 	// When no names are passed - there is no need to lookup IP sets
@@ -312,7 +312,11 @@ func ipSetNamesToIds(ipSetNames []string, vdc *govcd.Vdc) ([]string, error) {
 		var ipSetFound bool
 		for _, ipSet := range allIpSets {
 			if ipSet.Name == ipSetName {
-				ipSetIds[index] = ipSet.ID
+				if isShortFormat {
+					ipSetIds[index] = strings.Split(ipSet.ID, ":")[1]
+				} else {
+					ipSetIds[index] = ipSet.ID
+				}
 				ipSetFound = true
 			}
 		}

--- a/vcd/resource_vcd_nsxv_dhcp_relay.go
+++ b/vcd/resource_vcd_nsxv_dhcp_relay.go
@@ -244,7 +244,7 @@ func getDhcpRelayType(d *schema.ResourceData, edge *govcd.EdgeGateway, vcdClient
 
 	if ipSetNames, ok := d.GetOk("ip_sets"); ok {
 		listOfIpSetNames = convertSchemaSetToSliceOfStrings(ipSetNames.(*schema.Set))
-		listOfIpSetIds, err = ipSetNamesToIds(listOfIpSetNames, vdc)
+		listOfIpSetIds, err = ipSetNamesToIds(listOfIpSetNames, vdc, false)
 		if err != nil {
 			return nil, fmt.Errorf("could not lookup supplied IP set IDs by their names: %s", err)
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -224,7 +224,7 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/vmware/go-vcloud-director/v2 v2.5.0-alpha.11
+# github.com/vmware/go-vcloud-director/v2 v2.5.0
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util

--- a/website/docs/r/edgegateway.html.markdown
+++ b/website/docs/r/edgegateway.html.markdown
@@ -175,7 +175,7 @@ One of `accept` or `deny`. Default `deny`.
 * `outgoing_rate_limit` (Optional) - Outgoing rate limit in Mbps.
 * `subnet` (Required) - One or more blocks of [External Network Subnet](#external-network-subnet).
 
-~> **Note:** Rate limitting works only with external networks backed by distributed portgroups.
+~> **Note:** Rate limiting works only with external networks backed by distributed portgroups.
 
 
 <a id="external-network-subnet"></a>

--- a/website/docs/r/edgegateway.html.markdown
+++ b/website/docs/r/edgegateway.html.markdown
@@ -175,6 +175,8 @@ One of `accept` or `deny`. Default `deny`.
 * `outgoing_rate_limit` (Optional) - Outgoing rate limit in Mbps.
 * `subnet` (Required) - One or more blocks of [External Network Subnet](#external-network-subnet).
 
+~> **Note:** Rate limitting works only with external networks backed by distributed portgroups.
+
 
 <a id="external-network-subnet"></a>
 ## External Network Subnet 


### PR DESCRIPTION
vCD 9.0 has the following tests failing. The below problems are fixed:

* `TestAccVcdEdgeGatewayExternalNetworks` 
```shell
--- FAIL: TestAccVcdEdgeGatewayExternalNetworks (59.95s)
    testing.go:635: Step 0 error: After applying this step and refreshing, the plan was not empty:
...
external_network.1.incoming_rate_limit:                       "0" => "77.77" (forces new resource)
external_network.1.name:                                      "test_external_network" => "test_external_network" (forces new resource)
external_network.1.outgoing_rate_limit:                       "0" => "88.88234" (forces new resource)
...
```
_Problem_ is that vCD 9.0 never returns rate limit settings even though it accepts and sets them. Then read defaults them to 0 and every apply triggers updates. Because it is `TypeSet` with more values - one cannot simply skip the `read` for this field.

_Solution_ - when vCD 9.0 connection is detected  and the object is `resource` - pass through the values from configuration instead of real API value. That way `read` does not work for 9.0, but every `apply` is clean.

`go test -count=1 -v -tags ALL -run "TestAccVcdEdgeGateway" .` passed on vCD 9.0, 9.5, 10

* `TestAccVcdEdgeGatewayExternalNetworks` would fail if portgroup used for external network is comming from standard vSwitch. 
```
--- FAIL: TestAccVcdEdgeGatewayExternalNetworks (23.30s)
    testing.go:635: Step 0 error: errors during apply:
        Error: error creating edge gateway: error instantiating a new Edge Gateway: API Error: 400: [ afe82342-16a3-4acc-b9a1-be760a1cbbc0 ] Rate limiting is not supported on external networks backed by standard switch portgroup.
          on /tmp/tf-test289349390/main.tf line 41:
          (source code not available)
```

_Problem_ - rate limiting is only supported on external networks which are backed by distributed port groups.
_Solution_ - the test for rate limiting is split into separate one with explicit check if the used portgroup supports rate limiting. If it doesn't - the test is skipped.

`go test -count=1 -v -tags ALL -run "TestAccVcdEdgeGateway" .` passed on vCD 9.0, 9.1, 9.5, 10

* `TestAccVcdNsxvEdgeFirewallRuleIpSets` fails
```
--- FAIL: TestAccVcdNsxvEdgeFirewallRuleIpSets (312.50s)
    testing.go:635: Step 1 error: errors during apply:
        Error: unable to update firewall rule with ID 134161: error while updating firewall rule : [ParseErr]: error parsing error body for non-200 request: EOF (&{Status:400 Bad Request StatusCode:400 Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[Cache-Control:[no-store, must-revalidate] Content-Length:[0] Date:[Tue, 10 Dec 2019 19:48:37 GMT] X-Vcloud-Authorization:[1df385e570724b87a41963b939a6e071] X-Vmware-Vcloud-Request-Id:[9c664431-ef11-45c5-bf02-4f09c84a7574]] Body:0xc00984e620 ContentLength:0 TransferEncoding:[] Close:false Uncompressed:false Trailer:map[] Request:0xc000489400 TLS:0xc0076606e0})
          on /var/folders/h2/c60z324s6219c3hc_w28hbx80000gp/T/tf-test148114423/main.tf line 2:
          (source code not available)
```
_Problem_ - apparently for `update` (and **only** for update) operations vCD 9.0 requires ip set IDs to be in short format `ipset-460` instead of usually working long IDs `a0c3c92a-a180-48fb-96ec-91c610c7c254:ipset-460`.
_Solution_ - when vCD 9.0 is detected and an update procedure is requested - shorten the IP set IDs.

`go test -v -tags ALL -run "TestAccVcdNsxvEdgeFirewallRuleIpSets" .` passed on vCD 9.0, 9.5, 10

**Note.** The testing was carried out on vCD 9.0.0.3 because earlier vCD 9.0 versions have more internal bugs which are not to be solved in Terraform provider.