### PR TITLE
fix allocation mode when empty VM is created

### DIFF
--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -2214,7 +2214,7 @@ func addEmptyVm(d *schema.ResourceData, vcdClient *VCDClient, org *govcd.Org, vd
 			NetworkConnectionSection: &types.NetworkConnectionSection{
 				PrimaryNetworkConnectionIndex: 0,
 				NetworkConnection: []*types.NetworkConnection{
-					&types.NetworkConnection{Network: "none", NetworkConnectionIndex: 0, IPAddress: "any", IsConnected: false, IPAddressAllocationMode: "DHCP"}},
+					&types.NetworkConnection{Network: "none", NetworkConnectionIndex: 0, IPAddress: "any", IsConnected: false, IPAddressAllocationMode: "NONE"}},
 			},
 			Description:               d.Get("description").(string),
 			GuestCustomizationSection: customizationSection,


### PR DESCRIPTION
Error:
```

=== RUN   TestAccVcdVAppEmptyVm

Warning: `MediaName` is not configured: boot image won't be tested.

    TestAccVcdVAppEmptyVm: testing.go:654: Step 0 error: errors during apply:

 

        Error: [VM creation] error creating VM TestAccVcdVAppEmptyVmVM : error instantiating a new VM: API Error: 400: [ 071bf1a0-1466-46f5-b625-e770558061c7 ] Invalid network parameter: Unknown IP Addressing Mode "DHCP" for vNIC 0 on VM "TestAccVcdVAppEmptyVmVM" connected to network "none".
          on /var/folders/rz/cn7hvgzd1dl5y23l378dsf_c0000gn/T/tf-test594231135/main.tf line 113:

          (source code not available)

 

 

--- FAIL: TestAccVcdVAppEmptyVm (315.24s)
```
in vCD 10.0.2 API get stricter and starts complain when not right field provided. 

This simple PR fixes that.