### PR TITLE
Declare vCD 9.0 support drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 2.7.0 (Unreleased)
+
+NOTES:
+* Drop support for vCD 9.0
+
 ## 2.6.0 (December 13, 2019)
 
 FEATURES:

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -20,7 +20,6 @@ When upgrading the provider please check for such labels for the resources you a
 
 The following vCloud Director versions are supported by this provider:
 
-* 9.0
 * 9.1
 * 9.5
 * 9.7


### PR DESCRIPTION
The plan:
* 2.7.0 - declare vCD 9.0 support drop
* 2.8.0 - actually change the API version used

Signed-off-by: Linas Virbalas <lvirbalas@vmware.com>