### PR TITLE
Fix an issue where vcd_nsxv_firewall_rule and vcd_nsxv_dnat may fail using a regular user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ IMPROVEMENTS:
   networks including multiple subnets, IP pool sub-allocation and rate limits - [GH-401,GH-418]
 * `resource/vcd_edgegateway` enables read support for field `distributed_routing` after switch to
   vCD API v29.0 - [GH-401]
+* `vcd_nsxv_firewall_rule` - improve internal lookup mechanism for `gateway_interfaces` field in
+  source and/or destination [GH-419]
 
 BUG FIXES:
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,5 @@ go 1.13
 require (
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/terraform-plugin-sdk v1.3.0
-	github.com/vmware/go-vcloud-director/v2 v2.5.0
+	github.com/vmware/go-vcloud-director/v2 v2.5.1
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.5.0-alpha.9.0.20191212073012-bca9d7aa5a86

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.5.0
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.5.0-alpha.9.0.20191212065333-e4c9449627f4
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.5.0-alpha.9.0.20191212073012-bca9d7aa5a86

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.3.0
 	github.com/vmware/go-vcloud-director/v2 v2.5.0
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.5.0-alpha.9.0.20191212065333-e4c9449627f4

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbf
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Didainius/go-vcloud-director/v2 v2.5.0-alpha.9.0.20191212065333-e4c9449627f4 h1:s2ko63HTS0FU1+BQhbYLQwDDT5EwUVZ2xzdR15uUbTQ=
+github.com/Didainius/go-vcloud-director/v2 v2.5.0-alpha.9.0.20191212065333-e4c9449627f4/go.mod h1:zjondbeyTfZlzhwxOzyF4K2sWWYgMEv5H91dp5dPbU8=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
@@ -201,8 +203,6 @@ github.com/vmihailenco/msgpack v3.3.3+incompatible h1:wapg9xDUZDzGCNFlwc5SqI1rvc
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/go-vcloud-director/v2 v2.5.0 h1:Jriz+tpmDd/vkT/FuCDqGTJ1NHKkWnP/oPsoKTQqhxI=
-github.com/vmware/go-vcloud-director/v2 v2.5.0/go.mod h1:zjondbeyTfZlzhwxOzyF4K2sWWYgMEv5H91dp5dPbU8=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbf
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.5.0-alpha.9.0.20191212065333-e4c9449627f4 h1:s2ko63HTS0FU1+BQhbYLQwDDT5EwUVZ2xzdR15uUbTQ=
-github.com/Didainius/go-vcloud-director/v2 v2.5.0-alpha.9.0.20191212065333-e4c9449627f4/go.mod h1:zjondbeyTfZlzhwxOzyF4K2sWWYgMEv5H91dp5dPbU8=
+github.com/Didainius/go-vcloud-director/v2 v2.5.0-alpha.9.0.20191212073012-bca9d7aa5a86 h1:8qllT23Vr4YL628dnPpz+EDmzVbPBFQPhgtLsSjznXE=
+github.com/Didainius/go-vcloud-director/v2 v2.5.0-alpha.9.0.20191212073012-bca9d7aa5a86/go.mod h1:zjondbeyTfZlzhwxOzyF4K2sWWYgMEv5H91dp5dPbU8=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbf
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.5.0-alpha.9.0.20191212073012-bca9d7aa5a86 h1:8qllT23Vr4YL628dnPpz+EDmzVbPBFQPhgtLsSjznXE=
-github.com/Didainius/go-vcloud-director/v2 v2.5.0-alpha.9.0.20191212073012-bca9d7aa5a86/go.mod h1:zjondbeyTfZlzhwxOzyF4K2sWWYgMEv5H91dp5dPbU8=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
@@ -203,6 +201,8 @@ github.com/vmihailenco/msgpack v3.3.3+incompatible h1:wapg9xDUZDzGCNFlwc5SqI1rvc
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmware/go-vcloud-director/v2 v2.5.1 h1:VYZyhkLDbUNwDpSFp+b+6rCZ9/1Om2IORP01ExCHspU=
+github.com/vmware/go-vcloud-director/v2 v2.5.1/go.mod h1:zjondbeyTfZlzhwxOzyF4K2sWWYgMEv5H91dp5dPbU8=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -411,7 +411,7 @@ func getConfigStruct(config string) TestConfig {
 		configStruct.Provider.User = user
 		configStruct.Provider.Password = password
 		configStruct.Provider.SysOrg = configStruct.VCD.Org
-		fmt.Println("VCD_TEST_USER was enabled. Using Org User credentials from configuration file")
+		fmt.Println("VCD_TEST_ORG_USER was enabled. Using Org User credentials from configuration file")
 	}
 	if configStruct.Provider.Token != "" && configStruct.Provider.Password == "" {
 		configStruct.Provider.Password = "TOKEN"

--- a/vcd/datasource_vcd_edgegateway.go
+++ b/vcd/datasource_vcd_edgegateway.go
@@ -131,7 +131,7 @@ func datasourceVcdEdgeGateway() *schema.Resource {
 						"enable_rate_limit": {
 							Computed:    true,
 							Type:        schema.TypeBool,
-							Description: "Enable rate limitting",
+							Description: "Enable rate limiting",
 						},
 						"incoming_rate_limit": {
 							Computed:    true,

--- a/vcd/resource_vcd_edgegateway.go
+++ b/vcd/resource_vcd_edgegateway.go
@@ -76,7 +76,7 @@ var externalNetworkResource = &schema.Resource{
 			Default:     false,
 			ForceNew:    true,
 			Type:        schema.TypeBool,
-			Description: "Enable rate limitting",
+			Description: "Enable rate limiting",
 		},
 		"incoming_rate_limit": {
 			Optional:    true,

--- a/vcd/resource_vcd_edgegateway_test.go
+++ b/vcd/resource_vcd_edgegateway_test.go
@@ -302,7 +302,7 @@ func TestAccVcdEdgeGatewayExternalNetworks(t *testing.T) {
 					// TODO after
 					// https://github.com/terraform-providers/terraform-provider-aws/issues/7198
 					// Data source checks. There is a bug in Terraform where a data source cannot
-					// have two computed TypeSet variables because they get overwriten The test
+					// have two computed TypeSet variables because they get overwritten The test
 					// below is left such, that it triggers an error as soon as the bug is fixed.
 					// (probably when we pull in newer SDK)
 					resource.TestCheckResourceAttr("data.vcd_edgegateway.egw", "external_network.#", "1"),
@@ -405,14 +405,14 @@ func isPortGroupDistributed(portGroupName string) (bool, error) {
 	return false, nil
 }
 
-// TestAccVcdEdgeGatewayRateLimits focues on testing how the `external_network` block handles
+// TestAccVcdEdgeGatewayRateLimits focuses on testing how the `external_network` block handles
 // network interface limits. It escapes quickly when the ExternalNetworkPortGroup of external
 // network is of type "NETWORK" (standard switch portgroup) and only proceeds when it is of type
-// "DV_PORTGROUP" (Backed by distributed switch). Only "DV_PORTGROUP" support rate limitting.
+// "DV_PORTGROUP" (Backed by distributed switch). Only "DV_PORTGROUP" support rate limiting.
 func TestAccVcdEdgeGatewayRateLimits(t *testing.T) {
 	isPgDistributed, err := isPortGroupDistributed(testConfig.Networking.ExternalNetworkPortGroup)
 	if err != nil {
-		t.Skipf("Skipping test because port group type could not be validated: %s", err.Error())
+		t.Skipf("Skipping test because port group type could not be validated")
 	}
 
 	if !isPgDistributed {

--- a/vcd/resource_vcd_nsxv_firewall_rule_test.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule_test.go
@@ -26,8 +26,6 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 		"RouteNetworkName": "TestAccVcdVAppVmNet",
 		"Catalog":          testSuiteCatalogName,
 		"CatalogItem":      testSuiteCatalogOVAItem,
-		"VappName":         vappName2,
-		"VmName":           vmName,
 		"Tags":             "gateway firewall",
 	}
 
@@ -891,8 +889,6 @@ func TestAccVcdNsxvEdgeFirewallRuleIpSets(t *testing.T) {
 		"RouteNetworkName": "TestAccVcdVAppVmNet",
 		"Catalog":          testSuiteCatalogName,
 		"CatalogItem":      testSuiteCatalogOVAItem,
-		"VappName":         vappName2,
-		"VmName":           vmName,
 		"Tags":             "gateway firewall",
 	}
 
@@ -1077,8 +1073,6 @@ func TestAccVcdNsxvEdgeFirewallRuleVms(t *testing.T) {
 		"RouteNetworkName": "TestAccVcdVAppVmNet",
 		"Catalog":          testSuiteCatalogName,
 		"CatalogItem":      testSuiteCatalogOVAItem,
-		"VappName":         vappName2,
-		"VmName":           vmName,
 		"Tags":             "gateway firewall",
 	}
 

--- a/vcd/resource_vcd_nsxv_firewall_rule_test.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule_test.go
@@ -1052,6 +1052,20 @@ resource "vcd_nsxv_ip_set" "aceeptance-ipset-2" {
 `
 
 func TestAccVcdNsxvEdgeFirewallRuleVms(t *testing.T) {
+	// vCD 9.0 has a known bug - therefore skip the test if it is vCD 9.0
+	vcdClient, err := getTestVCDFromJson(testConfig)
+	if err != nil {
+		t.Skip("unable to validate vCD version - skipping test")
+	}
+	err = ProviderAuthenticate(vcdClient, testConfig.Provider.User, testConfig.Provider.Password, testConfig.Provider.Token, testConfig.Provider.SysOrg)
+	if err != nil {
+		t.Skip("unable to validate vCD version - skipping test")
+	}
+	if vcdClient.APIVCDMaxVersionIs("= 29.0") {
+		t.Skip("Skipping this test for vCD 9.0 because of a known issue: " +
+			"https://github.com/terraform-providers/terraform-provider-vcd/issues/420")
+	}
+
 	// String map to fill the template
 	var params = StringMap{
 		"Org":              testConfig.VCD.Org,

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/edgegateway.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/edgegateway.go
@@ -1348,8 +1348,10 @@ func getVnicIndexByNetworkNameAndType(networkName, networkType string, vnics *ty
 	foundCount := 0
 
 	for _, vnic := range vnics.EdgeInterface {
-		// Look for matching portgroup name and network type
-		if vnic.Name == networkName && vnic.Type == networkType {
+		// Look for matching portgroup name and network type. If the PortgroupName is no empty -
+		// check that it contains network name as well.
+		if vnic.Name == networkName && vnic.Type == networkType &&
+			(vnic.PortgroupName == networkName || vnic.PortgroupName == "") {
 			foundIndex = vnic.Index
 			foundCount++
 		}

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/edgegateway.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/edgegateway.go
@@ -1348,7 +1348,7 @@ func getVnicIndexByNetworkNameAndType(networkName, networkType string, vnics *ty
 	foundCount := 0
 
 	for _, vnic := range vnics.EdgeInterface {
-		// Look for matching portgroup name and network type. If the PortgroupName is no empty -
+		// Look for matching portgroup name and network type. If the PortgroupName is not empty -
 		// check that it contains network name as well.
 		if vnic.Name == networkName && vnic.Type == networkType &&
 			(vnic.PortgroupName == networkName || vnic.PortgroupName == "") {

--- a/vendor/github.com/vmware/go-vcloud-director/v2/govcd/edgegateway.go
+++ b/vendor/github.com/vmware/go-vcloud-director/v2/govcd/edgegateway.go
@@ -1349,7 +1349,7 @@ func getVnicIndexByNetworkNameAndType(networkName, networkType string, vnics *ty
 
 	for _, vnic := range vnics.EdgeInterface {
 		// Look for matching portgroup name and network type
-		if vnic.Name == networkName && vnic.PortgroupName == networkName && vnic.Type == networkType {
+		if vnic.Name == networkName && vnic.Type == networkType {
 			foundIndex = vnic.Index
 			foundCount++
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -224,7 +224,7 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/vmware/go-vcloud-director/v2 v2.5.0
+# github.com/vmware/go-vcloud-director/v2 v2.5.0 => github.com/Didainius/go-vcloud-director/v2 v2.5.0-alpha.9.0.20191212065333-e4c9449627f4
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -224,7 +224,7 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/vmware/go-vcloud-director/v2 v2.5.0 => github.com/Didainius/go-vcloud-director/v2 v2.5.0-alpha.9.0.20191212073012-bca9d7aa5a86
+# github.com/vmware/go-vcloud-director/v2 v2.5.1
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -224,7 +224,7 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/vmware/go-vcloud-director/v2 v2.5.0 => github.com/Didainius/go-vcloud-director/v2 v2.5.0-alpha.9.0.20191212065333-e4c9449627f4
+# github.com/vmware/go-vcloud-director/v2 v2.5.0 => github.com/Didainius/go-vcloud-director/v2 v2.5.0-alpha.9.0.20191212073012-bca9d7aa5a86
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util

--- a/website/docs/r/edgegateway.html.markdown
+++ b/website/docs/r/edgegateway.html.markdown
@@ -169,7 +169,7 @@ One of `accept` or `deny`. Default `deny`.
 ## External Network
 
 * `name` (Required) - Name of existing external network
-* `enable_rate_limit` (Optional) - `True` if rate limitting should be applied on this interface.
+* `enable_rate_limit` (Optional) - `True` if rate limiting should be applied on this interface.
   Default is `false`.
 * `incoming_rate_limit` (Optional) - Incoming rate limit in Mbps.
 * `outgoing_rate_limit` (Optional) - Outgoing rate limit in Mbps.


### PR DESCRIPTION
This PR bumps underlying go-vcloud-director SDK which has a fix (https://github.com/vmware/go-vcloud-director/pull/275) for vNic lookup on networks (impacted resources `vcd_nsxv_firewall_rule`and `vcd_nsxv_dnat`). When user is not authenticated as sysadmin one of the field values is returned empty instead of having a value.

