### PR TITLE
Improve GitHub issue template by adding debug configuration steps

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -20,8 +20,8 @@ If this issue appears to affect multiple resources, it may be an issue with Terr
 ```
 
 ### Debug Output
-Please provide a link to GitHub [Gist(s)](gist.github.com/) containing complete debug output. You
-can enable debug by using the below commands:
+Please provide a link to GitHub [Gist(s)](https://gist.github.com) containing complete debug
+output. You can enable debug by using the commands below:
 ```shell
 export TF_LOG_PATH=tf.log            
 export TF_LOG=TRACE                  
@@ -31,12 +31,12 @@ export GOVCD_LOG=true
 
 On Windows the command instead of `export` is `set`.
 
-Replicate the issue after setting above listed environment variables and it should create two new
-files in working directory `tf.log` and `go-vcloud-director.log`. The `tf.log` is a general
+Replicate the issue after setting the environment variables listed above and it should create two
+new files in the working directory: `tf.log` and `go-vcloud-director.log`. The `tf.log` is a general
 Terraform debug log (more information about it is in
 https://www.terraform.io/docs/internals/debugging.html) while the `go-vcloud-director.log` is a
 specific log file for `terraform-provider-vcd` containing debug information about performed API
-calls. Please attach both of them to your Gist.
+calls. Please attach both of them to your [Gist](https://gist.github.com).
 
 ### Panic Output
 If Terraform produced a panic, please provide a link to a GitHub Gist containing the output of the `crash.log`.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -20,8 +20,8 @@ If this issue appears to affect multiple resources, it may be an issue with Terr
 ```
 
 ### Debug Output
-Please provide a link to GitHub Gist(s) containing complete debug output. You can enable debug by
-using the below commands:
+Please provide a link to GitHub [Gist(s)](gist.github.com/) containing complete debug output. You
+can enable debug by using the below commands:
 ```hcl
 export TF_LOG_PATH=tf.log            
 export TF_LOG=TRACE                  
@@ -36,7 +36,7 @@ files in working directory `tf.log` and `go-vcloud-director.log`. The `tf.log` i
 Terraform debug log (more information about it is in
 https://www.terraform.io/docs/internals/debugging.html) while the `go-vcloud-director.log` is a
 specific log file for `terraform-provider-vcd` containing debug information about performed API
-calls.
+calls. Please attach both of them to your Gist.
 
 ### Panic Output
 If Terraform produced a panic, please provide a link to a GitHub Gist containing the output of the `crash.log`.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -20,7 +20,23 @@ If this issue appears to affect multiple resources, it may be an issue with Terr
 ```
 
 ### Debug Output
-Please provider a link to a GitHub Gist containing the complete debug output: https://www.terraform.io/docs/internals/debugging.html. Please do NOT paste the debug output in the issue; just paste a link to the Gist.
+Please provide a link to GitHub Gist(s) containing complete debug output. You can enable debug by
+using the below commands:
+```hcl
+export TF_LOG_PATH=tf.log            
+export TF_LOG=trace                  
+export GOVCD_LOG_FILE=go-vcloud-director.log
+export GOVCD_LOG=true     
+```
+
+On Windows the command instead of `export` is `set`.
+
+Replicate the issue after setting above listed environment variables and it should create two new
+files in working directory `tf.log` and `go-vcloud-director.log`. The `tf.log` is a general
+Terraform debug log (more information about it is in
+https://www.terraform.io/docs/internals/debugging.html) while the `go-vcloud-director.log` is a
+specific log file for `terraform-provider-vcd` containing debug information about performed API
+calls.
 
 ### Panic Output
 If Terraform produced a panic, please provide a link to a GitHub Gist containing the output of the `crash.log`.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -24,7 +24,7 @@ Please provide a link to GitHub Gist(s) containing complete debug output. You ca
 using the below commands:
 ```hcl
 export TF_LOG_PATH=tf.log            
-export TF_LOG=trace                  
+export TF_LOG=TRACE                  
 export GOVCD_LOG_FILE=go-vcloud-director.log
 export GOVCD_LOG=true     
 ```

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -22,7 +22,7 @@ If this issue appears to affect multiple resources, it may be an issue with Terr
 ### Debug Output
 Please provide a link to GitHub [Gist(s)](gist.github.com/) containing complete debug output. You
 can enable debug by using the below commands:
-```hcl
+```shell
 export TF_LOG_PATH=tf.log            
 export TF_LOG=TRACE                  
 export GOVCD_LOG_FILE=go-vcloud-director.log


### PR DESCRIPTION
This PR modifies GitHub issue template so that it adds information on how to enable debug for both Terraform and `go-vcloud-director` in one go with the hope to make  log collection  easier for newcomers.