### PR TITLE
Add recovery feature to binary tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -8,6 +8,7 @@
 - [Adding new tests](#adding-new-tests)
   - [Parallelism considerations](#parallelism-considerations)
 - [Binary testing](#binary-testing)
+- [Handling failures in binary tests](#handling-failures-in-binary-tests)
 - [Upgrade testing](#upgrade-testing)
 - [Custom terraform scripts](#custom-terraform-scripts)
 - [Environment variables](#environment-variables)
@@ -334,6 +335,39 @@ The "pause" option will stop the test after every call to the terraform tool, wa
 When the test runs unattended, it is possible to stop it gracefully by creating a file named `pause` inside the
 `test-artifacts` directory. When such file exists, the test execution stops at the next `terraform` command, waiting
 for user input.
+
+## Handling failures in binary tests
+
+When one test fails, the binary test script will attempt to recover it, by running `terraform destroy`. If the recovery
+fails, the whole test halts. If recovery succeeds, the names of the failed test are recorded inside 
+`./vcd/test-artifacts/failed_tests.txt` and the summary at the end of the test will show them.
+
+If the test runs with `make test-binary`, the output is captured inside `./vcd/test-artifacts/test-binary-TIME.txt` (where
+`TIME` has the format `YYYY-MM-DD-HH-MM`). To see the actual failure, open the output file and search for the name of
+the test that failed.
+
+For example, the test ends with this annotation :
+
+```
+# ---------------------------------------------------------
+# Operations dir: /path/to/terraform-provider-vcd/vcd/test-artifacts/tmp
+# Started:        Thu Mar 12 14:10:43 CET 2020
+# Ended:          Thu Mar 12 14:12:16 CET 2020
+# Elapsed:        1m:33s (93 sec)
+# exit code:      0
+# ---------------------------------------------------------
+# ---------------------------------------------------------
+# FAILED TESTS    4
+# ---------------------------------------------------------
+Thu Mar 12 14:11:02 CET 2020 - vcd.TestUser_test_user_catalog_author_basic.tf (apply)
+Thu Mar 12 14:11:08 CET 2020 - vcd.TestUser_test_user_catalog_author_basic.tf (plancheck)
+Thu Mar 12 14:11:30 CET 2020 - vcd.TestUser_test_user_admin_basic.tf (apply)
+Thu Mar 12 14:11:36 CET 2020 - vcd.TestUser_test_user_admin_basic.tf (plancheck)
+# ---------------------------------------------------------
+```
+
+In the output file (in the directory `./vcd/test-artifacts`), look for `vcd.TestUser_test_user_catalog_author_basic.tf`
+and you will see the operations occurring with the actual errors.
 
 ## Upgrade testing
 

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -152,10 +152,13 @@ function binary_test {
     cp $scripts_dir/test-binary.sh test-artifacts/test-binary.sh
     chmod +x test-artifacts/test-binary.sh
     cd test-artifacts
-    if [ -f already_run.txt ]
-    then
-        rm -f already_run.txt
-    fi
+    for old_file in already_run.txt failed_tests.txt
+    do
+        if [ -f ${old_file} ]
+        then
+            rm -f ${old_file}
+        fi
+    done
     if [ -n "$NORUN" ]
     then
         pwd
@@ -178,7 +181,8 @@ function binary_test {
         ./test-binary.sh test-env-destroy
         exit $?
     fi
-     ./test-binary.sh
+    timestamp=$(date +%Y-%m-%d-%H-%M)
+    ./test-binary.sh 2>&1 | tee test-binary-${timestamp}.txt
 }
 
 function exists_in_path {


### PR DESCRIPTION
This change will add the ability to recover a failed binary test, by running `terraform destroy` after a failed `apply` or `destroy`.
Failed tests are listed in `failed_tests.txt`, and the final summary lists what happened
```
# ---------------------------------------------------------
# Operations dir: /path/to/terraform-provider-vcd/vcd/test-artifacts/tmp
# Started:        Thu Mar 12 14:10:43 CET 2020
# Ended:          Thu Mar 12 14:12:16 CET 2020
# Elapsed:        1m:33s (93 sec)
# exit code:      0
# ---------------------------------------------------------
# ---------------------------------------------------------
# FAILED TESTS    4
# ---------------------------------------------------------
Thu Mar 12 14:11:02 CET 2020 - vcd.TestUser_test_user_catalog_author_basic.tf (apply)
Thu Mar 12 14:11:08 CET 2020 - vcd.TestUser_test_user_catalog_author_basic.tf (plancheck)
Thu Mar 12 14:11:30 CET 2020 - vcd.TestUser_test_user_admin_basic.tf (apply)
Thu Mar 12 14:11:36 CET 2020 - vcd.TestUser_test_user_admin_basic.tf (plancheck)
# ---------------------------------------------------------
```
The test will halt if the recovery destroy fails.

The binary test triggered by `make test-binary` will save the output in a text file inside `test-artifact`. The file is named `test-binary-YYYY-MM-DD-HH-MM.txt`