### PR TITLE
Skip TestAccDataSourceNotFound/vcd_external_network test with org user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ IMPROVEMENTS:
   definition to specify NIC type - [GH-441]
 * `resource/vcd_vapp_vm` and `datasource/vcd_vapp_vm` `customization` block supports all available
   features [GH-462, GH-469]
-* `datasource/*` - all data sources return an error when object is not found [GH-446]
+* `datasource/*` - all data sources return an error when object is not found [GH-446, GH-470]
 
 DEPRECATIONS:
 * `resource/vcd_vapp_vm` `network.name` deprecates automatic attachment of vApp Org network when

--- a/vcd/datasource_test.go
+++ b/vcd/datasource_test.go
@@ -29,6 +29,12 @@ func TestAccDataSourceNotFound(t *testing.T) {
 
 func testSpecificDataSourceNotFound(t *testing.T, dataSourceName string) func(*testing.T) {
 	return func(t *testing.T) {
+
+		// Skip sub-test if conditions are not met
+		if dataSourceName == "vcd_external_network" && !usingSysAdmin() {
+			t.Skip(`Works only with system admin privileges`)
+		}
+
 		// Get list of mandatory fields in schema for a particular data source
 		mandatoryFields := getMandatoryDataSourceSchemaFields(dataSourceName)
 		mandatoryRuntimeFields := getMandatoryDataSourceRuntimeFields(dataSourceName)


### PR DESCRIPTION
Data source automated tests try to use automated data source test for `vcd_external_network` but it does not work in org user mode as `vcd_external_network`requires admin privileges. This PR fixes it (skips `TestAccDataSourceNotFound/vcd_external_network` sub-test when suite user is not sysadmin.

`VCD_TEST_ORG_USER=1 go test -v -tags ALL -run "TestAccDataSourceNotFound" .`
