### PR TITLE
Add NIC to VM in test 'TestAccVcdVAppVmUpdateCustomization'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ IMPROVEMENTS:
 * `resource/vcd_vapp_vm` and `datasource/vcd_vapp_vm` include a field `adapter_type` in `network`
   definition to specify NIC type - [GH-441]
 * `resource/vcd_vapp_vm` and `datasource/vcd_vapp_vm` `customization` block supports all available
-  features [GH-462, GH-469]
+  features [GH-462, GH-469, GH-477]
 * `datasource/*` - all data sources return an error when object is not found [GH-446, GH-470]
 * `vcd_vapp_vm` allows to add routed vApp network, not only isolated one. `network.name` can reference 
   `vcd_vapp_network.name` of a vApp network with `org_network_name` set [GH-472]
@@ -48,7 +48,7 @@ BUG FIXES:
 * Fix a potential data race in client connection caching when VCD_CACHE is enabled [GH-453]
 * `resource/vcd_vapp_vm` when `customization.0.force=false` crashes with `interface {} is nil` [GH-462]
 * `resource/vcd_vapp_vm` `customization.0.force=true` could have skipped "Forced customization" on
-  each apply [GH-462]
+  each apply [GH-462, GH-477]
 
 NOTES:
 

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.13
 require (
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/terraform-plugin-sdk v1.5.0
-	github.com/vmware/go-vcloud-director/v2 v2.6.0-beta.2
+	github.com/vmware/go-vcloud-director/v2 v2.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/vmihailenco/msgpack v3.3.3+incompatible h1:wapg9xDUZDzGCNFlwc5SqI1rvc
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/go-vcloud-director/v2 v2.6.0-beta.2 h1:xsKRAxgn+zh1CdHw0joJumuTepX07sxfAtqbvCKjtto=
-github.com/vmware/go-vcloud-director/v2 v2.6.0-beta.2/go.mod h1:XY9Fmqp1JeHIU2nP87NykB6unNCsY6qV4Zdu5JI4aZU=
+github.com/vmware/go-vcloud-director/v2 v2.6.0 h1:hnqxk36dLDfd2f8AOvBjZZx67zrnGkCpaY9qnRJXIeg=
+github.com/vmware/go-vcloud-director/v2 v2.6.0/go.mod h1:XY9Fmqp1JeHIU2nP87NykB6unNCsY6qV4Zdu5JI4aZU=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -215,7 +215,7 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/vmware/go-vcloud-director/v2 v2.6.0-beta.2
+# github.com/vmware/go-vcloud-director/v2 v2.6.0
 github.com/vmware/go-vcloud-director/v2/govcd
 github.com/vmware/go-vcloud-director/v2/types/v56
 github.com/vmware/go-vcloud-director/v2/util


### PR DESCRIPTION
Acceptance test `TestAccVcdVAppVmUpdateCustomization` checks how guest customization status differs when PowerOnAndForceCustomization is triggered.

At 2.6.0 release time the test configuration had a vApp network and VM with 1 NIC, which was removed for 2.7 (during customization block improvements) to save on testing time and avoid creating network.

Apparently all vCD versions (9.5, 9.7, 10.0) work fine, but 9.1 behaves differently when no network cards are present and this causes test failure.

This PR adds back NIC definition to make test work fine on 9.1. General `customizatoin.force=true` behavior will still work fine. The test itself was quite complicated and has to catch VM guest customization states while they transition. When no NIC is present - states transition a bit differently.


This PR was tested so:

* vCD 9.1 
  * acceptance: `go test  -count=1 -timeout=80m -v -tags ALL -run "TestAccVcdVAppVm.*Cust.*" .`
  * binary: `./test-binary.sh names "*Customization*"`

* vCD 10: 
  * acceptance: `go test  -count=1 -timeout=80m -v -tags ALL -run "TestAccVcdVAppVm.*Cust.*" .`
  * binary: `./test-binary.sh names "*Customization*"`

