### PR TITLE
Make datasource vcd_vapp_vm test predictable

### DIFF
--- a/vcd/datasource_vcd_vapp_vm_test.go
+++ b/vcd/datasource_vcd_vapp_vm_test.go
@@ -3,48 +3,20 @@
 package vcd
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/vmware/go-vcloud-director/v2/govcd"
 )
 
 // TestAccVcdVappDS tests a VM data source if a vApp + VM is found in the VDC
 func TestAccVcdVappVmDS(t *testing.T) {
-	// This test requires access to the vCD before filling templates
-	// Thus it won't run in the short test
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
-
-	vapp, err := getAvailableVapp()
-	if err != nil {
-		t.Skip("No suitable vApp found for this test")
-		return
-	}
-	var vm *govcd.VM
-
-	if vapp.VApp.Children != nil && len(vapp.VApp.Children.VM) > 0 {
-		vm, err = vapp.GetVMById(vapp.VApp.Children.VM[0].ID, false)
-		if err != nil {
-			t.Skip(fmt.Sprintf("error retrieving VM %s", vapp.VApp.Children.VM[0].Name))
-			return
-		}
-	}
-	if vm == nil {
-		t.Skip(fmt.Sprintf("No VM available in vApp %s", vapp.VApp.Name))
-		return
-	}
-
 	var params = StringMap{
-		"Org":      testConfig.VCD.Org,
-		"VDC":      testConfig.VCD.Vdc,
-		"VappName": vapp.VApp.Name,
-		"VmName":   vm.VM.Name,
-		"FuncName": "TestVappVmDS",
-		"Tags":     "vm",
+		"Org":         testConfig.VCD.Org,
+		"VDC":         testConfig.VCD.Vdc,
+		"Catalog":     testSuiteCatalogName,
+		"CatalogItem": testSuiteCatalogOVAItem,
+		"FuncName":    "TestVappVmDS",
+		"Tags":        "vm",
 	}
 	configText := templateFill(datasourceTestVappVm, params)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
@@ -56,10 +28,10 @@ func TestAccVcdVappVmDS(t *testing.T) {
 			resource.TestStep{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckOutput("name", vm.VM.Name),
-					resource.TestCheckOutput("storage_profile", vm.VM.StorageProfile.Name),
-					resource.TestCheckOutput("description", vm.VM.Description),
-					resource.TestCheckOutput("href", vm.VM.HREF),
+					resource.TestCheckResourceAttr("data.vcd_vapp_vm.vm-ds", "name", "web1"),
+					resource.TestCheckResourceAttr("data.vcd_vapp_vm.vm-ds", "storage_profile", "*"),
+					resource.TestCheckResourceAttrSet("data.vcd_vapp_vm.vm-ds", "href"),
+					resource.TestCheckResourceAttrSet("data.vcd_vapp_vm.vm-ds", "description"),
 					resource.TestCheckResourceAttr("data.vcd_vapp_vm.vm-ds", "customization.0.enabled", "true"),
 					resource.TestCheckResourceAttr("data.vcd_vapp_vm.vm-ds", "customization.0.change_sid", "false"),
 					resource.TestCheckResourceAttr("data.vcd_vapp_vm.vm-ds", "customization.0.join_domain", "false"),
@@ -72,25 +44,34 @@ func TestAccVcdVappVmDS(t *testing.T) {
 }
 
 const datasourceTestVappVm = `
+resource "vcd_vapp" "web" {
+  name = "web"
+}
+
+resource "vcd_vapp_vm" "web1" {
+  vapp_name     = vcd_vapp.web.name
+  name          = "web1"
+  catalog_name  = "{{.Catalog}}"
+  template_name = "{{.CatalogItem}}"
+  memory        = 1024
+  cpus          = 2
+  cpu_cores     = 1
+  power_on      = false
+
+  storage_profile = "*"
+
+  customization {
+    enabled               = true
+    change_sid            = false
+    join_domain           = false
+    number_of_auto_logons = 0
+  }
+}
+
 data "vcd_vapp_vm" "vm-ds" {
-  name             = "{{.VmName}}"
+  name             = vcd_vapp_vm.web1.name
+  vapp_name        = vcd_vapp.web.name
   org              = "{{.Org}}"
   vdc              = "{{.VDC}}"
-  vapp_name        = "{{.VappName}}"
-}
-
-output "name" {
-  value = data.vcd_vapp_vm.vm-ds.name
-}
-
-output "description" {
-  value = data.vcd_vapp_vm.vm-ds.description
-}
-output "storage_profile" {
-  value = data.vcd_vapp_vm.vm-ds.storage_profile
-}
-
-output "href" {
-  value = data.vcd_vapp_vm.vm-ds.href
 }
 `

--- a/vcd/datasource_vcd_vapp_vm_test.go
+++ b/vcd/datasource_vcd_vapp_vm_test.go
@@ -19,6 +19,10 @@ func TestAccVcdVappVmDS(t *testing.T) {
 		"Tags":        "vm",
 	}
 	configText := templateFill(datasourceTestVappVm, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
The test `TestAccVcdVappVmDS` depended on existing VM. This makes some checks hard because VM may be already altered in some way which does not work with defined checks.

This PR introduces VM creation into the test itself.