### PR TITLE
Improve isolation of tagged tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 ## 2.10.0 (Unreleased)
+
+IMPROVEMENTS:
+
+* Added command `make tag` to check testing tags isolation. It also runs when calling `make test` [GH-532]
+
+
 ## 2.9.0 (June 30, 2020)
 FEATURES:
 
 * **New Resource**: `vcd_vm_affinity_rule` VM affinity and anti-affinity rules ([#514](https://github.com/terraform-providers/terraform-provider-vcd/issues/514))
 * **New Data Source**: `vcd_vm_affinity_rule` VM affinity and anti-affinity rules ([#514](https://github.com/terraform-providers/terraform-provider-vcd/issues/514))
-* **New Resource:** `vcd_org_group` Org Group management ([#513](https://github.com/terraform-providers/terraform-provider-vcd/issues/513))
 * Add support for SAML auth with Active Directory Federation Services (ADFS) as IdP using
   "/adfs/services/trust/13/usernamemixed" endpoint usin auth_type="saml_adfs". ([#504](https://github.com/terraform-providers/terraform-provider-vcd/issues/504))
 * Add support for LDAP authentication using auth_type="integrated". ([#504](https://github.com/terraform-providers/terraform-provider-vcd/issues/504))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 IMPROVEMENTS:
 
-* Added command `make tag` to check testing tags isolation. It also runs when calling `make test` [GH-532]
+* Added command `make tagverify` to check testing tags isolation. It also runs when calling `make test` [GH-532]
 
 
 ## 2.9.0 (June 30, 2020)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -75,7 +75,7 @@ testunit: fmtcheck
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' unit"
 
 # Runs the basic execution test
-test: testunit tag
+test: testunit tagverify
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' short"
 
 # Runs the full acceptance test as Org user
@@ -163,7 +163,7 @@ test-compile:
 	cd vcd && go test -race -tags ALL -c .
 
 # checks that tagged tests can run independently
-tag:
+tagverify:
 	@scripts/test-tags.sh
 
 # builds the website and allows running it from localhost

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -75,7 +75,7 @@ testunit: fmtcheck
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' unit"
 
 # Runs the basic execution test
-test: testunit
+test: testunit tag
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' short"
 
 # Runs the full acceptance test as Org user
@@ -161,6 +161,10 @@ vendor-check:
 # checks that the code can compile
 test-compile:
 	cd vcd && go test -race -tags ALL -c .
+
+# checks that tagged tests can run independently
+tag:
+	@scripts/test-tags.sh
 
 # builds the website and allows running it from localhost
 website:

--- a/scripts/test-tags.sh
+++ b/scripts/test-tags.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# This test checks that all the build tags defined in api_vcd_test.go
+# can run individually
+
+if [ ! -d vcd ]
+then
+    echo "./vcd directory missing"
+    exit 1
+fi
+cd vcd
+
+if [ ! -f config_test.go ]
+then
+    echo "file ./vcd/config_test.go not found"
+    exit 1
+fi
+
+start=$(date +%s)
+tags1=$(head -n 1 config_test.go | sed -e 's/^.*build //')
+tags2=$(head -n 1 provider_test.go | sed -e 's/^.*build //')
+tags=$(echo $tags1 $tags2 | tr " " "\n" | sort | uniq| tr "\n" " "; echo) 
+
+echo "=== RUN TagsTest"
+for tag in $tags
+do
+    
+    go test -tags $tag -timeout 0 -v -vcd-help > /dev/null
+
+    if [ "$?" == "0" ]
+    then
+        echo "  --- PASS: TagsTest/$tag"
+    else
+        echo "  --- FAIL: TagsTest/$tag"
+        failed="$failed $tag"
+    fi
+done
+
+end=$(date +%s)
+elapsed=$((end-start))
+if [ -n "$failed" ]
+then
+    echo "--- FAIL: TagsTest - Tests for tags [$failed] have failed (${elapsed}s)"
+    exit 1
+fi
+echo "--- PASS: TagsTest (${elapsed}s)"
+exit 0

--- a/scripts/test-tags.sh
+++ b/scripts/test-tags.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This test checks that all the build tags defined in api_vcd_test.go
+# This test checks that all the build tags defined in config_test.go and provider_test.go
 # can run individually
 
 if [ ! -d vcd ]

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -1,4 +1,4 @@
-// +build api functional catalog vapp network extnetwork org query vm vdc gateway disk binary lb lbServiceMonitor lbServerPool user search auth ALL
+// +build api functional catalog vapp network extnetwork org query vm vdc gateway disk binary lb lbServiceMonitor lbServerPool lbAppProfile lbAppRule lbVirtualServer user search auth ALL
 
 package vcd
 

--- a/vcd/datasource_vcd_org_vdc_test.go
+++ b/vcd/datasource_vcd_org_vdc_test.go
@@ -52,7 +52,7 @@ func TestAccVcdVdcDatasource(t *testing.T) {
 
 func validateResourceAndDataSource(t *testing.T, configText string, datasourceVdc string) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { preRunChecks(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVdcDestroy,
 		Steps: []resource.TestStep{
@@ -101,7 +101,7 @@ func validateResourceAndDataSource(t *testing.T, configText string, datasourceVd
 
 func validateDataSource(t *testing.T, configText string, datasourceVdc string) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { preRunChecks(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVdcDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
* Improved tagged tests to make sure they can run in isolation
* Added a test to check tags isolation (runs with `make test`)
* added command `make tagverify` to run the tags isolation test

```
$ make tagverify
=== RUN TagsTest
  --- PASS: TagsTest/ALL
  --- PASS: TagsTest/api
  --- PASS: TagsTest/auth
  --- PASS: TagsTest/binary
  --- PASS: TagsTest/catalog
  --- PASS: TagsTest/disk
  --- PASS: TagsTest/extnetwork
  --- PASS: TagsTest/functional
  --- PASS: TagsTest/gateway
  --- PASS: TagsTest/lb
  --- PASS: TagsTest/lbAppProfile
  --- PASS: TagsTest/lbAppRule
  --- PASS: TagsTest/lbServerPool
  --- PASS: TagsTest/lbServiceMonitor
  --- PASS: TagsTest/lbVirtualServer
  --- PASS: TagsTest/network
  --- PASS: TagsTest/org
  --- PASS: TagsTest/query
  --- PASS: TagsTest/search
  --- PASS: TagsTest/user
  --- PASS: TagsTest/vapp
  --- PASS: TagsTest/vdc
  --- PASS: TagsTest/vm
--- PASS: TagsTest (48s)
```
(Also removed `vcd_org_group` duplicated line from CHANGELOG)